### PR TITLE
Fix voice matching for Pocket TTS

### DIFF
--- a/Sources/MLXAudioCodecs/Mimi/Transformer.swift
+++ b/Sources/MLXAudioCodecs/Mimi/Transformer.swift
@@ -163,7 +163,18 @@ public final class Attention: Module {
             v = split(v, indices: [start], axis: 2)[1]
         }
 
-        var out = scaledDotProductAttention(queries: q, keys: k, values: v, scale: scale, mask: mask)
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode = {
+            if let mask { return .array(mask) }
+            return cfg.causal ? createAttentionMask(h: xs, cache: cache) : .none
+        }()
+
+        var out = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: maskMode
+        )
         out = swappedAxes(out, 1, 2).reshaped([b, t, hd])
         return out_proj(out)
     }
@@ -214,7 +225,7 @@ public final class MlpNoGating: Module {
     }
 
     public func callAsFunction(_ xs: MLXArray) -> MLXArray {
-        linear2(geluApprox(linear1(xs)))
+        linear2(gelu(linear1(xs)))
     }
 }
 

--- a/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift
@@ -87,7 +87,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
     private func encodeAudio(_ audio: MLXArray) -> MLXArray {
         let encoded = mimi.encodeToLatent(audio)
         let latents = encoded.transposed(0, 2, 1).asType(.float32)
-        let projT = speaker_proj_weight.transposed(0, 1)
+        let projT = speaker_proj_weight.transposed(1, 0)
         let conditioning = matmul(latents, projT)
         return conditioning
     }


### PR DESCRIPTION
The casual mask needed for Mimi wasn't present on the Swift side, and there was a couple of minor issues with python parity. With this change voice matching works with Pocket TTS.