### PR TITLE
feat: add MLXAudioG2P — neural ByT5 + dictionary lexicons

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,18 +11,6 @@ on:
 jobs:
   tests:
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Codecs
-            suite: MLXAudioTests/MLXAudioCodecsTests
-          - name: TTS
-            suite: MLXAudioTests/MLXAudioTTSTests
-          - name: STT
-            suite: MLXAudioTests/MLXAudioSTTTests
-          - name: VAD
-            suite: MLXAudioTests/MLXAudioVADTests
 
     steps:
       - uses: actions/checkout@v4
@@ -34,5 +22,5 @@ jobs:
         run: xcodebuild -downloadComponent MetalToolchain
       - name: Build
         run: xcodebuild build-for-testing -scheme MLXAudio-Package -destination 'platform=macOS' MACOSX_DEPLOYMENT_TARGET=14.0 CODE_SIGNING_ALLOWED=NO
-      - name: Run ${{ matrix.name }} tests
-        run: xcodebuild test-without-building -scheme MLXAudio-Package -destination 'platform=macOS' -only-testing:${{ matrix.suite }} CODE_SIGNING_ALLOWED=NO
+      - name: Run tests
+        run: xcodebuild test-without-building -scheme MLXAudio-Package -destination 'platform=macOS' -skip-testing:'MLXAudioTests/SmokeTests' -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ xcuserdata/*
 *.xcuserdatad
 *.xcuserdatad/xcdebugger
 *.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+.tmp/
+audit-repo/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "34a7603e1dffe285f62fe8fd7ec827331ba2ed6e29af3d84bbe4067726673071",
+  "originHash" : "fe5a833cd7fd673ed764afe5174f6cf2e0789ab3af4acea10b742f75454fe2d7",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "a2965424a4babeb0c8e4b5ec9708c3939bc52449",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,13 @@ let package = Package(
         // SwiftUI components
         .library(name: "MLXAudioUI", targets: ["MLXAudioUI"]),
 
+        // Grapheme-to-Phoneme (neural ByT5 + dictionary lexicons)
+        .library(name: "MLXAudioG2P", targets: ["MLXAudioG2P"]),
+
         // Legacy combined library (for backwards compatibility)
         .library(
             name: "MLXAudio",
-            targets: ["MLXAudioCore", "MLXAudioCodecs", "MLXAudioTTS", "MLXAudioSTT", "MLXAudioVAD", "MLXAudioLID", "MLXAudioSTS", "MLXAudioUI"]
+            targets: ["MLXAudioCore", "MLXAudioCodecs", "MLXAudioTTS", "MLXAudioSTT", "MLXAudioVAD", "MLXAudioLID", "MLXAudioSTS", "MLXAudioUI", "MLXAudioG2P"]
         ),
         .executable(
             name: "mlx-audio-swift-tts",
@@ -168,6 +171,16 @@ let package = Package(
             path: "Sources/MLXAudioSTS"
         ),
 
+        // MARK: - MLXAudioG2P
+        .target(
+            name: "MLXAudioG2P",
+            dependencies: [
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+            ],
+            path: "Sources/MLXAudioG2P"
+        ),
+
         // MARK: - MLXAudioUI
         .target(
             name: "MLXAudioUI",
@@ -217,6 +230,7 @@ let package = Package(
                 "MLXAudioSTS",
                 "MLXAudioLID",
                 "mlx-audio-swift-lid",
+                "MLXAudioG2P",
             ],
             path: "Tests",
             resources: [

--- a/Sources/MLXAudioG2P/Attention.swift
+++ b/Sources/MLXAudioG2P/Attention.swift
@@ -1,0 +1,61 @@
+import MLX
+import MLXNN
+
+public typealias KVCache = (keys: MLXArray, values: MLXArray)
+
+public class T5Attention: Module {
+    let numHeads: Int
+    let dKv: Int
+
+    @ModuleInfo(key: "query_proj") var queryProj: Linear
+    @ModuleInfo(key: "key_proj") var keyProj: Linear
+    @ModuleInfo(key: "value_proj") var valueProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    public init(config: T5Config) {
+        self.numHeads = config.numHeads
+        self.dKv = config.dKv
+        let innerDim = config.innerDim
+
+        self._queryProj.wrappedValue = Linear(config.dModel, innerDim, bias: false)
+        self._keyProj.wrappedValue = Linear(config.dModel, innerDim, bias: false)
+        self._valueProj.wrappedValue = Linear(config.dModel, innerDim, bias: false)
+        self._outProj.wrappedValue = Linear(innerDim, config.dModel, bias: false)
+    }
+
+    public func callAsFunction(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        mask: MLXArray? = nil,
+        cache: KVCache? = nil
+    ) -> (MLXArray, KVCache) {
+        let B = queries.shape[0]
+
+        var q = queryProj(queries)
+        var k = keyProj(keys)
+        var v = valueProj(values)
+
+        q = q.reshaped(B, -1, numHeads, dKv).transposed(0, 2, 1, 3)
+        k = k.reshaped(B, -1, numHeads, dKv).transposed(0, 2, 1, 3)
+        v = v.reshaped(B, -1, numHeads, dKv).transposed(0, 2, 1, 3)
+
+        if let cache = cache {
+            k = concatenated([cache.keys, k], axis: 2)
+            v = concatenated([cache.values, v], axis: 2)
+        }
+        let newCache: KVCache = (keys: k, values: v)
+
+        var scores = matmul(q, k.transposed(0, 1, 3, 2))
+
+        if let mask = mask {
+            scores = scores + mask
+        }
+
+        let weights = softmax(scores, axis: -1)
+        var output = matmul(weights, v)
+
+        output = output.transposed(0, 2, 1, 3).reshaped(B, -1, numHeads * dKv)
+        return (outProj(output), newCache)
+    }
+}

--- a/Sources/MLXAudioG2P/Config.swift
+++ b/Sources/MLXAudioG2P/Config.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct T5Config: Codable {
+    public let vocabSize: Int
+    public let dModel: Int
+    public let dFf: Int
+    public let dKv: Int
+    public let numHeads: Int
+    public let numLayers: Int
+    public let numDecoderLayers: Int
+    public let relativeAttentionNumBuckets: Int
+    public let relativeAttentionMaxDistance: Int
+    public let layerNormEpsilon: Float
+    public let feedForwardProj: String
+    public let tieWordEmbeddings: Bool
+    public let decoderStartTokenId: Int
+    public let eosTokenId: Int
+    public let padTokenId: Int
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case dModel = "d_model"
+        case dFf = "d_ff"
+        case dKv = "d_kv"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case numDecoderLayers = "num_decoder_layers"
+        case relativeAttentionNumBuckets = "relative_attention_num_buckets"
+        case relativeAttentionMaxDistance = "relative_attention_max_distance"
+        case layerNormEpsilon = "layer_norm_epsilon"
+        case feedForwardProj = "feed_forward_proj"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case decoderStartTokenId = "decoder_start_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+    }
+
+    public var innerDim: Int { dKv * numHeads }
+
+    public static func load(from directory: URL) throws -> T5Config {
+        let url = directory.appendingPathComponent("config.json")
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T5Config.self, from: data)
+    }
+}

--- a/Sources/MLXAudioG2P/Decoder.swift
+++ b/Sources/MLXAudioG2P/Decoder.swift
@@ -1,0 +1,66 @@
+import MLX
+import MLXNN
+
+public class T5Decoder: Module {
+    @ModuleInfo var layers: [T5DecoderLayer]
+    let ln: RMSNorm
+    @ModuleInfo(key: "relative_attention_bias") var positionBias: RelativePositionBias
+
+    public init(config: T5Config) {
+        self._layers.wrappedValue = (0 ..< config.numDecoderLayers).map { _ in
+            T5DecoderLayer(config: config)
+        }
+        self.ln = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+        self._positionBias.wrappedValue = RelativePositionBias(
+            numHeads: config.numHeads,
+            numBuckets: config.relativeAttentionNumBuckets,
+            maxDistance: config.relativeAttentionMaxDistance,
+            bidirectional: false
+        )
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray,
+        memory: MLXArray,
+        cache: [KVCache?]? = nil
+    ) -> (MLXArray, [KVCache]) {
+        let T = x.shape[1]
+
+        let offset: Int
+        if let firstCache = cache?.first, let c = firstCache {
+            offset = c.keys.shape[2]
+        } else {
+            offset = 0
+        }
+
+        var mask = positionBias(
+            queryLength: T, keyLength: T + offset, offset: offset
+        )
+
+        if T > 1 {
+            let causalMask = MultiHeadAttention.createAdditiveCausalMask(T)
+            mask = mask + causalMask
+        }
+
+        var h = x
+        var newCaches = [KVCache]()
+        newCaches.reserveCapacity(layers.count)
+
+        for (i, layer) in layers.enumerated() {
+            let layerCache = cache?[safe: i] ?? nil
+            let (out, newCache) = layer(
+                h, memory: memory, selfAttnMask: mask, cache: layerCache
+            )
+            h = out
+            newCaches.append(newCache)
+        }
+
+        return (ln(h), newCaches)
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/MLXAudioG2P/DecoderLayer.swift
+++ b/Sources/MLXAudioG2P/DecoderLayer.swift
@@ -1,0 +1,46 @@
+import MLX
+import MLXNN
+
+public class T5DecoderLayer: Module {
+    @ModuleInfo(key: "self_attention") var selfAttention: T5Attention
+    @ModuleInfo(key: "cross_attention") var crossAttention: T5Attention
+    @ModuleInfo var dense: T5DenseActivation
+    let ln1: RMSNorm
+    let ln2: RMSNorm
+    let ln3: RMSNorm
+
+    public init(config: T5Config) {
+        self._selfAttention.wrappedValue = T5Attention(config: config)
+        self._crossAttention.wrappedValue = T5Attention(config: config)
+        self._dense.wrappedValue = T5DenseActivation(config: config)
+        self.ln1 = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+        self.ln2 = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+        self.ln3 = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray,
+        memory: MLXArray,
+        selfAttnMask: MLXArray? = nil,
+        cache: KVCache? = nil
+    ) -> (MLXArray, KVCache) {
+        var x = x
+        let y = ln1(x)
+        let (selfAttnOut, newCache) = selfAttention(
+            queries: y, keys: y, values: y,
+            mask: selfAttnMask, cache: cache
+        )
+        x = x + selfAttnOut
+
+        let z = ln2(x)
+        let (crossAttnOut, _) = crossAttention(
+            queries: z, keys: memory, values: memory
+        )
+        x = x + crossAttnOut
+
+        let w = ln3(x)
+        x = x + dense(w)
+
+        return (x, newCache)
+    }
+}

--- a/Sources/MLXAudioG2P/Encoder.swift
+++ b/Sources/MLXAudioG2P/Encoder.swift
@@ -1,0 +1,31 @@
+import MLX
+import MLXNN
+
+public class T5Encoder: Module {
+    @ModuleInfo var layers: [T5EncoderLayer]
+    let ln: RMSNorm
+    @ModuleInfo(key: "relative_attention_bias") var positionBias: RelativePositionBias
+
+    public init(config: T5Config) {
+        self._layers.wrappedValue = (0 ..< config.numLayers).map { _ in
+            T5EncoderLayer(config: config)
+        }
+        self.ln = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+        self._positionBias.wrappedValue = RelativePositionBias(
+            numHeads: config.numHeads,
+            numBuckets: config.relativeAttentionNumBuckets,
+            maxDistance: config.relativeAttentionMaxDistance,
+            bidirectional: true
+        )
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let seqLen = x.shape[1]
+        let bias = positionBias(queryLength: seqLen, keyLength: seqLen)
+        var h = x
+        for layer in layers {
+            h = layer(h, mask: bias)
+        }
+        return ln(h)
+    }
+}

--- a/Sources/MLXAudioG2P/EncoderLayer.swift
+++ b/Sources/MLXAudioG2P/EncoderLayer.swift
@@ -1,0 +1,26 @@
+import MLX
+import MLXNN
+
+public class T5EncoderLayer: Module {
+    @ModuleInfo var attention: T5Attention
+    @ModuleInfo var dense: T5DenseActivation
+    let ln1: RMSNorm
+    let ln2: RMSNorm
+
+    public init(config: T5Config) {
+        self._attention.wrappedValue = T5Attention(config: config)
+        self._dense.wrappedValue = T5DenseActivation(config: config)
+        self.ln1 = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+        self.ln2 = RMSNorm(dimensions: config.dModel, eps: config.layerNormEpsilon)
+    }
+
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray) -> MLXArray {
+        var x = x
+        let y = ln1(x)
+        let (attnOut, _) = attention(queries: y, keys: y, values: y, mask: mask)
+        x = x + attnOut
+        let z = ln2(x)
+        x = x + dense(z)
+        return x
+    }
+}

--- a/Sources/MLXAudioG2P/FeedForward.swift
+++ b/Sources/MLXAudioG2P/FeedForward.swift
@@ -1,0 +1,18 @@
+import MLX
+import MLXNN
+
+public class T5DenseActivation: Module {
+    @ModuleInfo(key: "wi_0") var wi0: Linear
+    @ModuleInfo(key: "wi_1") var wi1: Linear
+    @ModuleInfo var wo: Linear
+
+    public init(config: T5Config) {
+        self._wi0.wrappedValue = Linear(config.dModel, config.dFf, bias: false)
+        self._wi1.wrappedValue = Linear(config.dModel, config.dFf, bias: false)
+        self._wo.wrappedValue = Linear(config.dFf, config.dModel, bias: false)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        wo(gelu(wi0(x)) * wi1(x))
+    }
+}

--- a/Sources/MLXAudioG2P/G2P.swift
+++ b/Sources/MLXAudioG2P/G2P.swift
@@ -1,0 +1,56 @@
+import Foundation
+import MLX
+import MLXNN
+
+public class G2P {
+    private let model: T5ForConditionalGeneration
+    private let tokenizer = ByT5Tokenizer()
+    private let maxLength: Int
+
+    public init(modelDirectory: URL, maxLength: Int = 50) throws {
+        self.model = try WeightLoader.load(from: modelDirectory)
+        self.maxLength = maxLength
+    }
+
+    public func convert(_ word: String, language: String) -> String {
+        let input = tokenizer.formatInput(word, language: language)
+        let inputIds = tokenizer.encode(input)
+        let inputTensor = MLXArray(inputIds).expandedDimensions(axis: 0)
+        let encoderOutput = model.encode(inputTensor)
+        let outputIds = greedyDecode(encoderOutput: encoderOutput)
+        return tokenizer.decode(outputIds)
+    }
+
+    private func greedyDecode(encoderOutput: MLXArray) -> [Int32] {
+        var currentToken = MLXArray([Int32(model.config.decoderStartTokenId)])
+            .expandedDimensions(axis: 0)
+        var cache: [KVCache?]? = nil
+        var outputIds = [Int32]()
+
+        for _ in 0 ..< maxLength {
+            let (logits, newCaches) = model.decode(
+                currentToken,
+                encoderOutput: encoderOutput,
+                cache: cache
+            )
+
+            let nextTokenId = argMax(logits[0..., -1, 0...], axis: -1)
+                .item(Int32.self)
+
+            if nextTokenId == model.config.eosTokenId {
+                break
+            }
+
+            outputIds.append(nextTokenId)
+            currentToken = MLXArray([nextTokenId]).expandedDimensions(axis: 0)
+            cache = newCaches.map { Optional($0) }
+            eval(currentToken, newCaches)
+        }
+
+        return outputIds
+    }
+
+    public func convert(_ words: [String], language: String) -> [String] {
+        words.map { convert($0, language: language) }
+    }
+}

--- a/Sources/MLXAudioG2P/G2PTypes.swift
+++ b/Sources/MLXAudioG2P/G2PTypes.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct PhonemeUnit: Sendable, Hashable {
+    public let symbol: String
+    public init(symbol: String) { self.symbol = symbol }
+}
+
+public protocol Phonemizing: Sendable {
+    func phonemize(_ grapheme: String) throws -> [PhonemeUnit]
+}
+
+public enum G2PError: Error, Sendable, Equatable {
+    case emptyInput
+    case unsupportedLocale(String)
+    case phonemizationFailed(token: String, reason: String)
+    case alignmentFailed(reason: String)
+    case resourceLoadFailed(name: String, reason: String)
+}

--- a/Sources/MLXAudioG2P/Lexicon/CMUDict/ARPAbetMapper.swift
+++ b/Sources/MLXAudioG2P/Lexicon/CMUDict/ARPAbetMapper.swift
@@ -1,0 +1,66 @@
+public enum ARPAbetMapper {
+
+    public static func toIPA(_ arpabet: String) -> String? {
+        guard !arpabet.isEmpty else { return nil }
+
+        let lastChar = arpabet.last!
+        let isStressed = lastChar >= "0" && lastChar <= "2"
+        let base = isStressed ? String(arpabet.dropLast()) : arpabet
+        let stress = isStressed ? Int(String(lastChar)) : nil
+
+        switch base {
+        case "AH":
+            return stress == 0 ? "ə" : "ʌ"
+        case "ER":
+            return stress == 0 ? "ɚ" : "ɝ"
+        default:
+            break
+        }
+
+        return mapping[base]
+    }
+
+    public static func convertSequence(_ arpabet: [String]) -> [String] {
+        arpabet.compactMap { toIPA($0) }
+    }
+
+    private static let mapping: [String: String] = [
+        "AA": "ɑ",
+        "AE": "æ",
+        "AO": "ɔ",
+        "AW": "aʊ",
+        "AY": "aɪ",
+        "EH": "ɛ",
+        "EY": "eɪ",
+        "IH": "ɪ",
+        "IY": "i",
+        "OW": "oʊ",
+        "OY": "ɔɪ",
+        "UH": "ʊ",
+        "UW": "u",
+        "B": "b",
+        "CH": "tʃ",
+        "D": "d",
+        "DH": "ð",
+        "F": "f",
+        "G": "ɡ",
+        "HH": "h",
+        "JH": "dʒ",
+        "K": "k",
+        "L": "l",
+        "M": "m",
+        "N": "n",
+        "NG": "ŋ",
+        "P": "p",
+        "R": "ɹ",
+        "S": "s",
+        "SH": "ʃ",
+        "T": "t",
+        "TH": "θ",
+        "V": "v",
+        "W": "w",
+        "Y": "j",
+        "Z": "z",
+        "ZH": "ʒ",
+    ]
+}

--- a/Sources/MLXAudioG2P/Lexicon/CMUDict/CMUDictLoader.swift
+++ b/Sources/MLXAudioG2P/Lexicon/CMUDict/CMUDictLoader.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public enum CMUDictLoader {
+
+    public static func load(from directory: URL) throws -> InMemoryLexicon {
+        let url = directory.appendingPathComponent("cmudict.dict")
+
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw G2PError.resourceLoadFailed(
+                name: "cmudict.dict",
+                reason: "File not found at \(url.path)"
+            )
+        }
+
+        let data = try Data(contentsOf: url)
+
+        guard let text = String(data: data, encoding: .isoLatin1)
+            ?? String(data: data, encoding: .utf8) else {
+            throw G2PError.resourceLoadFailed(
+                name: "cmudict.dict",
+                reason: "Unable to decode file content"
+            )
+        }
+
+        let rawEntries = CMUDictParser.parse(text: text, primaryOnly: true)
+
+        let lexiconEntries = rawEntries.map { raw in
+            LexiconEntry(
+                grapheme: raw.word,
+                phonemes: ARPAbetMapper.convertSequence(raw.arpabet)
+            )
+        }
+
+        return InMemoryLexicon(entries: lexiconEntries)
+    }
+}

--- a/Sources/MLXAudioG2P/Lexicon/CMUDict/CMUDictParser.swift
+++ b/Sources/MLXAudioG2P/Lexicon/CMUDict/CMUDictParser.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+public struct CMUDictRawEntry: Sendable, Hashable {
+    public let word: String
+    public let arpabet: [String]
+    public let variant: Int?
+
+    public init(word: String, arpabet: [String], variant: Int?) {
+        self.word = word
+        self.arpabet = arpabet
+        self.variant = variant
+    }
+}
+
+public enum CMUDictParser {
+    public static func parseLine(_ line: String) -> CMUDictRawEntry? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix(";;;") else { return nil }
+
+        // Split on first whitespace: word is first token, pronunciation is the rest.
+        // Handles both single-space (raw cmudict.dict) and double-space formats.
+        guard let firstSpace = trimmed.firstIndex(of: " ") else { return nil }
+
+        let wordPart = String(trimmed[trimmed.startIndex..<firstSpace])
+        let pronPart = String(trimmed[trimmed.index(after: firstSpace)...])
+            .trimmingCharacters(in: .whitespaces)
+
+        guard !wordPart.isEmpty, !pronPart.isEmpty else { return nil }
+
+        let word: String
+        let variant: Int?
+
+        if let parenStart = wordPart.firstIndex(of: "("),
+           let parenEnd = wordPart.firstIndex(of: ")"),
+           parenStart < parenEnd {
+            word = String(wordPart[wordPart.startIndex..<parenStart]).lowercased()
+            variant = Int(wordPart[wordPart.index(after: parenStart)..<parenEnd])
+        } else {
+            word = wordPart.lowercased()
+            variant = nil
+        }
+
+        let arpabet = pronPart.split(separator: " ").map(String.init)
+        guard !arpabet.isEmpty else { return nil }
+
+        return CMUDictRawEntry(word: word, arpabet: arpabet, variant: variant)
+    }
+
+    public static func parse(text: String, primaryOnly: Bool = false) -> [CMUDictRawEntry] {
+        text.split(separator: "\n", omittingEmptySubsequences: false)
+            .compactMap { parseLine(String($0)) }
+            .filter { !primaryOnly || $0.variant == nil }
+    }
+}

--- a/Sources/MLXAudioG2P/Lexicon/InMemoryLexicon.swift
+++ b/Sources/MLXAudioG2P/Lexicon/InMemoryLexicon.swift
@@ -1,0 +1,13 @@
+public struct InMemoryLexicon: LexiconProviding, Sendable {
+    private let entries: [String: LexiconEntry]
+
+    public init(entries: [LexiconEntry]) {
+        self.entries = Dictionary(
+            uniqueKeysWithValues: entries.map { ($0.grapheme.lowercased(), $0) }
+        )
+    }
+
+    public func lookup(_ grapheme: String) -> LexiconEntry? {
+        entries[grapheme.lowercased()]
+    }
+}

--- a/Sources/MLXAudioG2P/Lexicon/LexiconEntry.swift
+++ b/Sources/MLXAudioG2P/Lexicon/LexiconEntry.swift
@@ -1,0 +1,9 @@
+public struct LexiconEntry: Sendable, Hashable {
+    public let grapheme: String
+    public let phonemes: [String]
+
+    public init(grapheme: String, phonemes: [String]) {
+        self.grapheme = grapheme
+        self.phonemes = phonemes
+    }
+}

--- a/Sources/MLXAudioG2P/Lexicon/LexiconProviding.swift
+++ b/Sources/MLXAudioG2P/Lexicon/LexiconProviding.swift
@@ -1,0 +1,3 @@
+public protocol LexiconProviding: Sendable {
+    func lookup(_ grapheme: String) -> LexiconEntry?
+}

--- a/Sources/MLXAudioG2P/Model.swift
+++ b/Sources/MLXAudioG2P/Model.swift
@@ -1,0 +1,60 @@
+import MLX
+import MLXNN
+
+class OutputHead: Module {
+    @ModuleInfo var linear: Linear
+
+    init(config: T5Config) {
+        self._linear.wrappedValue = Linear(config.dModel, config.vocabSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear(x)
+    }
+}
+
+public class T5ForConditionalGeneration: Module {
+    let config: T5Config
+    @ModuleInfo var wte: Embedding
+    @ModuleInfo var encoder: T5Encoder
+    @ModuleInfo var decoder: T5Decoder
+    @ModuleInfo(key: "lm_head") var lmHead: OutputHead?
+
+    public init(config: T5Config) {
+        self.config = config
+        self._wte.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize, dimensions: config.dModel
+        )
+        self._encoder.wrappedValue = T5Encoder(config: config)
+        self._decoder.wrappedValue = T5Decoder(config: config)
+
+        if !config.tieWordEmbeddings {
+            self._lmHead.wrappedValue = OutputHead(config: config)
+        }
+    }
+
+    public func encode(_ inputIds: MLXArray) -> MLXArray {
+        encoder(wte(inputIds))
+    }
+
+    public func decode(
+        _ decoderInputIds: MLXArray,
+        encoderOutput: MLXArray,
+        cache: [KVCache?]? = nil
+    ) -> (MLXArray, [KVCache]) {
+        let embeddings = wte(decoderInputIds)
+        let (decoderOutput, newCaches) = decoder(
+            embeddings, memory: encoderOutput, cache: cache
+        )
+
+        let logits: MLXArray
+        if config.tieWordEmbeddings {
+            let scale = 1.0 / Float(config.dModel).squareRoot()
+            logits = wte.asLinear(decoderOutput * scale)
+        } else {
+            logits = lmHead!(decoderOutput)
+        }
+
+        return (logits, newCaches)
+    }
+}

--- a/Sources/MLXAudioG2P/NeuralPhonemizer.swift
+++ b/Sources/MLXAudioG2P/NeuralPhonemizer.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Neural G2P fallback using ByT5 model.
+///
+/// Usage:
+/// ```swift
+/// let neural = try NeuralPhonemizer(modelDirectory: modelURL, language: "eng-us")
+/// let pack = EnglishLanguagePack(
+///     normalizer: .englishDefault,
+///     tokenizer: .englishDefault,
+///     lexicon: try CMUDictLoader.loadFromBundle(),
+///     fallback: neural
+/// )
+/// ```
+public final class NeuralPhonemizer: Phonemizing, @unchecked Sendable {
+    private let g2p: G2P
+    private let language: String
+
+    public init(modelDirectory: URL, language: String = "eng-us", maxLength: Int = 50) throws {
+        self.g2p = try G2P(modelDirectory: modelDirectory, maxLength: maxLength)
+        self.language = language
+    }
+
+    public func phonemize(_ grapheme: String) throws -> [PhonemeUnit] {
+        let ipa = g2p.convert(grapheme, language: language)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !ipa.isEmpty else {
+            throw G2PError.phonemizationFailed(
+                token: grapheme,
+                reason: "Neural model returned empty output"
+            )
+        }
+
+        return ipa.filter { !$0.isWhitespace }
+            .map { PhonemeUnit(symbol: String($0)) }
+    }
+}

--- a/Sources/MLXAudioG2P/RelativePositionBias.swift
+++ b/Sources/MLXAudioG2P/RelativePositionBias.swift
@@ -1,0 +1,85 @@
+import MLX
+import MLXNN
+
+func relativePositionBucket(
+    relativePosition: MLXArray,
+    bidirectional: Bool,
+    numBuckets: Int,
+    maxDistance: Int
+) -> MLXArray {
+    var numBuckets = numBuckets
+    var relativePosition = relativePosition
+    var relativeBuckets = MLXArray.zeros(like: relativePosition)
+
+    if bidirectional {
+        numBuckets /= 2
+        relativeBuckets = relativeBuckets + (relativePosition .> 0).asType(.int32) * numBuckets
+        relativePosition = abs(relativePosition)
+    } else {
+        relativePosition = -minimum(relativePosition, MLXArray.zeros(like: relativePosition))
+    }
+
+    let maxExact = numBuckets / 2
+    let isSmall = relativePosition .< maxExact
+
+    let relativePositionFloat = relativePosition.asType(.float32)
+    let maxExactF = MLXArray(Float(maxExact))
+    let maxDistF = MLXArray(Float(maxDistance))
+    var relativePositionIfLarge = maxExactF + (
+        log(relativePositionFloat / maxExactF)
+            / log(maxDistF / maxExactF)
+            * Float(numBuckets - maxExact)
+    )
+    relativePositionIfLarge = minimum(
+        relativePositionIfLarge,
+        MLXArray(Float(numBuckets - 1))
+    )
+
+    relativeBuckets = relativeBuckets + `where`(
+        isSmall,
+        relativePosition,
+        relativePositionIfLarge.asType(.int32)
+    )
+    return relativeBuckets
+}
+
+public class RelativePositionBias: Module {
+    let bidirectional: Bool
+    let numBuckets: Int
+    let maxDistance: Int
+    @ModuleInfo var embeddings: Embedding
+
+    public init(
+        numHeads: Int,
+        numBuckets: Int = 32,
+        maxDistance: Int = 128,
+        bidirectional: Bool = true
+    ) {
+        self.bidirectional = bidirectional
+        self.numBuckets = numBuckets
+        self.maxDistance = maxDistance
+        self._embeddings.wrappedValue = Embedding(
+            embeddingCount: numBuckets, dimensions: numHeads
+        )
+    }
+
+    public func callAsFunction(
+        queryLength: Int, keyLength: Int, offset: Int = 0
+    ) -> MLXArray {
+        let contextPosition = MLXArray(
+            Int32(offset) ..< Int32(offset + queryLength)
+        ).expandedDimensions(axis: 1)
+        let memoryPosition = MLXArray(
+            Int32(0) ..< Int32(keyLength)
+        ).expandedDimensions(axis: 0)
+        let relativePosition = memoryPosition - contextPosition
+
+        let buckets = relativePositionBucket(
+            relativePosition: relativePosition,
+            bidirectional: bidirectional,
+            numBuckets: numBuckets,
+            maxDistance: maxDistance
+        )
+        return embeddings(buckets).transposed(2, 0, 1)
+    }
+}

--- a/Sources/MLXAudioG2P/Tokenizer.swift
+++ b/Sources/MLXAudioG2P/Tokenizer.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public struct ByT5Tokenizer: Sendable {
+    public static let padTokenId: Int32 = 0
+    public static let eosTokenId: Int32 = 1
+    public static let unkTokenId: Int32 = 2
+    private static let byteOffset: Int32 = 3
+
+    public init() {}
+
+    public func encode(_ text: String) -> [Int32] {
+        var ids = [Int32]()
+        ids.reserveCapacity(text.utf8.count + 1)
+        for byte in text.utf8 {
+            ids.append(Int32(byte) + Self.byteOffset)
+        }
+        ids.append(Self.eosTokenId)
+        return ids
+    }
+
+    public func decode(_ ids: [Int32]) -> String {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(ids.count)
+        for id in ids {
+            if id == Self.eosTokenId { break }
+            if id == Self.padTokenId || id == Self.unkTokenId { continue }
+            let byte = id - Self.byteOffset
+            if byte >= 0, byte <= 255 {
+                bytes.append(UInt8(byte))
+            }
+        }
+        return String(bytes: bytes, encoding: .utf8) ?? ""
+    }
+
+    public func formatInput(_ word: String, language: String) -> String {
+        "<\(language)>: \(word)"
+    }
+}

--- a/Sources/MLXAudioG2P/Weights.swift
+++ b/Sources/MLXAudioG2P/Weights.swift
@@ -1,0 +1,88 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum WeightLoader {
+
+    private static let sharedReplacements: [(String, String)] = [
+        (".block.", ".layers."),
+        (".k.", ".key_proj."),
+        (".o.", ".out_proj."),
+        (".q.", ".query_proj."),
+        (".v.", ".value_proj."),
+        ("shared.", "wte."),
+        ("lm_head.", "lm_head.linear."),
+        (".layer.0.layer_norm.", ".ln1."),
+        (".layer.1.layer_norm.", ".ln2."),
+        (".layer.2.layer_norm.", ".ln3."),
+        (".final_layer_norm.", ".ln."),
+        (
+            "layers.0.layer.0.SelfAttention.relative_attention_bias.",
+            "relative_attention_bias.embeddings."
+        ),
+    ]
+
+    private static let encoderReplacements: [(String, String)] = [
+        (".layer.0.SelfAttention.", ".attention."),
+        (".layer.1.DenseReluDense.", ".dense."),
+    ]
+
+    private static let decoderReplacements: [(String, String)] = [
+        (".layer.0.SelfAttention.", ".self_attention."),
+        (".layer.1.EncDecAttention.", ".cross_attention."),
+        (".layer.2.DenseReluDense.", ".dense."),
+    ]
+
+    private static let ignoredPatterns: [String] = [
+        ".cross_attention.relative_attention_bias."
+    ]
+
+    static func sanitizeKey(_ key: String) -> String? {
+        var key = key
+
+        for (from, to) in sharedReplacements {
+            key = key.replacingOccurrences(of: from, with: to)
+        }
+
+        if key.hasPrefix("encoder.") {
+            for (from, to) in encoderReplacements {
+                key = key.replacingOccurrences(of: from, with: to)
+            }
+        } else if key.hasPrefix("decoder.") {
+            for (from, to) in decoderReplacements {
+                key = key.replacingOccurrences(of: from, with: to)
+            }
+        }
+
+        if ignoredPatterns.contains(where: { key.contains($0) }) { return nil }
+        return key
+    }
+
+    public static func sanitize(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result = [String: MLXArray]()
+        result.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            if let sanitized = sanitizeKey(key) {
+                result[sanitized] = value
+            }
+        }
+        return result
+    }
+
+    public static func load(from directory: URL) throws -> T5ForConditionalGeneration {
+        let config = try T5Config.load(from: directory)
+        let model = T5ForConditionalGeneration(config: config)
+
+        let weightsURL = directory.appendingPathComponent("model.safetensors")
+        let rawWeights = try loadArrays(url: weightsURL)
+        let weights = sanitize(rawWeights)
+
+        let parameters = ModuleParameters.unflattened(weights)
+        try model.update(parameters: parameters, verify: .noUnusedKeys)
+
+        model.freeze()
+        model.train(false)
+
+        return model
+    }
+}

--- a/Tests/MLXAudioG2PCMUDictTests.swift
+++ b/Tests/MLXAudioG2PCMUDictTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import MLXAudioG2P
+
+struct CMUDictParserTests {
+
+    @Test func parsesBasicEntry() throws {
+        let entry = try #require(CMUDictParser.parseLine("hello  HH AH0 L OW1"))
+        #expect(entry.word == "hello")
+        #expect(entry.arpabet == ["HH", "AH0", "L", "OW1"])
+        #expect(entry.variant == nil)
+    }
+
+    @Test func parsesVariantEntry() throws {
+        let entry = try #require(CMUDictParser.parseLine("the(2)  DH IY0"))
+        #expect(entry.word == "the")
+        #expect(entry.arpabet == ["DH", "IY0"])
+        #expect(entry.variant == 2)
+    }
+
+    @Test func skipsCommentLines() {
+        #expect(CMUDictParser.parseLine(";;; this is a comment") == nil)
+    }
+
+    @Test func skipsEmptyLines() {
+        #expect(CMUDictParser.parseLine("") == nil)
+        #expect(CMUDictParser.parseLine("   ") == nil)
+    }
+
+    @Test func handlesSinglePhoneme() throws {
+        let entry = try #require(CMUDictParser.parseLine("a  AH0"))
+        #expect(entry.word == "a")
+        #expect(entry.arpabet == ["AH0"])
+    }
+
+    @Test func parsesBulkText() {
+        let text = """
+        ;;; comment
+        hello  HH AH0 L OW1
+        world  W ER1 L D
+        the  DH AH0
+        the(2)  DH IY0
+        """
+        let entries = CMUDictParser.parse(text: text)
+        #expect(entries.count == 4)
+        #expect(entries[0].word == "hello")
+        #expect(entries[3].variant == 2)
+    }
+
+    @Test func filtersPrimaryOnly() {
+        let text = """
+        the  DH AH0
+        the(2)  DH IY0
+        hello  HH AH0 L OW1
+        """
+        let entries = CMUDictParser.parse(text: text, primaryOnly: true)
+        #expect(entries.count == 2)
+        #expect(entries.allSatisfy { $0.variant == nil })
+    }
+}
+
+struct ARPAbetMapperTests {
+
+    @Test func mapsConsonant() {
+        #expect(ARPAbetMapper.toIPA("TH") == "θ")
+        #expect(ARPAbetMapper.toIPA("SH") == "ʃ")
+        #expect(ARPAbetMapper.toIPA("NG") == "ŋ")
+        #expect(ARPAbetMapper.toIPA("HH") == "h")
+        #expect(ARPAbetMapper.toIPA("CH") == "tʃ")
+        #expect(ARPAbetMapper.toIPA("JH") == "dʒ")
+        #expect(ARPAbetMapper.toIPA("ZH") == "ʒ")
+    }
+
+    @Test func mapsVowelStrippingStress() {
+        #expect(ARPAbetMapper.toIPA("AH0") == "ə")
+        #expect(ARPAbetMapper.toIPA("AH1") == "ʌ")
+        #expect(ARPAbetMapper.toIPA("AH2") == "ʌ")
+        #expect(ARPAbetMapper.toIPA("ER0") == "ɚ")
+        #expect(ARPAbetMapper.toIPA("ER1") == "ɝ")
+    }
+
+    @Test func mapsRegularVowels() {
+        #expect(ARPAbetMapper.toIPA("AA0") == "ɑ")
+        #expect(ARPAbetMapper.toIPA("AA1") == "ɑ")
+        #expect(ARPAbetMapper.toIPA("AE1") == "æ")
+        #expect(ARPAbetMapper.toIPA("EY0") == "eɪ")
+        #expect(ARPAbetMapper.toIPA("OW1") == "oʊ")
+        #expect(ARPAbetMapper.toIPA("AW0") == "aʊ")
+        #expect(ARPAbetMapper.toIPA("AY1") == "aɪ")
+        #expect(ARPAbetMapper.toIPA("OY0") == "ɔɪ")
+    }
+
+    @Test func returnsNilForUnknown() {
+        #expect(ARPAbetMapper.toIPA("XX") == nil)
+        #expect(ARPAbetMapper.toIPA("") == nil)
+    }
+
+    @Test func convertsFullSequence() {
+        let ipa = ARPAbetMapper.convertSequence(["HH", "AH0", "L", "OW1"])
+        #expect(ipa == ["h", "ə", "l", "oʊ"])
+    }
+
+    @Test func convertsSequenceSkipsUnknown() {
+        let ipa = ARPAbetMapper.convertSequence(["HH", "XX", "L"])
+        #expect(ipa == ["h", "l"])
+    }
+}
+
+struct CMUDictLoaderTests {
+
+    private static var cmuDictDir: URL? {
+        ProcessInfo.processInfo.environment["MLXAUDIO_CMUDICT_DIR"].map { URL(fileURLWithPath: $0) }
+    }
+
+    @Test func loadsFromDirectory() throws {
+        guard let dir = Self.cmuDictDir else {
+            print("Skipping: set MLXAUDIO_CMUDICT_DIR to cmudict directory")
+            return
+        }
+        let lexicon = try CMUDictLoader.load(from: dir)
+        #expect(lexicon.lookup("hello") != nil)
+        #expect(lexicon.lookup("world") != nil)
+        #expect(lexicon.lookup("the") != nil)
+    }
+
+    @Test func producesCorrectIPA() throws {
+        guard let dir = Self.cmuDictDir else { return }
+        let lexicon = try CMUDictLoader.load(from: dir)
+        let hello = try #require(lexicon.lookup("hello"))
+        #expect(hello.phonemes == ["h", "ə", "l", "oʊ"])
+    }
+
+    @Test func handlesUppercaseQuery() throws {
+        guard let dir = Self.cmuDictDir else { return }
+        let lexicon = try CMUDictLoader.load(from: dir)
+        #expect(lexicon.lookup("HELLO") != nil)
+        #expect(lexicon.lookup("Hello") != nil)
+    }
+
+    @Test func returnsNilForNonsense() throws {
+        guard let dir = Self.cmuDictDir else { return }
+        let lexicon = try CMUDictLoader.load(from: dir)
+        #expect(lexicon.lookup("xyzzyplugh") == nil)
+    }
+
+    @Test func hasReasonableCount() throws {
+        guard let dir = Self.cmuDictDir else { return }
+        let lexicon = try CMUDictLoader.load(from: dir)
+        #expect(lexicon.lookup("phone") != nil)
+        #expect(lexicon.lookup("knight") != nil)
+        #expect(lexicon.lookup("psychology") != nil)
+        #expect(lexicon.lookup("through") != nil)
+    }
+
+    @Test func fixesDigraphsCorrectly() throws {
+        guard let dir = Self.cmuDictDir else { return }
+        let lexicon = try CMUDictLoader.load(from: dir)
+
+        let phone = try #require(lexicon.lookup("phone"))
+        #expect(phone.phonemes.contains("f"))
+        #expect(!phone.phonemes.contains("p"))
+
+        let knight = try #require(lexicon.lookup("knight"))
+        #expect(knight.phonemes.first == "n")
+    }
+}
+

--- a/Tests/MLXAudioG2PTests.swift
+++ b/Tests/MLXAudioG2PTests.swift
@@ -1,0 +1,239 @@
+import Testing
+import Foundation
+@testable import MLXAudioG2P
+import MLXAudioCore
+
+// MARK: - Unit Tests (no model required)
+
+struct ByT5TokenizerTests {
+    let tokenizer = ByT5Tokenizer()
+
+    @Test func encodeASCII() {
+        let ids = tokenizer.encode("hi")
+        // 'h'=104 +3=107, 'i'=105 +3=108, EOS=1
+        #expect(ids == [107, 108, 1])
+    }
+
+    @Test func decodeRoundTrip() {
+        let original = "hello"
+        let decoded = tokenizer.decode(tokenizer.encode(original))
+        #expect(decoded == original)
+    }
+
+    @Test func decodeStopsAtEOS() {
+        let ids: [Int32] = [107, 108, 1, 109, 110]
+        #expect(tokenizer.decode(ids) == "hi")
+    }
+
+    @Test func decodeSkipsPadAndUnk() {
+        let ids: [Int32] = [0, 2, 107, 108, 1]
+        #expect(tokenizer.decode(ids) == "hi")
+    }
+
+    @Test func formatInput() {
+        #expect(tokenizer.formatInput("hello", language: "eng-us") == "<eng-us>: hello")
+    }
+
+    @Test func encodeMultibyteUTF8() {
+        let ids = tokenizer.encode("ü")
+        #expect(ids.count == 3) // ü = 2 UTF-8 bytes + EOS
+        #expect(ids.last == ByT5Tokenizer.eosTokenId)
+    }
+
+    @Test func emptyStringEncodesEOSOnly() {
+        #expect(tokenizer.encode("") == [1])
+    }
+}
+
+struct WeightSanitizationTests {
+    @Test func sharedToWTE() {
+        #expect(WeightLoader.sanitizeKey("shared.weight") == "wte.weight")
+    }
+
+    @Test func encoderSelfAttention() {
+        #expect(
+            WeightLoader.sanitizeKey("encoder.block.0.layer.0.SelfAttention.q.weight")
+                == "encoder.layers.0.attention.query_proj.weight"
+        )
+    }
+
+    @Test func decoderSelfAttention() {
+        #expect(
+            WeightLoader.sanitizeKey("decoder.block.0.layer.0.SelfAttention.q.weight")
+                == "decoder.layers.0.self_attention.query_proj.weight"
+        )
+    }
+
+    @Test func decoderCrossAttention() {
+        #expect(
+            WeightLoader.sanitizeKey("decoder.block.0.layer.1.EncDecAttention.k.weight")
+                == "decoder.layers.0.cross_attention.key_proj.weight"
+        )
+    }
+
+    @Test func layerNormKeys() {
+        #expect(
+            WeightLoader.sanitizeKey("encoder.block.0.layer.0.layer_norm.weight")
+                == "encoder.layers.0.ln1.weight"
+        )
+    }
+
+    @Test func filtersIgnoredKeys() {
+        #expect(
+            WeightLoader.sanitizeKey(
+                "decoder.block.0.layer.1.EncDecAttention.relative_attention_bias.embeddings.weight"
+            ) == nil
+        )
+    }
+}
+
+struct T5ConfigTests {
+    private static let sampleJSON = """
+    {
+        "vocab_size": 384,
+        "d_model": 256,
+        "d_ff": 512,
+        "d_kv": 32,
+        "num_heads": 4,
+        "num_layers": 12,
+        "num_decoder_layers": 4,
+        "relative_attention_num_buckets": 32,
+        "relative_attention_max_distance": 128,
+        "layer_norm_epsilon": 1e-6,
+        "feed_forward_proj": "gated-gelu",
+        "tie_word_embeddings": true,
+        "decoder_start_token_id": 0,
+        "eos_token_id": 1,
+        "pad_token_id": 0
+    }
+    """
+
+    @Test func decodesFromJSON() throws {
+        let config = try JSONDecoder().decode(
+            T5Config.self, from: Self.sampleJSON.data(using: .utf8)!
+        )
+        #expect(config.vocabSize == 384)
+        #expect(config.dModel == 256)
+        #expect(config.numHeads == 4)
+        #expect(config.numLayers == 12)
+        #expect(config.numDecoderLayers == 4)
+        #expect(config.innerDim == 128)
+        #expect(config.tieWordEmbeddings == true)
+    }
+
+    @Test func loadsFromDirectory() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try Self.sampleJSON.write(
+            to: tmpDir.appendingPathComponent("config.json"),
+            atomically: true, encoding: .utf8
+        )
+
+        let config = try T5Config.load(from: tmpDir)
+        #expect(config.vocabSize == 384)
+        #expect(config.innerDim == 128)
+    }
+}
+
+// MARK: - Integration Tests (downloads model, requires Metal + network)
+
+struct NeuralG2PIntegrationTests {
+    private static let networkEnabled = ProcessInfo.processInfo.environment["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1"
+
+    private static func modelDirectory() async throws -> URL {
+        try await ModelUtils.resolveOrDownloadModel(
+            repoID: "beshkenadze/g2p-multilingual-byT5-tiny-mlx",
+            requiredExtension: "safetensors"
+        )
+    }
+
+    @Test func convertEnglishWord() async throws {
+        guard Self.networkEnabled else { print("Skipping network NeuralG2P test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable."); return }
+        let g2p = try G2P(modelDirectory: try await Self.modelDirectory())
+        let ipa = g2p.convert("hello", language: "eng-us")
+        #expect(!ipa.isEmpty)
+        #expect(ipa.contains("h") || ipa.contains("ɛ") || ipa.contains("l"))
+    }
+
+    @Test func batchConvert() async throws {
+        guard Self.networkEnabled else { return }
+        let g2p = try G2P(modelDirectory: try await Self.modelDirectory())
+        let results = g2p.convert(["hello", "world"], language: "eng-us")
+        #expect(results.count == 2)
+        #expect(results.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test func neuralPhonemizerProducesPhonemeUnits() async throws {
+        guard Self.networkEnabled else { return }
+        let phonemizer = try NeuralPhonemizer(
+            modelDirectory: try await Self.modelDirectory()
+        )
+        let phonemes = try phonemizer.phonemize("test")
+        #expect(!phonemes.isEmpty)
+        #expect(phonemes.allSatisfy { !$0.symbol.isEmpty })
+    }
+
+    @Test func deterministicOutput() async throws {
+        guard Self.networkEnabled else { return }
+        let g2p = try G2P(modelDirectory: try await Self.modelDirectory())
+        let first = g2p.convert("phone", language: "eng-us")
+        let second = g2p.convert("phone", language: "eng-us")
+        #expect(first == second)
+    }
+
+    @Test func spanishG2PVocabCoverage() async throws {
+        guard Self.networkEnabled else { return }
+        let g2p = try G2P(modelDirectory: try await Self.modelDirectory(), maxLength: 256)
+
+        // Test individual Spanish words and a short sentence
+        let words = ["hola", "mundo", "prueba", "español", "gracias"]
+        let sentence = "Hola, esto es una prueba."
+
+        var allIPA = ""
+        for word in words {
+            let ipa = g2p.convert(word, language: "es")
+            fputs("[ES] \(word) → \(ipa)\n", stderr)
+            allIPA += ipa
+        }
+        let sentenceIPA = g2p.convert(sentence, language: "es")
+        fputs("[ES] sentence → \(sentenceIPA)\n", stderr)
+        allIPA += sentenceIPA
+
+        let kokoroVocabStr: [String] = [
+            " ", "!", "\"", "(", ")", ",", ".", ":", ";", "?",
+            "A", "I", "O", "Q", "S", "T", "W", "Y",
+            "a", "b", "c", "d", "e", "f", "h", "i", "j", "k", "l", "m",
+            "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+            "æ", "ç", "ð", "ø", "ŋ", "œ", "ɐ", "ɑ", "ɒ", "ɔ", "ɕ", "ɖ",
+            "ə", "ɚ", "ɛ", "ɜ", "ɟ", "ɡ", "ɣ", "ɤ", "ɥ", "ɨ", "ɪ", "ɯ",
+            "ɰ", "ɲ", "ɳ", "ɴ", "ɸ", "ɹ", "ɻ", "ɽ", "ɾ", "ʁ", "ʂ", "ʃ",
+            "ʈ", "ʊ", "ʋ", "ʌ", "ʎ", "ʒ", "ʔ", "ʝ", "ʣ", "ʤ", "ʥ", "ʦ",
+            "ʧ", "ʨ", "ʰ", "ʲ", "ˈ", "ˌ", "ː", "\u{0303}", "β", "θ", "χ",
+            "ᵊ", "ᵝ", "ᵻ", "\u{2014}", "\u{201C}", "\u{201D}", "\u{2026}",
+            "\u{2192}", "\u{2193}", "\u{2197}", "\u{2198}", "ꭧ",
+        ]
+        let kokoroVocab = Set(kokoroVocabStr.compactMap(\.first))
+
+        var mapped = 0, unmapped = 0
+        var unmappedChars: Set<Character> = []
+        for ch in allIPA {
+            if kokoroVocab.contains(ch) {
+                mapped += 1
+            } else {
+                unmapped += 1
+                unmappedChars.insert(ch)
+            }
+        }
+
+        let total = mapped + unmapped
+        let coverage = total > 0 ? Double(mapped) / Double(total) : 0
+        fputs("[ES] Coverage: \(Int(coverage * 100))% (\(mapped)/\(total))\n", stderr)
+        fputs("[ES] Unmapped chars: \(unmappedChars.sorted(by: { String($0) < String($1) }))\n", stderr)
+
+        #expect(!allIPA.isEmpty, "Spanish G2P should produce output")
+        #expect(coverage > 0.7, "Kokoro vocab should cover most Spanish IPA (got \(Int(coverage * 100))%)")
+    }
+}


### PR DESCRIPTION
## Summary

Unified grapheme-to-phoneme module combining neural and dictionary approaches:
- **Neural layer**: ByT5 encoder-decoder supporting 100+ languages via `beshkenadze/g2p-multilingual-byT5-tiny-mlx` (20.8M params)
- **Dictionary layer**: CMUDict parser, ARPAbet→IPA mapper, InMemoryLexicon for fast lookup (dictionary downloaded on-demand from `beshkenadze/cmudict-ipa`)

## Changes

- **20 source files** in `Sources/MLXAudioG2P/`:
  - T5 encoder-decoder, byte-level tokenizer, weight sanitizer
  - `G2PTypes.swift`: `Phonemizing` protocol, `PhonemeUnit`, `G2PError`
  - `NeuralPhonemizer`: word-level G2P conforming to `Phonemizing`
  - `Lexicon/`: CMUDictLoader, CMUDictParser, ARPAbetMapper, InMemoryLexicon, LexiconProviding, LexiconEntry
- **CI**: skip SmokeTests, disable parallel testing for Metal VM stability
- **Tests**: ByT5 tokenizer + model tests (network-guarded), CMUDict parser + ARPAbet mapper tests

## Context

PR 1 of 4 adding KittenTTS and Kokoro TTS:
1. **This PR** — MLXAudioG2P
2. StyleTTS2 shared blocks + English G2P stack
3. KittenTTS model
4. Kokoro TTS with multilingual support (9 languages, 40+ voices)

## Test Plan

```bash
swift build --target MLXAudioG2P
swift build --build-tests
MLXAUDIO_ENABLE_NETWORK_TESTS=1 swift test --filter G2P
```