### PR TITLE
fix Parakeet V2 mel scale and add eval for joint output

### DIFF
--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetAudio.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetAudio.swift
@@ -32,12 +32,14 @@ enum ParakeetAudio {
         )
 
         let power = MLX.abs(stftOutput).square().asType(originalDType)
+        // NeMo's AudioToMelSpectrogramPreprocessor defaults to HTK mel scale.
+        // Both Parakeet V2 and V3 were trained with NeMo, so use HTK here.
         let filters = melFilters(
             sampleRate: config.sampleRate,
             nFft: config.nFft,
             nMels: config.features,
             norm: config.normalize,
-            melScale: .slaney
+            melScale: .htk
         )
 
         var mel = MLX.matmul(power, filters.asType(power.dtype))

--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
@@ -259,6 +259,7 @@ public final class ParakeetModel: Module, STTGenerationModel {
                 )
 
                 let jointOut = joint(frame, pred)
+                eval(jointOut)
                 let tokenLogits = jointOut[0, 0, 0, ..<(blankToken + 1)]
                 let durationLogits = jointOut[0, 0, 0, (blankToken + 1)...]
                 let token = tokenLogits.argMax(axis: -1).item(Int.self)
@@ -342,6 +343,7 @@ public final class ParakeetModel: Module, STTGenerationModel {
                 )
 
                 let jointOut = joint(frame, pred)
+                eval(jointOut)
                 let token = jointOut.argMax(axis: -1).item(Int.self)
                 let step = ParakeetDecodingLogic.rnntStep(
                     predictedToken: token,

--- a/Sources/MLXAudioSTT/Models/Parakeet/README.md
+++ b/Sources/MLXAudioSTT/Models/Parakeet/README.md
@@ -6,6 +6,7 @@ Parakeet speech-to-text model support for `MLXAudioSTT`.
 
 - [mlx-community/parakeet-tdt-1.1b](https://huggingface.co/mlx-community/parakeet-tdt-1.1b)
 - [mlx-community/parakeet-tdt-0.6b-v3](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3)
+- [mlx-community/parakeet-tdt-0.6b-v2](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v2)
 - [mlx-community/parakeet-tdt_ctc-1.1b](https://huggingface.co/mlx-community/parakeet-tdt-1.1b)
 - [mlx-community/parakeet-ctc-0.6b](https://huggingface.co/mlx-community/parakeet-ctc-0.6b)
 - [mlx-community/parakeet-ctc-1.1b](https://huggingface.co/mlx-community/parakeet-ctc-1.1b)


### PR DESCRIPTION
- Change mel filter scale from .slaney to .htk to match NeMo's AudioToMelSpectrogramPreprocessor defaults (both Parakeet V2 and V3 were trained with NeMo using HTK mel scale)
- Add eval(jointOut) calls in both TDT and standard RNN-T decode paths to ensure joint network output is materialized before argmax
- Add parakeet-tdt-0.6b-v2 to supported models list