### PR TITLE
Stop audio and generation when backgrounded to fix app crash

### DIFF
--- a/Examples/VoicesApp/VoicesApp/Views/ContentView.swift
+++ b/Examples/VoicesApp/VoicesApp/Views/ContentView.swift
@@ -265,6 +265,15 @@ struct ContentView: View {
                 .presentationDragIndicator(.visible)
                 #endif
         }
+        .onChange(of: scenePhase) { _, phase in
+            switch phase {
+            case .background:
+                viewModel.pause()
+                viewModel.stop()
+            default:
+                break
+            }
+        }
         .task {
             await viewModel.loadModel()
         }


### PR DESCRIPTION
- Stop audio playing and MLX generation when the app is background to fix the app crashing