### PR TITLE
fix: exclude in-tree docs from SwiftPM targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -109,7 +109,20 @@ let package = Package(
                 .product(name: "HuggingFace", package: "swift-huggingface"),
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
-            path: "Sources/MLXAudioTTS"
+            path: "Sources/MLXAudioTTS",
+            exclude: [
+                "Models/Chatterbox/README.md",
+                "Models/EchoTTS/README.md",
+                "Models/FishSpeech/README.md",
+                "Models/Llama/README.md",
+                "Models/Marvis/README.md",
+                "Models/PocketTTS/README.md",
+                "Models/Qwen3/README.md",
+                "Models/Qwen3TTS/README.md",
+                "Models/Soprano/README.md",
+                "Models/StyleTTS2/KittenTTS/README.md",
+                "Models/StyleTTS2/Kokoro/README.md",
+            ]
         ),
 
         // MARK: - MLXAudioSTT
@@ -126,7 +139,17 @@ let package = Package(
                 .product(name: "HuggingFace", package: "swift-huggingface"),
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
-            path: "Sources/MLXAudioSTT"
+            path: "Sources/MLXAudioSTT",
+            exclude: [
+                "Models/CohereTranscribe/README.md",
+                "Models/FireRedASR2/README.md",
+                "Models/GLMASR/README.md",
+                "Models/GraniteSpeech/README.md",
+                "Models/Parakeet/README.md",
+                "Models/Qwen3ASR/README.md",
+                "Models/SenseVoice/README.md",
+                "Models/VoxtralRealtime/README.md",
+            ]
         ),
 
         // MARK: - MLXAudioVAD
@@ -139,7 +162,11 @@ let package = Package(
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
                 .product(name: "HuggingFace", package: "swift-huggingface"),
             ],
-            path: "Sources/MLXAudioVAD"
+            path: "Sources/MLXAudioVAD",
+            exclude: [
+                "Models/SmartTurn/README.md",
+                "Models/Sortformer/README.md",
+            ]
         ),
 
         // MARK: - MLXAudioLID
@@ -152,7 +179,10 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "HuggingFace", package: "swift-huggingface"),
             ],
-            path: "Sources/MLXAudioLID"
+            path: "Sources/MLXAudioLID",
+            exclude: [
+                "README.md",
+            ]
         ),
 
         // MARK: - MLXAudioSTS
@@ -171,7 +201,11 @@ let package = Package(
                 .product(name: "HuggingFace", package: "swift-huggingface"),
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
-            path: "Sources/MLXAudioSTS"
+            path: "Sources/MLXAudioSTS",
+            exclude: [
+                "Models/LFMAudio/README.md",
+                "Models/SAMAudio/README.md",
+            ]
         ),
 
         // MARK: - MLXAudioG2P
@@ -198,27 +232,42 @@ let package = Package(
         .executableTarget(
             name: "mlx-audio-swift-tts",
             dependencies: ["MLXAudioCore", "MLXAudioTTS", "MLXAudioSTT"],
-            path: "Sources/Tools/mlx-audio-swift-tts"
+            path: "Sources/Tools/mlx-audio-swift-tts",
+            exclude: [
+                "README.md",
+            ]
         ),
         .executableTarget(
             name: "mlx-audio-swift-codec",
             dependencies: ["MLXAudioCore", "MLXAudioCodecs"],
-            path: "Sources/Tools/mlx-audio-swift-codec"
+            path: "Sources/Tools/mlx-audio-swift-codec",
+            exclude: [
+                "README.md",
+            ]
         ),
         .executableTarget(
             name: "mlx-audio-swift-sts",
             dependencies: ["MLXAudioCore", "MLXAudioSTS"],
-            path: "Sources/Tools/mlx-audio-swift-sts"
+            path: "Sources/Tools/mlx-audio-swift-sts",
+            exclude: [
+                "README.md",
+            ]
         ),
         .executableTarget(
             name: "mlx-audio-swift-stt",
             dependencies: ["MLXAudioCore", "MLXAudioSTT"],
-            path: "Sources/Tools/mlx-audio-swift-stt"
+            path: "Sources/Tools/mlx-audio-swift-stt",
+            exclude: [
+                "README.md",
+            ]
         ),
         .executableTarget(
             name: "mlx-audio-swift-lid",
             dependencies: ["MLXAudioCore", "MLXAudioLID"],
-            path: "Sources/Tools/mlx-audio-swift-lid"
+            path: "Sources/Tools/mlx-audio-swift-lid",
+            exclude: [
+                "README.md",
+            ]
         ),
 
         // MARK: - Tests


### PR DESCRIPTION
Heya! I noticed some of the in-tree docs were getting picked up during build since they weren’t excluded from the package targets, so I added those excludes in `Package.swift`.

Validated locally on Apple Silicon with `xcodebuild` using:
- `MLXAudio-Package`
- `mlx-audio-swift-tts`

Edit: Woops, fixed. Initially, I'd accidentally stacked this atop another branch I'm working on, sorry about that. I need more coffee this morning xD
