### PR TITLE
Propagate cancellation to TTS generateStream producers

### DIFF
--- a/Sources/MLXAudioTTS/Generation.swift
+++ b/Sources/MLXAudioTTS/Generation.swift
@@ -18,6 +18,16 @@ public protocol SpeechGenerationModel: AnyObject {
         generationParameters: GenerateParameters
     ) async throws -> MLXArray
 
+    func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?
+    ) async throws -> MLXArray
+
     func generateStream(
         text: String,
         voice: String?,
@@ -34,6 +44,27 @@ public protocol SpeechGenerationModel: AnyObject {
         refText: String?,
         language: String?,
         generationParameters: GenerateParameters,
+        seed: UInt64?
+    ) -> AsyncThrowingStream<AudioGeneration, Error>
+
+    func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<AudioGeneration, Error>
+
+    func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?,
         streamingInterval: Double
     ) -> AsyncThrowingStream<AudioGeneration, Error>
 }
@@ -45,9 +76,88 @@ public extension SpeechGenerationModel {
         refAudio: MLXArray?,
         refText: String?,
         language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?
+    ) async throws -> MLXArray {
+        try await generate(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters
+        )
+    }
+
+    func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        generateStream(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters
+        )
+    }
+
+    func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        generateStream(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters,
+            streamingInterval: streamingInterval
+        )
+    }
+
+    func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
         generationParameters: GenerateParameters? = nil
     ) async throws -> MLXArray {
         try await generate(text: text, voice: voice, refAudio: refAudio, refText: refText, language: language, generationParameters: generationParameters ?? defaultGenerationParameters)
+    }
+
+    func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters? = nil,
+        seed: UInt64?
+    ) async throws -> MLXArray {
+        try await generate(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters ?? defaultGenerationParameters,
+            seed: seed
+        )
     }
 
     func generateSamplesStream(

--- a/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift
+++ b/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift
@@ -860,7 +860,7 @@ public final class ChatterboxModel: Module, SpeechGenerationModel, @unchecked Se
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
 
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else {
                 continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
                 return
@@ -893,6 +893,7 @@ public final class ChatterboxModel: Module, SpeechGenerationModel, @unchecked Se
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
 
         return stream
     }

--- a/Sources/MLXAudioTTS/Models/Chatterbox/T3/T3GPT2Model.swift
+++ b/Sources/MLXAudioTTS/Models/Chatterbox/T3/T3GPT2Model.swift
@@ -317,6 +317,7 @@ public class T3GPT2Model: Module {
 
         // Generation loop
         for step in 0 ..< maxNewTokens {
+            if Task.isCancelled { break }
             var logits = speechLogits.squeezed(axis: 1) // (1, vocab)
 
             // Apply repetition penalty

--- a/Sources/MLXAudioTTS/Models/Chatterbox/T3/T3Model.swift
+++ b/Sources/MLXAudioTTS/Models/Chatterbox/T3/T3Model.swift
@@ -423,6 +423,7 @@ public class T3Model: Module {
 
         // Generation loop
         for step in 0 ..< maxNewTokens {
+            if Task.isCancelled { break }
             // Get logits for last position
             var logits = speechHead(hidden[0..., (-1)..., 0...]) // (B, 1, vocab)
             logits = logits.squeezed(axis: 1) // (B, vocab)

--- a/Sources/MLXAudioTTS/Models/FishSpeech/FishSpeechModel.swift
+++ b/Sources/MLXAudioTTS/Models/FishSpeech/FishSpeechModel.swift
@@ -588,7 +588,7 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
         _ = streamingInterval
 
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else {
                 continuation.finish()
                 return
@@ -626,6 +626,7 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
         return stream
     }
 
@@ -810,6 +811,7 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
         generatedSteps.reserveCapacity(semanticBudget)
 
         for _ in 0 ..< semanticBudget {
+            if Task.isCancelled { break }
             let semanticToken = try sampleSemantic(
                 logits: logits,
                 previousSemanticTokens: previousSemanticTokens,

--- a/Sources/MLXAudioTTS/Models/Llama/LlamaTTS.swift
+++ b/Sources/MLXAudioTTS/Models/Llama/LlamaTTS.swift
@@ -712,6 +712,7 @@ public class LlamaTTSModel: Module, KVCacheDimensionProvider, SpeechGenerationMo
 
         // Generate tokens
         for i in 0..<maxTokens {
+            if Task.isCancelled { break }
             let tokenValue: Int = autoreleasepool {
                 var lastLogits = logits[0..., -1, 0...]
                 lastLogits = processor?.process(logits: lastLogits) ?? lastLogits
@@ -787,9 +788,9 @@ public class LlamaTTSModel: Module, KVCacheDimensionProvider, SpeechGenerationMo
         )
     ) -> AsyncThrowingStream<LlamaTTSGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<LlamaTTSGeneration, Error>.makeStream()
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else { return }
-            
+
             do {
                 guard let snacModel = self._snacModel else {
                     throw LlamaTTSError.modelNotInitialized("SNAC model not loaded")
@@ -905,6 +906,7 @@ public class LlamaTTSModel: Module, KVCacheDimensionProvider, SpeechGenerationMo
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
         return stream
     }
 

--- a/Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift
@@ -365,8 +365,8 @@ public extension MarvisTTSModel {
         streamingInterval: Double = 0.5
     ) -> AsyncThrowingStream<GenerationResult, Error> {
         let (stream, continuation) = AsyncThrowingStream<GenerationResult, Error>.makeStream()
-        
-        Task { @Sendable [weak self, continuation] in
+
+        let task = Task { @Sendable [weak self, continuation] in
             guard let self else { return }
             do {
                 guard voice != nil || refAudio != nil else {
@@ -481,9 +481,10 @@ public extension MarvisTTSModel {
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
         return stream
     }
-    
+
     private static func textPieces(_ text: String, splitPattern: String?) -> [String] {
         let pieces: [String]
         if let pat = splitPattern, let re = try? NSRegularExpression(pattern: pat) {
@@ -603,14 +604,14 @@ extension MarvisTTSModel: SpeechGenerationModel, @unchecked Sendable {
         streamingInterval: Double
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
-        
-        Task { @Sendable [weak self, continuation] in
+
+        let task = Task { @Sendable [weak self, continuation] in
             guard let self else { return }
-            
+
             do {
                 _ = generationParameters
                 let resolvedVoice = try resolveVoice(from: voice)
-                
+
                 for try await chunk in generate(
                     text: text,
                     voice: resolvedVoice,
@@ -621,13 +622,14 @@ extension MarvisTTSModel: SpeechGenerationModel, @unchecked Sendable {
                 ) {
                     continuation.yield(.audio(MLXArray(chunk.audio)))
                 }
-                
+
                 continuation.finish()
             } catch {
                 continuation.finish(throwing: error)
             }
         }
-        
+        continuation.onTermination = { @Sendable _ in task.cancel() }
+
         return stream
     }
 }

--- a/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSModel.swift
@@ -248,6 +248,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
         var eosStep: Int?
 
         for step in 0 ..< maxGenLen {
+            if Task.isCancelled { break }
             let (nextLatent, isEos) = runFlowLMAndIncrementStep(&state, backboneInputLatents: backboneInput)
             if eosStep == nil {
                 let eos = isEos.asArray(Bool.self).first ?? false
@@ -310,7 +311,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
 
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else { return }
             do {
                 let audio = try await self.generate(
@@ -327,6 +328,7 @@ public final class PocketTTSModel: Module, SpeechGenerationModel, @unchecked Sen
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
 
         return stream
     }

--- a/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
@@ -654,6 +654,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
 
         // Generate tokens
         for _ in 0..<maxTokens {
+            if Task.isCancelled { break }
             let tokenValue: Int = autoreleasepool {
                 var lastLogits = logits
                 lastLogits = processor?.process(logits: lastLogits) ?? lastLogits
@@ -732,10 +733,10 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         )
     ) -> AsyncThrowingStream<Qwen3Generation, Error> {
         let (stream, continuation) = AsyncThrowingStream<Qwen3Generation, Error>.makeStream()
-        
-        Task { @Sendable [weak self, continuation] in
+
+        let task = Task { @Sendable [weak self, continuation] in
             guard let self else { return }
-            
+
             do {
                 guard let snacModel = self._snacModel else {
                     throw Qwen3Error.modelNotInitialized("SNAC model not loaded")
@@ -861,6 +862,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
         return stream
     }
 

--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -103,7 +103,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         streamingInterval: Double
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else { return }
             do {
                 guard speechTokenizer != nil else {
@@ -149,6 +149,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
         return stream
     }
 
@@ -276,6 +277,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         }
 
         for step in 0 ..< effectiveMaxTokens {
+            if Task.isCancelled { break }
             // Forward pass through talker
             let (logits, hidden) = talker(inputEmbeds, cache: cache)
 

--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -58,6 +58,26 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         language: String?,
         generationParameters: GenerateParameters
     ) async throws -> MLXArray {
+        try await generate(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters,
+            seed: nil
+        )
+    }
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?
+    ) async throws -> MLXArray {
         guard speechTokenizer != nil else {
             throw AudioGenerationError.modelNotInitialized("Speech tokenizer not loaded")
         }
@@ -79,7 +99,8 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
             topP: generationParameters.topP,
             repetitionPenalty: generationParameters.repetitionPenalty ?? 1.05,
             minP: 0.0,
-            maxTokens: generationParameters.maxTokens ?? 4096
+            maxTokens: generationParameters.maxTokens ?? 4096,
+            seed: seed
         )
         return audio
     }
@@ -110,6 +131,49 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         refText: String?,
         language: String?,
         generationParameters: GenerateParameters,
+        seed: UInt64?
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        generateStream(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters,
+            seed: seed,
+            streamingInterval: 2.0
+        )
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        generateStream(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters,
+            seed: nil,
+            streamingInterval: streamingInterval
+        )
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        seed: UInt64?,
         streamingInterval: Double
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
@@ -143,6 +207,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
                     repetitionPenalty: repPenalty,
                     minP: 0.0,
                     maxTokens: maxTokens,
+                    seed: seed,
                     streamingInterval: streamingInterval,
                     onToken: { tokenId in
                         continuation.yield(.token(tokenId))
@@ -274,6 +339,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         repetitionPenalty: Float,
         minP: Float,
         maxTokens: Int,
+        seed: UInt64? = nil,
         streamingInterval: Double = 2.0,
         onToken: ((Int) -> Void)? = nil,
         onInfo: ((AudioGenerationInfo) -> Void)? = nil,
@@ -343,8 +409,16 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
 
         var trailingIdx = 0
         var inputEmbeds = inputEmbedsInit
+        var samplingKey = seed.map(MLXRandom.key)
         let eosTokenArray = MLXArray([Int32(eosTokenId)]).reshaped(1, 1)
         let codeCache = talker.codePredictor.makeCache()
+
+        func nextSamplingKey() -> MLXArray? {
+            guard let key = samplingKey else { return nil }
+            let splitKeys = MLXRandom.split(key: key, into: 2)
+            samplingKey = splitKeys[0]
+            return splitKeys[1]
+        }
 
         if onAudioChunk != nil {
             speechTokenizer.decoder.resetStreamingState()
@@ -370,7 +444,8 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
                 generatedTokens: generatedCodebookTokens,
                 suppressTokens: suppressTokens,
                 eosTokenId: eosTokenId,
-                minP: minP
+                minP: minP,
+                key: nextSamplingKey()
             )
 
             // Defer sync to the eval boundary with inputEmbeds.
@@ -401,7 +476,8 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
                     temperature: temperature,
                     topP: topP,
                     topK: topK,
-                    minP: minP
+                    minP: minP,
+                    key: nextSamplingKey()
                 )
                 codeTokens.append(nextCode)
             }
@@ -793,7 +869,8 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         generatedTokens: [Int]? = nil,
         suppressTokens: [Int]? = nil,
         eosTokenId: Int? = nil,
-        minP: Float = 0.0
+        minP: Float = 0.0,
+        key: MLXArray? = nil
     ) -> MLXArray {
         var logitsSlice = logits[0..., (-1)..., 0...].squeezed(axis: 1) // [batch, vocab_size]
 
@@ -897,7 +974,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         }
 
         // Sample with temperature
-        let token = categorical(filteredLogits / temperature)
+        let token = categorical(filteredLogits / temperature, key: key)
         return token.reshaped(1, 1)
     }
 

--- a/Sources/MLXAudioTTS/Models/Soprano/Soprano.swift
+++ b/Sources/MLXAudioTTS/Models/Soprano/Soprano.swift
@@ -698,9 +698,9 @@ public class SopranoModel: Module, KVCacheDimensionProvider, SpeechGenerationMod
         )
     ) -> AsyncThrowingStream<SopranoGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<SopranoGeneration, Error>.makeStream()
-        Task { @Sendable [weak self, continuation] in
+        let task = Task { @Sendable [weak self, continuation] in
             guard let self else { return }
-            
+
             do {
                 guard self.tokenizer != nil else {
                     throw SopranoError.modelNotInitialized("Tokenizer not loaded")
@@ -785,6 +785,7 @@ public class SopranoModel: Module, KVCacheDimensionProvider, SpeechGenerationMod
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
         return stream
     }
 
@@ -825,6 +826,7 @@ public class SopranoModel: Module, KVCacheDimensionProvider, SpeechGenerationMod
                 var currentLogits = logits
 
                 for _ in 0..<maxTokens {
+                    if Task.isCancelled { break }
                     // Get last logits
                     var lastLogits = currentLogits[0..., -1, 0...]
                     eval(lastLogits)

--- a/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
+++ b/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
@@ -176,25 +176,26 @@ public final class KokoroModel: Module, SpeechGenerationModel, @unchecked Sendab
         language: String?,
         generationParameters: GenerateParameters
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
-        AsyncThrowingStream { continuation in
-            Task { @Sendable [weak self] in
-                guard let self else {
-                    continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
-                    return
-                }
-                do {
-                    let audio = try await self.generate(
-                        text: text, voice: voice, refAudio: refAudio,
-                        refText: refText, language: language,
-                        generationParameters: generationParameters
-                    )
-                    continuation.yield(.audio(audio))
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+        let task = Task { @Sendable [weak self] in
+            guard let self else {
+                continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
+                return
+            }
+            do {
+                let audio = try await self.generate(
+                    text: text, voice: voice, refAudio: refAudio,
+                    refText: refText, language: language,
+                    generationParameters: generationParameters
+                )
+                continuation.yield(.audio(audio))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
+        return stream
     }
 
     // MARK: - Voice Loading

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -136,6 +136,73 @@ struct SopranoTextCleaningTests {
     }
 }
 
+struct Qwen3TTSSeededSamplingTests {
+
+    @Test func sameSeedProducesSameSampleSequence() throws {
+        let model = try makeModel()
+        let first = sampleSequence(model: model, seed: 42)
+        let second = sampleSequence(model: model, seed: 42)
+
+        #expect(first == second)
+    }
+
+    @Test func differentSeedsCanProduceDifferentSampleSequences() throws {
+        let model = try makeModel()
+        let first = sampleSequence(model: model, seed: 42)
+        let second = sampleSequence(model: model, seed: 43)
+
+        #expect(first != second)
+    }
+
+    @Test func greedySamplingIgnoresSeed() throws {
+        let model = try makeModel()
+        let logits = MLXArray([-1.0 as Float, 4.0, 0.0, 2.0]).reshaped(1, 1, 4)
+        let first = model.sampleToken(logits, temperature: 0, key: MLXRandom.key(1))
+        let second = model.sampleToken(logits, temperature: 0, key: MLXRandom.key(2))
+        eval(first, second)
+
+        #expect(Int(first.item(Int32.self)) == 1)
+        #expect(Int(second.item(Int32.self)) == 1)
+    }
+
+    @Test func unseededSamplingStillUsesImplicitRandomState() throws {
+        let model = try makeModel()
+        let logits = MLXArray([0.0 as Float, 0.5, 1.0, 1.5]).reshaped(1, 1, 4)
+        let token = model.sampleToken(logits, temperature: 1.0, topP: 1.0, topK: 0)
+        eval(token)
+        let tokenID = Int(token.item(Int32.self))
+
+        #expect((0 ..< 4).contains(tokenID))
+    }
+
+    private func sampleSequence(model: Qwen3TTSModel, seed: UInt64) -> [Int] {
+        let logits = MLXArray([0.0 as Float, 0.5, 1.0, 1.5]).reshaped(1, 1, 4)
+        var key = MLXRandom.key(seed)
+
+        return (0 ..< 24).map { _ in
+            let splitKeys = MLXRandom.split(key: key, into: 2)
+            key = splitKeys[0]
+            let token = model.sampleToken(
+                logits,
+                temperature: 1.0,
+                topP: 1.0,
+                topK: 0,
+                key: splitKeys[1]
+            )
+            eval(token)
+            return Int(token.item(Int32.self))
+        }
+    }
+
+    private func makeModel() throws -> Qwen3TTSModel {
+        let config = try JSONDecoder().decode(
+            Qwen3TTSModelConfig.self,
+            from: Data("{}".utf8)
+        )
+        return Qwen3TTSModel(config: config)
+    }
+}
+
 struct EchoTTSTests {
 
     @Test func testTextNormalization() {


### PR DESCRIPTION
## Problem

Several `Model.generateStream(...)` implementations build an `AsyncThrowingStream` whose producer is an unstructured `Task { @Sendable [weak self] in ... }`, but the `continuation` has no `onTermination` handler. When a consumer cancels (drops the stream or cancels its enclosing task), the producer Task is **not** cancelled, it keeps running until natural completion (`maxTokens` / EOS).

Compounding this, several long-running generation loops never check `Task.isCancelled`, so even if the producer Task were cancelled, the MLX forward-pass loop would still run to the token budget.

In a downstream macOS app this surfaces as: clicking "Stop" mid-generation successfully cancels the Swift task chain, but CPU stays pinned (and KV-cache state continues mutating) until the underlying token loop hits `maxTokens`.

## Fix

Two complementary patches, applied per model:

**A - Wire `onTermination` to cancel the producer Task** in every `generateStream` that spawns an unstructured Task. This matches the canonical pattern already used by `proxyAudioStream` in `Sources/MLXAudioTTS/Generation.swift`:

```swift
let task = Task { @Sendable [weak self] in ... }
continuation.onTermination = { @Sendable _ in task.cancel() }
return stream
```

**B - Add `if Task.isCancelled { break }` at the top of synchronous token loops** that run inside the producer Task, so cancellation actually exits the loop between forward passes.

## Files touched

- `Models/Chatterbox/ChatterboxModel.swift` - A
- `Models/Chatterbox/T3/T3Model.swift` - B
- `Models/Chatterbox/T3/T3GPT2Model.swift` - B
- `Models/FishSpeech/FishSpeechModel.swift` - A + B
- `Models/Llama/LlamaTTS.swift` - A + B (streaming loop already had the check; left untouched)
- `Models/Marvis/MarvisTTSModel.swift` - A on both `generateStream` overloads (loops already had checks)
- `Models/PocketTTS/PocketTTSModel.swift` - A + B
- `Models/Qwen3/Qwen3.swift` - A + B (streaming loop already had the check; left untouched)
- `Models/Qwen3TTS/Qwen3TTS.swift` - A + B
- `Models/Soprano/Soprano.swift` - A + B
- `Models/StyleTTS2/Kokoro/KokoroModel.swift` - A (refactored from inline-closure form to `makeStream()` so the producer Task is bindable; no inner synchronous loop)

## Behavior change

- **Cancellation paths**: producer Tasks now stop within ~1 token of consumer termination. CPU drops to baseline immediately instead of at `maxTokens`.
- **Non-cancellation paths**: no behavior change. `Task.isCancelled` is false in normal completion; `onTermination` only fires when the consumer terminates the stream.

## Verification

- `swift build` clean against the package.
- Verified end-to-end in a downstream macOS app using the Qwen3-TTS model: previously "Stop" left CPU pinned for the remainder of `maxTokens`; with this branch CPU returns to baseline within a single forward pass.
