### PR TITLE
Fix Swift 6.2 compilation errors: @Sendable closures and OptionSet type inference

### DIFF
--- a/Sources/MLXAudioCodecs/Mimi/Mimi.swift
+++ b/Sources/MLXAudioCodecs/Mimi/Mimi.swift
@@ -237,7 +237,7 @@ public extension Mimi {
         repoId: String = "kyutai/moshiko-pytorch-bf16",
         filename: String = "tokenizer-e351c8d8-checkpoint125.safetensors",
         cache: HubCache = .default,
-        progressHandler: @escaping (Progress) -> Void
+        progressHandler: @Sendable @escaping (Progress) -> Void
     ) async throws -> Mimi {
         print("[Mimi] Starting Mimi model loading from \(repoId)")
 
@@ -320,7 +320,7 @@ public extension Mimi {
         print("[Mimi] Updating model parameters...")
         let updateStart = CFAbsoluteTimeGetCurrent()
         let parameters = ModuleParameters.unflattened(weights)
-        try model.update(parameters: parameters, verify: [.all])
+        try model.update(parameters: parameters, verify: .all)
         let updateTime = CFAbsoluteTimeGetCurrent() - updateStart
         print(String(format: "[Mimi] Model parameters updated in %.2f seconds", updateTime))
 

--- a/Sources/MLXAudioCodecs/SNAC/SNACDecoder.swift
+++ b/Sources/MLXAudioCodecs/SNAC/SNACDecoder.swift
@@ -179,7 +179,7 @@ public class SNAC: Module {
         let snac = try fromConfig(configPath)
 
         let weights = try loadArrays(url: weightsPath)
-        try snac.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+        try snac.update(parameters: ModuleParameters.unflattened(weights), verify: .all)
         eval(snac)
 
         return snac

--- a/Sources/MLXAudioSTS/Models/MossFormer2SE/MossFormer2Model.swift
+++ b/Sources/MLXAudioSTS/Models/MossFormer2SE/MossFormer2Model.swift
@@ -358,7 +358,7 @@ public final class MossFormer2SEModel: STSModel {
             }
         }
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
         return MossFormer2SEModel(model: model, config: config)
     }

--- a/Sources/MLXAudioSTT/Models/GLMASR/GLMASR.swift
+++ b/Sources/MLXAudioSTT/Models/GLMASR/GLMASR.swift
@@ -658,7 +658,7 @@ public class GLMASRModel: Module {
                 }
             }
         }
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
 
         eval(model)
 

--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
@@ -551,7 +551,7 @@ public extension ParakeetModel {
             }
         }
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
         eval(model)
         return model
     }

--- a/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
@@ -1518,7 +1518,7 @@ public class Qwen3ASRModel: Module {
         }
 
         // Load weights into model
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
 
         return model

--- a/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ForcedAligner.swift
+++ b/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ForcedAligner.swift
@@ -589,7 +589,7 @@ public class Qwen3ForcedAlignerModel: Module {
             }
         }
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
 
         return model

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift
@@ -417,7 +417,7 @@ public extension VoxtralRealtimeModel {
             }
         }
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
         model.ensureAdaScales(transcriptionDelayMs: config.transcriptionDelayMs)
         eval(model)
 

--- a/Sources/MLXAudioTTS/Models/Llama/LlamaTTS.swift
+++ b/Sources/MLXAudioTTS/Models/Llama/LlamaTTS.swift
@@ -957,7 +957,7 @@ public class LlamaTTSModel: Module, KVCacheDimensionProvider, SpeechGenerationMo
             }
         }
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
 
         try await model.post_load_hook(model: model, modelDir: modelDir, cache: cache)

