### PR TITLE
feat: speaker embedding support for Qwen3-TTS CustomVoice models

### DIFF
--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -225,7 +225,16 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
             ttsPadEmbed = prepared.2
             refCodes = prepared.3
         } else {
-            let prepared = prepareGenerationInputs(text: text, language: language, instruct: instruct)
+            // For CustomVoice models: voice is a speaker name, not free-text instruct.
+            let isCVModel = config.ttsModelType == "custom_voice"
+            let speaker: String? = isCVModel ? instruct : nil
+            let effectiveInstruct: String? = isCVModel ? nil : instruct
+            let prepared = prepareGenerationInputs(
+                text: text,
+                language: language,
+                instruct: effectiveInstruct,
+                speaker: speaker
+            )
             inputEmbedsInit = prepared.0
             trailingTextHidden = prepared.1
             ttsPadEmbed = prepared.2
@@ -599,7 +608,8 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
     func prepareGenerationInputs(
         text: String,
         language: String,
-        instruct: String?
+        instruct: String?,
+        speaker: String? = nil
     ) -> (MLXArray, MLXArray, MLXArray) {
         guard let tokenizer, let talkerConfig = config.talkerConfig else {
             fatalError("Tokenizer/config not loaded")
@@ -621,10 +631,32 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let ttsEosEmbed = ttsEmbeds[0..., 1 ..< 2, 0...]
         let ttsPadEmbed = ttsEmbeds[0..., 2 ..< 3, 0...]
 
-        // Language ID
+        // Language ID — may be overridden by speaker dialect below
         var languageId: Int?
         if language.lowercased() != "auto", let langMap = talkerConfig.codecLanguageId {
             languageId = langMap[language.lowercased()]
+        }
+
+        // Speaker embedding (CustomVoice models only)
+        var speakerEmbed: MLXArray? = nil
+        if let speaker = speaker {
+            if let spkIdMap = talkerConfig.spkId,
+               let spkIdValue = spkIdMap[speaker.lowercased()] {
+                let spkIdArray = MLXArray([Int32(spkIdValue.intValue)]).reshaped(1, 1)
+                speakerEmbed = talker.getInputEmbeddings()(spkIdArray)
+                print("[Qwen3TTS] CustomVoice: speaker '\(speaker)' → spkId=\(spkIdValue.intValue)")
+            } else {
+                print("[Qwen3TTS] CustomVoice: WARNING - speaker '\(speaker)' not found in spkId map")
+            }
+            if let dialectMap = talkerConfig.spkIsDialect,
+               let dialectVal = dialectMap[speaker.lowercased()],
+               dialectVal.isDialect,
+               let dialectName = dialectVal.dialectName,
+               let langMap = talkerConfig.codecLanguageId,
+               let dialectLangId = langMap[dialectName] {
+                print("[Qwen3TTS] CustomVoice: dialect override '\(dialectName)' langId=\(dialectLangId)")
+                languageId = dialectLangId
+            }
         }
 
         // Build codec prefix
@@ -647,9 +679,14 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let codecEmbedSuffix = talker.getInputEmbeddings()(
             MLXArray([Int32(talkerConfig.codecPadId), Int32(talkerConfig.codecBosId)]).reshaped(1, 2)
         )
-        codecEmbed = concatenated([codecEmbed, codecEmbedSuffix], axis: 1)
+        if let spkEmbed = speakerEmbed {
+            codecEmbed = concatenated([codecEmbed, spkEmbed.reshaped([1, 1, -1]), codecEmbedSuffix], axis: 1)
+            print("[Qwen3TTS] CustomVoice: codec prefix length = \(codecEmbed.dim(1))")
+        } else {
+            codecEmbed = concatenated([codecEmbed, codecEmbedSuffix], axis: 1)
+        }
 
-        // Instruct embedding
+        // Instruct embedding (VoiceDesign only — not CustomVoice)
         var instructEmbed: MLXArray?
         if let instruct, !instruct.isEmpty {
             let instructText = "<|im_start|>user\n\(instruct)<|im_end|>\n"

--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTSConfig.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTSConfig.swift
@@ -115,6 +115,86 @@ public struct Qwen3TTSSpeakerEncoderConfig: Codable, Sendable {
     }
 }
 
+// MARK: - Flexible spk_id value (Int or [Int])
+//
+// The Base model has spk_id: {} (empty), so the bug was never hit.
+// The CustomVoice model has spk_id: {"ryan": 3061, ...} — a single Int per
+// speaker, NOT an array. This enum handles both forms transparently.
+
+public enum SpkIdValue: Codable, Sendable {
+    case single(Int)
+    case array([Int])
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let v = try? c.decode(Int.self) {
+            self = .single(v)
+            return
+        }
+        self = .array(try c.decode([Int].self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .single(let v): try c.encode(v)
+        case .array(let a): try c.encode(a)
+        }
+    }
+
+    /// Returns the first (or only) integer value.
+    public var intValue: Int {
+        switch self {
+        case .single(let v): return v
+        case .array(let a): return a.first ?? 0
+        }
+    }
+}
+
+// MARK: - Flexible spk_is_dialect value (Bool or String)
+//
+// The CustomVoice model has mixed types:
+//   {"ryan": false, "eric": "sichuan_dialect", ...}
+// The Base model has spk_is_dialect: {} (empty), masking the bug.
+
+public enum SpkDialectValue: Codable, Sendable {
+    case bool(Bool)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let v = try? c.decode(Bool.self) {
+            self = .bool(v)
+            return
+        }
+        self = .string(try c.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .bool(let v): try c.encode(v)
+        case .string(let s): try c.encode(s)
+        }
+    }
+
+    /// true if this speaker uses a dialect (non-false value).
+    public var isDialect: Bool {
+        switch self {
+        case .bool(let v): return v
+        case .string: return true
+        }
+    }
+
+    /// The dialect name, or nil if not a dialect.
+    public var dialectName: String? {
+        switch self {
+        case .bool: return nil
+        case .string(let s): return s
+        }
+    }
+}
+
 // MARK: - Talker Config
 
 public struct Qwen3TTSTalkerConfig: Codable, Sendable {
@@ -145,8 +225,10 @@ public struct Qwen3TTSTalkerConfig: Codable, Sendable {
     var codecPadId: Int
     var codecBosId: Int
     var codecLanguageId: [String: Int]?
-    var spkId: [String: [Int]]?
-    var spkIsDialect: [String: String]?
+    /// Speaker ID map. Values may be a single Int or an array of Ints.
+    var spkId: [String: SpkIdValue]?
+    /// Dialect flags. Values may be Bool (false = not a dialect) or String (dialect name).
+    var spkIsDialect: [String: SpkDialectValue]?
 
     enum CodingKeys: String, CodingKey {
         case codePredictorConfig = "code_predictor_config"
@@ -209,8 +291,8 @@ public struct Qwen3TTSTalkerConfig: Codable, Sendable {
         codecPadId = try c.decodeIfPresent(Int.self, forKey: .codecPadId) ?? 2148
         codecBosId = try c.decodeIfPresent(Int.self, forKey: .codecBosId) ?? 2149
         codecLanguageId = try c.decodeIfPresent([String: Int].self, forKey: .codecLanguageId)
-        spkId = try c.decodeIfPresent([String: [Int]].self, forKey: .spkId)
-        spkIsDialect = try c.decodeIfPresent([String: String].self, forKey: .spkIsDialect)
+        spkId = try c.decodeIfPresent([String: SpkIdValue].self, forKey: .spkId)
+        spkIsDialect = try c.decodeIfPresent([String: SpkDialectValue].self, forKey: .spkIsDialect)
     }
 
     var mropeSection: [Int]? {


### PR DESCRIPTION
## Summary

Adds speaker embedding injection for Qwen3-TTS `custom_voice` models (e.g. `mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit`), fixing voice identity not being preserved across sentences.

Also includes a prerequisite fix for flexible JSON decoding of `spkId` and `spkIsDialect` config fields which use mixed types in CustomVoice `config.json` files.

---

## Problem

When using CustomVoice models with a named speaker (e.g. `"ryan"`), the voice was not being applied — the model generated audio with a random/default voice instead of the requested speaker. This is because:

1. **Config decoding failed** — `spkId` values can be `Int` or `[Int]`, and `spkIsDialect` values can be `Bool` or `String`. A plain `Codable` struct would crash or silently drop these fields.

2. **Speaker embedding not injected** — Even with valid config, the `prepareGenerationInputs` path never looked up the speaker ID or injected its embedding into the codec prefix.

---

## Changes

### `Qwen3TTSModelConfig.swift` — Flexible config decoders
- Added `SpkIdValue` enum (`int` / `array` cases) with `.intValue` helper that returns the first (or only) speaker ID
- Added `SpkDialectValue` enum (`bool` / `dialect` cases) with `.isDialect` and `.dialectName` helpers
- Both enums handle the mixed-type JSON gracefully without schema changes

### `Qwen3TTS.swift` — Speaker embedding injection
- In `generateVoiceDesign()`: detect `ttsModelType == "custom_voice"`, route `voice` as `speaker` (not `instruct`)
- Added `speaker: String?` parameter to `prepareGenerationInputs()`
- Look up `speaker` in `talkerConfig.spkId` → get integer ID → call `talker.getInputEmbeddings()` to produce embedding
- Inject the speaker embedding between the codec think/nothink prefix tokens and the `[codecPad, codecBos]` suffix
- Apply dialect language ID override when `spkIsDialect` indicates a dialect speaker (Cantonese, Hokkien, etc.)

---

## Testing

Tested on device with `mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit` (8-bit quantized):
- Speaker `"ryan"` consistently produces the same voice across multiple sentences ✅
- Speaker `"female_1"` produces a distinctly different voice from `"ryan"` ✅  
- Standard VoiceDesign models (non-CustomVoice) are unaffected — `instruct` path unchanged ✅
- ICL (reference audio) path is unaffected ✅