### PR TITLE
fix: pass textProcessor through in KokoroModel.fromPretrained

### DIFF
--- a/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
+++ b/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
@@ -261,7 +261,7 @@ public final class KokoroModel: Module, SpeechGenerationModel, @unchecked Sendab
             cache: cache
         )
 
-        return try await fromModelDirectory(modelDir)
+        return try await fromModelDirectory(modelDir, textProcessor: textProcessor)
     }
 
     public static func fromModelDirectory(


### PR DESCRIPTION
fromPretrained accepts a textProcessor parameter but was not forwarding it to fromModelDirectory, so it always defaulted to nil. This meant the G2P pipeline (MisakiTextProcessor / KokoroMultilingualProcessor) never ran — raw English text went directly to the character-level tokenizer, producing garbled speech output.