--- a/Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift
@@ -53,7 +53,7 @@ public final class MarvisTTSModel: Module {
         hub: HubApi = .shared,
         repoId: String,
         promptURLs: [URL]? = nil,
-        progressHandler: @escaping (Progress) -> Void
+        progressHandler: @Sendable @escaping (Progress) -> Void
     ) async throws {
         let textTokenizer = try await loadTokenizer(configuration: ModelConfiguration(id: repoId), hub: hub)
         let codec = try await Mimi.fromPretrained(progressHandler: progressHandler)
@@ -144,7 +144,7 @@ public extension MarvisTTSModel {
     static func fromPretrained(
         _ modelRepo: String = "Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit",
         cache: HubCache = .default,
-        progressHandler: @escaping (Progress) -> Void = { _ in }
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
     ) async throws -> MarvisTTSModel {
         Memory.cacheLimit = 100 * 1024 * 1024
 
@@ -206,7 +206,7 @@ public extension MarvisTTSModel {
         }
         
         let parameters = ModuleParameters.unflattened(weights)
-        try model.update(parameters: parameters, verify: [.all])
+        try model.update(parameters: parameters, verify: .all)
         
         eval(model)
         return model
@@ -216,7 +216,7 @@ public extension MarvisTTSModel {
         hub: HubApi = .shared,
         repoId: String = "Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit",
         cache: HubCache = .default,
-        progressHandler: @escaping (Progress) -> Void
+        progressHandler: @Sendable @escaping (Progress) -> Void
     ) async throws -> MarvisTTSModel {
         _ = hub
         return try await fromPretrained(repoId, cache: cache, progressHandler: progressHandler)

--- a/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift
@@ -118,7 +118,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
     public static func loadPredefinedVoice(
         _ voiceName: String,
         modelFolder: URL,
-        progressHandler: @escaping (Progress) -> Void = { _ in }
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
     ) async throws -> MLXArray? {
         _ = progressHandler
         let fileURL = modelFolder.appendingPathComponent("embeddings/\(voiceName).safetensors")
@@ -135,7 +135,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
     private func resolveAudioPrompt(
         voice: String?,
         refAudio: MLXArray?,
-        progressHandler: @escaping (Progress) -> Void = { _ in }
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
     ) async throws -> AudioPrompt {
         if let refAudio {
             return .audio(normalizeAudio(refAudio))
@@ -355,7 +355,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
 
         let model = try await PocketTTSModel.fromConfig(config, modelFolder: modelDir)
         let weights = try await loadPocketTTSWeights(modelDir: modelDir)
-        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: .all)
 
         eval(model)
         return model

--- a/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
@@ -920,7 +920,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
 
 
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
 
         try await model.post_load_hook(model: model, modelDir: modelDir, cache: cache)

--- a/Sources/MLXAudioTTS/Models/Soprano/Soprano.swift
+++ b/Sources/MLXAudioTTS/Models/Soprano/Soprano.swift
@@ -947,7 +947,7 @@ public class SopranoModel: Module, KVCacheDimensionProvider, SpeechGenerationMod
             }
         }
 
-        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [.all])
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
 
         eval(model)
 


### PR DESCRIPTION
## Summary

Fixes two compilation patterns that fail under Swift 6.2 (Xcode 26.2, `swift-tools-version: 6.2`):

### 1. Missing `@Sendable` on `progressHandler` closures

`HubClient.downloadSnapshot` expects a `@Sendable` closure, but several `fromPretrained` methods declare `progressHandler` without it:

```
error: passing non-Sendable parameter 'progressHandler' to function expecting a @Sendable closure
```

**Fix:** Add `@Sendable` attribute to closure parameters.

**Affected files (3):**
- `Sources/MLXAudioCodecs/Mimi/Mimi.swift`
- `Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift`
- `Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift`

### 2. `[.all]` fails `OptionSet` type inference

The array literal `[.all]` fails type inference for `OptionSet` parameters in Swift 6.2. Since `.all` represents all options directly, the array wrapper is unnecessary:

```
error: type of expression is ambiguous without a type annotation
```

**Fix:** Replace `verify: [.all]` with `verify: .all`.

**Affected files (13):**
- `Sources/MLXAudioCodecs/Mimi/Mimi.swift`
- `Sources/MLXAudioCodecs/SNAC/SNACDecoder.swift`
- `Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift`
- `Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift`
- `Sources/MLXAudioTTS/Models/Llama/LlamaTTS.swift`
- `Sources/MLXAudioTTS/Models/Soprano/Soprano.swift`
- `Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift`
- `Sources/MLXAudioSTT/Models/GLMASR/GLMASR.swift`
- `Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift`
- `Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift`
- `Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ForcedAligner.swift`
- `Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift`
- `Sources/MLXAudioSTS/Models/MossFormer2SE/MossFormer2Model.swift`

Closes #65