### PR TITLE
docs: add contributing guide

### DIFF
--- a/ADDING_A_MODEL.md
+++ b/ADDING_A_MODEL.md
@@ -1,0 +1,245 @@
+# Adding a New Model
+
+## Module layout
+
+Place the model under the appropriate Swift module:
+
+```
+Sources/
+├── MLXAudioTTS/Models/<ModelName>/   # Text-to-speech
+├── MLXAudioSTT/Models/<ModelName>/   # Speech-to-text
+├── MLXAudioSTS/Models/<ModelName>/   # Speech-to-speech / enhancement
+└── MLXAudioCodecs/Models/<ModelName>/ # Standalone audio codecs
+```
+
+Typical file structure for a model:
+
+```
+Sources/MLXAudioTTS/Models/MyModel/
+├── MyModel.swift          # Main class — protocol conformance + generate()
+├── MyModelConfig.swift    # Configuration struct (Codable + Sendable)
+├── MyModelDecoder.swift   # Decoder component (if needed)
+└── MyModelUtils.swift     # Utilities (if needed)
+```
+
+**Naming conventions:**
+- Main class: `MyModelModel` (e.g., `SopranoModel`, `Qwen3ASRModel`)
+- Config struct: `MyModelConfiguration` or `MyModelConfig`
+- Supporting types follow the same `MyModel` prefix
+
+## Protocols
+
+Implement the protocol that matches your model's task:
+
+**TTS — `SpeechGenerationModel`:**
+```swift
+public protocol SpeechGenerationModel {
+    var sampleRate: Int { get }
+    var defaultGenerationParameters: GenerationParameters { get }
+
+    func generate(text: String, parameters: GenerationParameters) async throws -> MLXArray
+    func generateStream(text: String, parameters: GenerationParameters)
+        -> AsyncThrowingStream<GenerationToken, Error>
+}
+```
+
+**STT — `STTGenerationModel`:**
+```swift
+public protocol STTGenerationModel {
+    func generate(audio: MLXArray, language: String?) async throws -> STTOutput
+    func generateStream(audio: MLXArray, language: String?)
+        -> AsyncThrowingStream<STTGeneration, Error>
+}
+```
+
+**Codec — `AudioCodecModel`:**
+```swift
+public protocol AudioCodecModel: AudioDecoderModel {
+    func encodeAudio(audio: MLXArray) async throws -> EncodedAudio
+}
+
+public protocol AudioDecoderModel {
+    var codecSampleRate: Int? { get }
+    func decodeAudio(input: DecoderInput) async throws -> MLXArray
+}
+```
+
+## Configuration struct
+
+```swift
+public struct MyModelConfig: Codable, Sendable {
+    public let hiddenSize: Int
+    public let numLayers: Int
+    public let sampleRate: Int
+
+    // Map Swift camelCase ↔ JSON snake_case
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize  = "hidden_size"
+        case numLayers   = "num_layers"
+        case sampleRate  = "sample_rate"
+    }
+}
+```
+
+All config structs must be `Codable` (for JSON loading) and `Sendable` (for
+concurrency safety). Use `CodingKeys` to map JSON snake_case to Swift camelCase.
+
+## Model class
+
+```swift
+import MLX
+import MLXAudioCore
+
+public class MyModelModel: SpeechGenerationModel {
+    public let sampleRate: Int
+    public var defaultGenerationParameters = GenerationParameters()
+
+    private let config: MyModelConfig
+    // ... layers
+
+    public init(config: MyModelConfig) {
+        self.config = config
+        self.sampleRate = config.sampleRate
+        // initialize layers …
+    }
+
+    public func generate(
+        text: String,
+        parameters: GenerationParameters = .init()
+    ) async throws -> MLXArray {
+        // inference …
+        return audio  // MLXArray of shape [samples]
+    }
+
+    public func generateStream(
+        text: String,
+        parameters: GenerationParameters = .init()
+    ) -> AsyncThrowingStream<GenerationToken, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                // yield tokens progressively …
+                continuation.finish()
+            }
+        }
+    }
+
+    /// Load weights from a HuggingFace repository.
+    public static func fromPretrained(
+        _ repository: String,
+        token: String? = nil
+    ) async throws -> MyModelModel {
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repository, token: token
+        )
+        let config = try JSONDecoder().decode(
+            MyModelConfig.self,
+            from: Data(contentsOf: modelDir.appendingPathComponent("config.json"))
+        )
+        let model = MyModelModel(config: config)
+        let weights = try ModelUtils.loadWeights(from: modelDir)
+        let sanitized = model.sanitize(weights)
+        try model.update(parameters: sanitized)
+        return model
+    }
+
+    /// Rename / reshape PyTorch keys to match Swift attribute paths.
+    func sanitize(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result: [String: MLXArray] = [:]
+        for (key, value) in weights {
+            var k = key
+            if k.hasPrefix("model.") { k = String(k.dropFirst(6)) }
+            // Conv2d: PyTorch (out,in,kH,kW) → MLX (out,kH,kW,in)
+            // if isConvWeight { result[k] = value.transposed(0,2,3,1); continue }
+            result[k] = value
+        }
+        return result
+    }
+}
+```
+
+## Factory registration
+
+**This step is mandatory** — unlike the Python library, Swift does not
+auto-discover models. Add your model type to the factory switch in
+`Sources/MLXAudioTTS/TTSModel.swift` (or the STT/codec equivalent):
+
+```swift
+// In TTS.loadModel(from:withToken:modelType:)
+switch resolvedType {
+case .myModel:
+    return try await MyModelModel.fromPretrained(repository, token: token)
+// … existing cases
+}
+```
+
+Also add the case to the `TTSModelType` enum and the type-resolution logic that
+maps a HuggingFace `model_type` string to your enum case.
+
+## Publishing weights to mlx-community
+
+Model weights must be published to
+[mlx-community](https://huggingface.co/mlx-community) on HuggingFace, not
+bundled in this repository.
+
+### Naming convention
+
+```
+mlx-community/<ModelName>[-<Variant>]-<ParameterCount>-<Dtype>
+```
+
+| part | description | examples |
+|---|---|---|
+| `ModelName` | base model name, preserve original casing | `Soprano`, `Qwen3-TTS`, `Kokoro` |
+| `Variant` | optional variant tag | `Base`, `VoiceDesign`, `Realtime` |
+| `ParameterCount` | size indicator | `80M`, `0.6B`, `1.7B` |
+| `Dtype` | precision / quantization level | `bf16`, `fp16`, `8bit`, `4bit` |
+
+Real examples from mlx-community:
+
+```
+mlx-community/Soprano-80M-bf16
+mlx-community/Kokoro-82M-bf16
+mlx-community/Kokoro-82M-4bit
+mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16
+mlx-community/whisper-large-v3-turbo-asr-fp16
+mlx-community/parakeet-tdt-0.6b-v3
+```
+
+**Notes:**
+- Prefer `bf16` as the primary upload; add quantized variants for large models.
+- Include the parameter count when the model family has multiple sizes.
+- Link the mlx-community repo in your PR description.
+
+## Tests
+
+Add tests to the relevant test file (`Tests/MLXAudioTTSTests.swift`, etc.):
+
+```swift
+func testMyModelGeneration() async throws {
+    let model = try await MyModelModel.fromPretrained(
+        "mlx-community/MyModel-1B-bf16"
+    )
+    let audio = try await model.generate(text: "Hello world")
+    XCTAssertGreaterThan(audio.shape[0], 0)
+}
+
+func testMyModelStream() async throws {
+    let model = try await MyModelModel.fromPretrained(
+        "mlx-community/MyModel-1B-bf16"
+    )
+    var count = 0
+    for try await _ in model.generateStream(text: "Hello") { count += 1 }
+    XCTAssertGreaterThan(count, 0)
+}
+```
+
+## PR checklist
+
+- [ ] Model class conforms to the correct protocol (`SpeechGenerationModel`, `STTGenerationModel`, or `AudioCodecModel`)
+- [ ] Config struct is `Codable` + `Sendable` with `CodingKeys` for snake_case mapping
+- [ ] `fromPretrained()` loads `config.json` and all `.safetensors` from HF
+- [ ] `sanitize()` covers all key renames and Conv weight transposes
+- [ ] Model type added to factory switch statement
+- [ ] Weights published to `mlx-community` following naming convention
+- [ ] Tests cover `generate()` and `generateStream()`
+- [ ] Model listed in `README.md` model table

--- a/ADDING_A_MODEL.md
+++ b/ADDING_A_MODEL.md
@@ -1,245 +1,64 @@
 # Adding a New Model
 
-## Module layout
+Use the codebase as the source of truth. The fastest path is to find the
+closest existing model and follow its structure rather than treating this file
+as a full implementation spec.
 
-Place the model under the appropriate Swift module:
+## 1. Start from a similar model
 
-```
-Sources/
-├── MLXAudioTTS/Models/<ModelName>/   # Text-to-speech
-├── MLXAudioSTT/Models/<ModelName>/   # Speech-to-text
-├── MLXAudioSTS/Models/<ModelName>/   # Speech-to-speech / enhancement
-└── MLXAudioCodecs/Models/<ModelName>/ # Standalone audio codecs
-```
+- TTS: `Sources/MLXAudioTTS/Models/`
+- STT: `Sources/MLXAudioSTT/Models/`
+- STS: `Sources/MLXAudioSTS/Models/`
+- Codecs: `Sources/MLXAudioCodecs/Models/`
 
-Typical file structure for a model:
+Pick the nearest match in task and architecture, then mirror its layout,
+naming, and loading flow.
 
-```
-Sources/MLXAudioTTS/Models/MyModel/
-├── MyModel.swift          # Main class — protocol conformance + generate()
-├── MyModelConfig.swift    # Configuration struct (Codable + Sendable)
-├── MyModelDecoder.swift   # Decoder component (if needed)
-└── MyModelUtils.swift     # Utilities (if needed)
-```
+## 2. Match the right protocol
 
-**Naming conventions:**
-- Main class: `MyModelModel` (e.g., `SopranoModel`, `Qwen3ASRModel`)
-- Config struct: `MyModelConfiguration` or `MyModelConfig`
-- Supporting types follow the same `MyModel` prefix
+Implement the protocol for the model's task:
 
-## Protocols
+- TTS: `SpeechGenerationModel`
+- STT: `STTGenerationModel`
+- Codec: `AudioCodecModel`
 
-Implement the protocol that matches your model's task:
+Keep the public API aligned with similar models already in the repository.
 
-**TTS — `SpeechGenerationModel`:**
-```swift
-public protocol SpeechGenerationModel {
-    var sampleRate: Int { get }
-    var defaultGenerationParameters: GenerationParameters { get }
+## 3. Keep configuration and loading Swift-native
 
-    func generate(text: String, parameters: GenerationParameters) async throws -> MLXArray
-    func generateStream(text: String, parameters: GenerationParameters)
-        -> AsyncThrowingStream<GenerationToken, Error>
-}
-```
+- Decode `config.json` into a `Codable` + `Sendable` config type.
+- Map JSON fields with `CodingKeys` when needed.
+- Load weights from HuggingFace in `fromPretrained()`.
+- Add any key renames or tensor reshaping needed to match the Swift model.
 
-**STT — `STTGenerationModel`:**
-```swift
-public protocol STTGenerationModel {
-    func generate(audio: MLXArray, language: String?) async throws -> STTOutput
-    func generateStream(audio: MLXArray, language: String?)
-        -> AsyncThrowingStream<STTGeneration, Error>
-}
-```
+## 4. Register the model
 
-**Codec — `AudioCodecModel`:**
-```swift
-public protocol AudioCodecModel: AudioDecoderModel {
-    func encodeAudio(audio: MLXArray) async throws -> EncodedAudio
-}
+Factory registration is required.
 
-public protocol AudioDecoderModel {
-    var codecSampleRate: Int? { get }
-    func decodeAudio(input: DecoderInput) async throws -> MLXArray
-}
-```
+- Add the model type to the appropriate enum.
+- Update the corresponding factory switch in TTS/STT/STS/codec loading.
+- Make sure HuggingFace `model_type` resolution reaches the new case when
+  applicable.
 
-## Configuration struct
+## 5. Publish weights outside this repository
 
-```swift
-public struct MyModelConfig: Codable, Sendable {
-    public let hiddenSize: Int
-    public let numLayers: Int
-    public let sampleRate: Int
+Do not commit model weights here. Publish them on HuggingFace, preferably under
+[`mlx-community`](https://huggingface.co/mlx-community) when that fits the
+model.
 
-    // Map Swift camelCase ↔ JSON snake_case
-    enum CodingKeys: String, CodingKey {
-        case hiddenSize  = "hidden_size"
-        case numLayers   = "num_layers"
-        case sampleRate  = "sample_rate"
-    }
-}
-```
+Include the model repo in the PR description.
 
-All config structs must be `Codable` (for JSON loading) and `Sendable` (for
-concurrency safety). Use `CodingKeys` to map JSON snake_case to Swift camelCase.
+## 6. Add validation
 
-## Model class
-
-```swift
-import MLX
-import MLXAudioCore
-
-public class MyModelModel: SpeechGenerationModel {
-    public let sampleRate: Int
-    public var defaultGenerationParameters = GenerationParameters()
-
-    private let config: MyModelConfig
-    // ... layers
-
-    public init(config: MyModelConfig) {
-        self.config = config
-        self.sampleRate = config.sampleRate
-        // initialize layers …
-    }
-
-    public func generate(
-        text: String,
-        parameters: GenerationParameters = .init()
-    ) async throws -> MLXArray {
-        // inference …
-        return audio  // MLXArray of shape [samples]
-    }
-
-    public func generateStream(
-        text: String,
-        parameters: GenerationParameters = .init()
-    ) -> AsyncThrowingStream<GenerationToken, Error> {
-        AsyncThrowingStream { continuation in
-            Task {
-                // yield tokens progressively …
-                continuation.finish()
-            }
-        }
-    }
-
-    /// Load weights from a HuggingFace repository.
-    public static func fromPretrained(
-        _ repository: String,
-        token: String? = nil
-    ) async throws -> MyModelModel {
-        let modelDir = try await ModelUtils.resolveOrDownloadModel(
-            repository, token: token
-        )
-        let config = try JSONDecoder().decode(
-            MyModelConfig.self,
-            from: Data(contentsOf: modelDir.appendingPathComponent("config.json"))
-        )
-        let model = MyModelModel(config: config)
-        let weights = try ModelUtils.loadWeights(from: modelDir)
-        let sanitized = model.sanitize(weights)
-        try model.update(parameters: sanitized)
-        return model
-    }
-
-    /// Rename / reshape PyTorch keys to match Swift attribute paths.
-    func sanitize(_ weights: [String: MLXArray]) -> [String: MLXArray] {
-        var result: [String: MLXArray] = [:]
-        for (key, value) in weights {
-            var k = key
-            if k.hasPrefix("model.") { k = String(k.dropFirst(6)) }
-            // Conv2d: PyTorch (out,in,kH,kW) → MLX (out,kH,kW,in)
-            // if isConvWeight { result[k] = value.transposed(0,2,3,1); continue }
-            result[k] = value
-        }
-        return result
-    }
-}
-```
-
-## Factory registration
-
-**This step is mandatory** — unlike the Python library, Swift does not
-auto-discover models. Add your model type to the factory switch in
-`Sources/MLXAudioTTS/TTSModel.swift` (or the STT/codec equivalent):
-
-```swift
-// In TTS.loadModel(from:withToken:modelType:)
-switch resolvedType {
-case .myModel:
-    return try await MyModelModel.fromPretrained(repository, token: token)
-// … existing cases
-}
-```
-
-Also add the case to the `TTSModelType` enum and the type-resolution logic that
-maps a HuggingFace `model_type` string to your enum case.
-
-## Publishing weights to mlx-community
-
-Model weights must be published to
-[mlx-community](https://huggingface.co/mlx-community) on HuggingFace, not
-bundled in this repository.
-
-### Naming convention
-
-```
-mlx-community/<ModelName>[-<Variant>]-<ParameterCount>-<Dtype>
-```
-
-| part | description | examples |
-|---|---|---|
-| `ModelName` | base model name, preserve original casing | `Soprano`, `Qwen3-TTS`, `Kokoro` |
-| `Variant` | optional variant tag | `Base`, `VoiceDesign`, `Realtime` |
-| `ParameterCount` | size indicator | `80M`, `0.6B`, `1.7B` |
-| `Dtype` | precision / quantization level | `bf16`, `fp16`, `8bit`, `4bit` |
-
-Real examples from mlx-community:
-
-```
-mlx-community/Soprano-80M-bf16
-mlx-community/Kokoro-82M-bf16
-mlx-community/Kokoro-82M-4bit
-mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16
-mlx-community/whisper-large-v3-turbo-asr-fp16
-mlx-community/parakeet-tdt-0.6b-v3
-```
-
-**Notes:**
-- Prefer `bf16` as the primary upload; add quantized variants for large models.
-- Include the parameter count when the model family has multiple sizes.
-- Link the mlx-community repo in your PR description.
-
-## Tests
-
-Add tests to the relevant test file (`Tests/MLXAudioTTSTests.swift`, etc.):
-
-```swift
-func testMyModelGeneration() async throws {
-    let model = try await MyModelModel.fromPretrained(
-        "mlx-community/MyModel-1B-bf16"
-    )
-    let audio = try await model.generate(text: "Hello world")
-    XCTAssertGreaterThan(audio.shape[0], 0)
-}
-
-func testMyModelStream() async throws {
-    let model = try await MyModelModel.fromPretrained(
-        "mlx-community/MyModel-1B-bf16"
-    )
-    var count = 0
-    for try await _ in model.generateStream(text: "Hello") { count += 1 }
-    XCTAssertGreaterThan(count, 0)
-}
-```
+- Add tests for the main generation path.
+- Add streaming tests when the model supports streaming.
+- Add the model to `README.md` if it is user-facing.
 
 ## PR checklist
 
-- [ ] Model class conforms to the correct protocol (`SpeechGenerationModel`, `STTGenerationModel`, or `AudioCodecModel`)
-- [ ] Config struct is `Codable` + `Sendable` with `CodingKeys` for snake_case mapping
-- [ ] `fromPretrained()` loads `config.json` and all `.safetensors` from HF
-- [ ] `sanitize()` covers all key renames and Conv weight transposes
-- [ ] Model type added to factory switch statement
-- [ ] Weights published to `mlx-community` following naming convention
-- [ ] Tests cover `generate()` and `generateStream()`
-- [ ] Model listed in `README.md` model table
+- [ ] Model lives in the correct module directory
+- [ ] Model conforms to the correct protocol
+- [ ] Config loading and weight loading work from HuggingFace
+- [ ] Factory registration is complete
+- [ ] Tests cover the main inference path
+- [ ] `README.md` is updated when needed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,56 +1,25 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+Be respectful, constructive, and professional.
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+## Expected behavior
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+- Assume good intent and discuss disagreements in good faith.
+- Give feedback about code and ideas, not about people.
+- Be welcoming to contributors with different backgrounds and experience levels.
 
-## Our Standards
+## Unacceptable behavior
 
-Examples of behavior that contributes to a positive environment:
-
-- Demonstrating empathy and kindness toward other people
-- Being respectful of differing opinions, viewpoints, and experiences
-- Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes
-- Focusing on what is best not just for us as individuals, but for the overall community
-
-Examples of unacceptable behavior:
-
-- The use of sexualized language or imagery, and sexual attention or advances of any kind
-- Trolling, insulting or derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
-
-## Scope
-
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
+- Harassment, threats, or intimidation
+- Hate speech or discriminatory behavior
+- Sexualized language or unwanted sexual attention
+- Personal attacks, trolling, or deliberate disruption
+- Publishing someone else's private information without permission
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement via
+Maintainers may edit, remove, or reject content that does not meet these
+standards, and may restrict participation when necessary.
+
+If you need to report a serious issue privately, use
 [GitHub Security Advisories](https://github.com/Blaizzy/mlx-audio-swift/security/advisories/new).
-All complaints will be reviewed and investigated promptly and fairly.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
-version 2.1, available at
-https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via
+[GitHub Security Advisories](https://github.com/Blaizzy/mlx-audio-swift/security/advisories/new).
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to MLX Audio Swift
+
+Thanks for contributing to MLX Audio Swift.
+
+## Pull Requests
+
+- Open pull requests against `Blaizzy/mlx-audio-swift:main`.
+- If you are contributing from a fork, make sure the base repository is
+  `Blaizzy/mlx-audio-swift` and the base branch is `main`.
+- Keep pull requests focused. Include tests and documentation updates when
+  behavior changes.
+- Keep PRs atomic and touch the smallest possible amount of code. This helps
+  reviewers evaluate and merge changes faster and with higher confidence.
+- Run local build and test checks before opening a PR when applicable.
+- The current CI workflow on `main` uses `xcodebuild` on macOS:
+
+```bash
+xcodebuild build-for-testing \
+  -scheme MLXAudio-Package \
+  -destination 'platform=macOS' \
+  MACOSX_DEPLOYMENT_TARGET=14.0 \
+  CODE_SIGNING_ALLOWED=NO
+
+xcodebuild test-without-building \
+  -scheme MLXAudio-Package \
+  -destination 'platform=macOS' \
+  -skip-testing:'MLXAudioTests/SmokeTests' \
+  -parallel-testing-enabled NO \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+## Commit Signing and Account Security
+
+To improve commit provenance and reduce supply chain risk, please sign commits
+submitted to this repository. This is a one-time setup on your machine.
+
+- Any GitHub-supported signing method is fine: GPG, SSH, or S/MIME.
+- Enable GitHub vigilant mode so commits and tags always show a verification
+  status.
+- Enable two-factor authentication on your GitHub account. Passkeys are
+  preferred when available.
+
+## References
+
+- [About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+- [Displaying verification statuses for all of your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits)
+- [Enable vigilant mode](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits#enabling-vigilant-mode)
+- [GPG setup walkthrough](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,11 @@
 
 Thanks for contributing to MLX Audio Swift.
 
-## Scope
+We welcome model ports, bug fixes, performance work, and documentation
+improvements.
 
-We welcome:
-- New model ports (TTS, STT, STS, codecs)
-- Bug fixes and performance improvements
-- Documentation and example improvements
-
-For large API changes or new features, **open an issue first** to discuss the
-approach before starting implementation. This avoids wasted effort on PRs that
-won't be accepted.
+For large API changes or new features, open an issue first so the approach can
+be discussed before implementation starts.
 
 ## Reporting Bugs
 
@@ -32,18 +27,15 @@ to report privately.
 ## Development Setup
 
 ```bash
-# Clone your fork
 git clone git@github.com:<you>/mlx-audio-swift.git
 cd mlx-audio-swift
-
-# Open in Xcode or build from CLI
 open Package.swift
 ```
 
 ## Pull Requests
 
 - Open pull requests against `Blaizzy/mlx-audio-swift:main`.
-- If you are contributing from a fork, make sure the base repository is
+- If you are contributing from a fork, make sure the base repo is
   `Blaizzy/mlx-audio-swift` and the base branch is `main`.
 - Keep pull requests focused. Include tests and documentation updates when
   behavior changes.
@@ -51,7 +43,13 @@ open Package.swift
   reviewers evaluate and merge changes faster and with higher confidence.
 - Run local build and test checks before opening a PR.
 
-The current CI workflow on `main` uses `xcodebuild` on macOS:
+If you want to mirror CI more closely, install the Metal toolchain first:
+
+```bash
+xcodebuild -downloadComponent MetalToolchain
+```
+
+Then run the usual local checks:
 
 ```bash
 xcodebuild build-for-testing \
@@ -70,9 +68,7 @@ xcodebuild test-without-building \
 
 ## Adding a New Model
 
-See [ADDING_A_MODEL.md](ADDING_A_MODEL.md) for the full guide — module layout,
-required protocols, configuration structs, factory registration, weight loading,
-mlx-community naming convention, tests, and PR checklist.
+See [ADDING_A_MODEL.md](ADDING_A_MODEL.md) for the short checklist.
 
 ## Keeping the repository clean
 
@@ -84,21 +80,6 @@ diff does not include:
 - Local model weights or large binaries
 - Changes to `.gitignore` that only cover your personal setup
 
-**Use a global gitignore for personal patterns** so you never have to touch the
-project's `.gitignore`:
-
-```bash
-# Create (or append to) your global gitignore
-echo "*.local.*" >> ~/.gitignore_global
-echo ".env.local" >> ~/.gitignore_global
-
-# Register it with git (one-time setup)
-git config --global core.excludesFile ~/.gitignore_global
-```
-
-The `*.local.*` pattern (e.g., `notes.local.md`, `config.local.json`) is a
-useful convention for files that should always stay local.
-
 ## Good First Issues
 
 Issues labeled [`good first issue`](https://github.com/Blaizzy/mlx-audio-swift/contribute)
@@ -106,23 +87,18 @@ are a good starting point if you are new to the codebase.
 
 ## Code of Conduct
 
-This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
-By participating, you agree to uphold it.
+This project follows the [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating, you agree to uphold it.
 
 ## Commit Signing and Account Security
 
-To improve commit provenance and reduce supply chain risk, please sign commits
-submitted to this repository. This is a one-time setup on your machine.
+Please sign commits submitted to this repository.
 
 - Any GitHub-supported signing method is fine: GPG, SSH, or S/MIME.
-- Enable GitHub vigilant mode so commits and tags always show a verification
-  status.
-- Enable two-factor authentication on your GitHub account. Passkeys are
-  preferred when available.
+- Enable GitHub vigilant mode.
+- Enable two-factor authentication on your GitHub account.
 
 ## References
 
 - [About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
-- [Displaying verification statuses for all of your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits)
 - [Enable vigilant mode](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits#enabling-vigilant-mode)
-- [GPG setup walkthrough](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,44 @@
 
 Thanks for contributing to MLX Audio Swift.
 
+## Scope
+
+We welcome:
+- New model ports (TTS, STT, STS, codecs)
+- Bug fixes and performance improvements
+- Documentation and example improvements
+
+For large API changes or new features, **open an issue first** to discuss the
+approach before starting implementation. This avoids wasted effort on PRs that
+won't be accepted.
+
+## Reporting Bugs
+
+Search [existing issues](https://github.com/Blaizzy/mlx-audio-swift/issues) before
+opening a new one. When reporting a bug, include:
+
+- macOS version and Apple Silicon chip (e.g., macOS 15.3, M3 Pro)
+- Xcode version (`xcodebuild -version`)
+- Full error output or crash log
+- Minimal reproducible snippet
+
+## Security Vulnerabilities
+
+Do **not** open a public issue for security vulnerabilities. Use
+[GitHub Security Advisories](https://github.com/Blaizzy/mlx-audio-swift/security/advisories/new)
+to report privately.
+
+## Development Setup
+
+```bash
+# Clone your fork
+git clone git@github.com:<you>/mlx-audio-swift.git
+cd mlx-audio-swift
+
+# Open in Xcode or build from CLI
+open Package.swift
+```
+
 ## Pull Requests
 
 - Open pull requests against `Blaizzy/mlx-audio-swift:main`.
@@ -11,8 +49,9 @@ Thanks for contributing to MLX Audio Swift.
   behavior changes.
 - Keep PRs atomic and touch the smallest possible amount of code. This helps
   reviewers evaluate and merge changes faster and with higher confidence.
-- Run local build and test checks before opening a PR when applicable.
-- The current CI workflow on `main` uses `xcodebuild` on macOS:
+- Run local build and test checks before opening a PR.
+
+The current CI workflow on `main` uses `xcodebuild` on macOS:
 
 ```bash
 xcodebuild build-for-testing \
@@ -28,6 +67,47 @@ xcodebuild test-without-building \
   -parallel-testing-enabled NO \
   CODE_SIGNING_ALLOWED=NO
 ```
+
+## Adding a New Model
+
+See [ADDING_A_MODEL.md](ADDING_A_MODEL.md) for the full guide — module layout,
+required protocols, configuration structs, factory registration, weight loading,
+mlx-community naming convention, tests, and PR checklist.
+
+## Keeping the repository clean
+
+Do not commit personal or temporary files. Before opening a PR, make sure your
+diff does not include:
+
+- Planning docs, notes, or spec files
+- Test scripts, scratch playgrounds, or one-off debug files
+- Local model weights or large binaries
+- Changes to `.gitignore` that only cover your personal setup
+
+**Use a global gitignore for personal patterns** so you never have to touch the
+project's `.gitignore`:
+
+```bash
+# Create (or append to) your global gitignore
+echo "*.local.*" >> ~/.gitignore_global
+echo ".env.local" >> ~/.gitignore_global
+
+# Register it with git (one-time setup)
+git config --global core.excludesFile ~/.gitignore_global
+```
+
+The `*.local.*` pattern (e.g., `notes.local.md`, `config.local.json`) is a
+useful convention for files that should always stay local.
+
+## Good First Issues
+
+Issues labeled [`good first issue`](https://github.com/Blaizzy/mlx-audio-swift/contribute)
+are a good starting point if you are new to the codebase.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you agree to uphold it.
 
 ## Commit Signing and Account Security
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ Check out the [Examples/VoicesApp](Examples/VoicesApp) directory for a complete 
 
 Additional usage examples can be found in the test files.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow, local checks, and
+commit-signing expectations for contributions to `main`.
+
 ## Credits
 
 - Built on [MLX Swift](https://github.com/ml-explore/mlx-swift)

--- a/README.md
+++ b/README.md
@@ -221,8 +221,7 @@ Additional usage examples can be found in the test files.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow, local checks, and
-commit-signing expectations for contributions to `main`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 ## Credits
 


### PR DESCRIPTION
## Summary

- add a dedicated `CONTRIBUTING.md` for contributions targeting `Blaizzy/mlx-audio-swift:main`
- document that PRs should stay atomic and touch the smallest possible amount of code
- add guidance for signed commits, GitHub vigilant mode, and account security
- link the contribution guide from `README.md`

## Validation

- not run (`docs`-only change)
