### PR TITLE
feat: add reusable qwen3 reference conditioning

### DIFF
--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -58,30 +58,25 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         language: String?,
         generationParameters: GenerateParameters
     ) async throws -> MLXArray {
-        guard speechTokenizer != nil else {
-            throw AudioGenerationError.modelNotInitialized("Speech tokenizer not loaded")
-        }
-        guard tokenizer != nil else {
-            throw AudioGenerationError.modelNotInitialized("Text tokenizer not loaded")
-        }
+        try requireGenerationComponents()
+        let settings = resolveVoiceDesignGenerationSettings(
+            language: language,
+            generationParameters: generationParameters
+        )
 
-        // VoiceDesign: voice parameter is the instruct (voice description)
-        let instruct = voice
-
-        let audio = generateVoiceDesign(
+        return try generateVoiceDesign(
             text: text,
-            instruct: instruct,
-            language: language ?? "auto",
+            instruct: voice,
+            language: settings.language,
             refAudio: refAudio,
             refText: refText,
-            temperature: generationParameters.temperature,
-            topK: 50,
-            topP: generationParameters.topP,
-            repetitionPenalty: generationParameters.repetitionPenalty ?? 1.05,
-            minP: 0.0,
-            maxTokens: generationParameters.maxTokens ?? 4096
+            temperature: settings.temperature,
+            topK: settings.topK,
+            topP: settings.topP,
+            repetitionPenalty: settings.repetitionPenalty,
+            minP: settings.minP,
+            maxTokens: settings.maxTokens
         )
-        return audio
     }
 
     public func generateStream(
@@ -112,54 +107,101 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         generationParameters: GenerateParameters,
         streamingInterval: Double
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
-        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
-        Task { @Sendable [weak self] in
-            guard let self else { return }
-            do {
-                guard speechTokenizer != nil else {
-                    throw AudioGenerationError.modelNotInitialized("Speech tokenizer not loaded")
-                }
-                guard tokenizer != nil else {
-                    throw AudioGenerationError.modelNotInitialized("Text tokenizer not loaded")
-                }
-
-                // VoiceDesign: voice parameter is the instruct (voice description)
-                let instruct = voice
-                let lang = language ?? "auto"
-                let temp = generationParameters.temperature
-                let topP = generationParameters.topP
-                let repPenalty = generationParameters.repetitionPenalty ?? 1.05
-                let maxTokens = generationParameters.maxTokens ?? 4096
-
-                _ = generateVoiceDesign(
-                    text: text,
-                    instruct: instruct,
-                    language: lang,
-                    refAudio: refAudio,
-                    refText: refText,
-                    temperature: temp,
-                    topK: 50,
-                    topP: topP,
-                    repetitionPenalty: repPenalty,
-                    minP: 0.0,
-                    maxTokens: maxTokens,
-                    streamingInterval: streamingInterval,
-                    onToken: { tokenId in
-                        continuation.yield(.token(tokenId))
-                    },
-                    onInfo: { info in
-                        continuation.yield(.info(info))
-                    },
-                    onAudioChunk: { chunk in
-                        continuation.yield(.audio(chunk))
-                    }
-                )
-                continuation.finish()
-            } catch {
-                continuation.finish(throwing: error)
-            }
+        let settings = resolveVoiceDesignGenerationSettings(
+            language: language,
+            generationParameters: generationParameters
+        )
+        return makeGenerationStream { model, onToken, onInfo, onAudioChunk in
+            _ = try model.generateVoiceDesign(
+                text: text,
+                instruct: voice,
+                language: settings.language,
+                refAudio: refAudio,
+                refText: refText,
+                temperature: settings.temperature,
+                topK: settings.topK,
+                topP: settings.topP,
+                repetitionPenalty: settings.repetitionPenalty,
+                minP: settings.minP,
+                maxTokens: settings.maxTokens,
+                streamingInterval: streamingInterval,
+                onToken: onToken,
+                onInfo: onInfo,
+                onAudioChunk: onAudioChunk
+            )
         }
-        return stream
+    }
+
+    public func generate(
+        text: String,
+        conditioning: Qwen3TTSReferenceConditioning,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        try requireGenerationComponents()
+        let settings = resolveVoiceDesignGenerationSettings(
+            language: conditioning.resolvedLanguage,
+            generationParameters: generationParameters
+        )
+
+        return try generateVoiceDesign(
+            text: text,
+            instruct: nil,
+            language: settings.language,
+            conditioning: conditioning,
+            refAudio: nil,
+            refText: nil,
+            temperature: settings.temperature,
+            topK: settings.topK,
+            topP: settings.topP,
+            repetitionPenalty: settings.repetitionPenalty,
+            minP: settings.minP,
+            maxTokens: settings.maxTokens
+        )
+    }
+
+    public func generateStream(
+        text: String,
+        conditioning: Qwen3TTSReferenceConditioning,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        generateStream(
+            text: text,
+            conditioning: conditioning,
+            generationParameters: generationParameters,
+            streamingInterval: 2.0
+        )
+    }
+
+    public func generateStream(
+        text: String,
+        conditioning: Qwen3TTSReferenceConditioning,
+        generationParameters: GenerateParameters,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let settings = resolveVoiceDesignGenerationSettings(
+            language: conditioning.resolvedLanguage,
+            generationParameters: generationParameters
+        )
+        return makeGenerationStream { model, onToken, onInfo, onAudioChunk in
+            _ = try model.generateVoiceDesign(
+                text: text,
+                instruct: nil,
+                language: settings.language,
+                conditioning: conditioning,
+                refAudio: nil,
+                refText: nil,
+                temperature: settings.temperature,
+                topK: settings.topK,
+                topP: settings.topP,
+                repetitionPenalty: settings.repetitionPenalty,
+                minP: settings.minP,
+                maxTokens: settings.maxTokens,
+                streamingInterval: streamingInterval,
+                onToken: onToken,
+                onInfo: onInfo,
+                onAudioChunk: onAudioChunk
+            )
+        }
     }
 
     // MARK: - Decode chunk helper
@@ -265,6 +307,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         text: String,
         instruct: String?,
         language: String,
+        conditioning: Qwen3TTSReferenceConditioning? = nil,
         refAudio: MLXArray?,
         refText: String?,
         temperature: Float,
@@ -277,9 +320,11 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         onToken: ((Int) -> Void)? = nil,
         onInfo: ((AudioGenerationInfo) -> Void)? = nil,
         onAudioChunk: ((MLXArray) -> Void)? = nil
-    ) -> MLXArray {
+    ) throws -> MLXArray {
         guard let speechTokenizer, let tokenizer else {
-            return MLXArray.zeros([1])
+            throw AudioGenerationError.modelNotInitialized(
+                "Qwen3TTS generateVoiceDesign requires both the speech tokenizer and the text tokenizer to be loaded."
+            )
         }
 
         let talkerConfig = config.talkerConfig!
@@ -290,10 +335,19 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let ttsPadEmbed: MLXArray
         let refCodes: MLXArray?
 
-        if let refAudio,
+        if let conditioning {
+            let prepared = try prepareICLGenerationInputs(
+                text: text,
+                conditioning: conditioning
+            )
+            inputEmbedsInit = prepared.0
+            trailingTextHidden = prepared.1
+            ttsPadEmbed = prepared.2
+            refCodes = prepared.3
+        } else if let refAudio,
            let refText,
            speechTokenizer.hasEncoder {
-            let prepared = prepareICLGenerationInputs(
+            let prepared = try prepareICLGenerationInputs(
                 text: text,
                 refAudio: refAudio,
                 refText: refText,
@@ -509,27 +563,158 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         return audio
     }
 
-    // MARK: - Prepare generation inputs
+    // MARK: - Reference conditioning
+
+    public func prepareReferenceConditioning(
+        refAudio: MLXArray,
+        refText: String,
+        language: String?
+    ) throws -> Qwen3TTSReferenceConditioning {
+        try prepareReferenceConditioning(
+            refAudio: refAudio,
+            refText: refText,
+            speakerEmbedding: nil,
+            language: language ?? "auto"
+        )
+    }
+
+    private struct VoiceDesignGenerationSettings {
+        let language: String
+        let temperature: Float
+        let topK: Int
+        let topP: Float
+        let repetitionPenalty: Float
+        let minP: Float
+        let maxTokens: Int
+    }
+
+    public struct Qwen3TTSReferenceConditioning: @unchecked Sendable {
+        public let speakerEmbedding: MLXArray?
+        public let referenceSpeechCodes: MLXArray
+        public let referenceTextTokenIDs: MLXArray
+        public let resolvedLanguage: String
+        public let codecLanguageID: Int?
+    }
+
+    private func requireGenerationComponents() throws {
+        guard speechTokenizer != nil else {
+            throw AudioGenerationError.modelNotInitialized("Speech tokenizer not loaded")
+        }
+        guard tokenizer != nil else {
+            throw AudioGenerationError.modelNotInitialized("Text tokenizer not loaded")
+        }
+    }
+
+    private func resolveVoiceDesignGenerationSettings(
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> VoiceDesignGenerationSettings {
+        VoiceDesignGenerationSettings(
+            language: language ?? "auto",
+            temperature: generationParameters.temperature,
+            topK: 50,
+            topP: generationParameters.topP,
+            repetitionPenalty: generationParameters.repetitionPenalty ?? 1.05,
+            minP: 0.0,
+            maxTokens: generationParameters.maxTokens ?? 4096
+        )
+    }
+
+    private func makeGenerationStream(
+        _ body: @escaping @Sendable (
+            Qwen3TTSModel,
+            @escaping (Int) -> Void,
+            @escaping (AudioGenerationInfo) -> Void,
+            @escaping (MLXArray) -> Void
+        ) throws -> Void
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+        Task { @Sendable [weak self] in
+            guard let self else { return }
+            do {
+                try requireGenerationComponents()
+                try body(
+                    self,
+                    { tokenId in continuation.yield(.token(tokenId)) },
+                    { info in continuation.yield(.info(info)) },
+                    { chunk in continuation.yield(.audio(chunk)) }
+                )
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        return stream
+    }
 
     func prepareICLGenerationInputs(
         text: String,
         refAudio: MLXArray,
         refText: String,
         language: String
-    ) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
-        guard let tokenizer, let talkerConfig = config.talkerConfig else {
-            fatalError("Tokenizer/config not loaded")
+    ) throws -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+        let conditioning = try prepareReferenceConditioning(
+            refAudio: refAudio,
+            refText: refText,
+            speakerEmbedding: nil,
+            language: language
+        )
+        return try prepareICLGenerationInputs(text: text, conditioning: conditioning)
+    }
+
+    func prepareReferenceConditioning(
+        refAudio: MLXArray,
+        refText: String,
+        speakerEmbedding: MLXArray?,
+        language: String
+    ) throws -> Qwen3TTSReferenceConditioning {
+        guard let tokenizer, let talkerConfig = config.talkerConfig, let speechTokenizer else {
+            throw AudioGenerationError.modelNotInitialized(
+                "Qwen3TTS reference conditioning requires the text tokenizer, talker config, and speech tokenizer to be loaded."
+            )
+        }
+        guard speechTokenizer.hasEncoder else {
+            throw AudioGenerationError.invalidInput(
+                "Qwen3TTS reference conditioning requires a speech tokenizer encoder, but this checkpoint does not provide one."
+            )
         }
 
         let refContext = referenceAudioContext(for: refAudio)
 
-        // Reference text and target text tokenization
+        let resolvedLanguage = language.lowercased() == "auto" ? "auto" : language.lowercased()
+
+        // Reference text tokenization
         let refChatText = "<|im_start|>assistant\n\(refText)<|im_end|>\n"
         let refIds = MLXArray(tokenizer.encode(text: refChatText).map { Int32($0) }).reshaped(1, -1)
         let refCount = refIds.dim(1)
         let refStart = min(3, refCount)
         let refEnd = max(refStart, refCount - 2)
         let refTextIds = refIds[0..., refStart ..< refEnd]
+
+        // Language ID
+        var languageId: Int?
+        if resolvedLanguage != "auto", let langMap = talkerConfig.codecLanguageId {
+            languageId = langMap[resolvedLanguage]
+        }
+
+        return Qwen3TTSReferenceConditioning(
+            speakerEmbedding: speakerEmbedding ?? refContext.speakerEmbedding,
+            referenceSpeechCodes: refContext.refCodes,
+            referenceTextTokenIDs: refTextIds,
+            resolvedLanguage: resolvedLanguage,
+            codecLanguageID: languageId
+        )
+    }
+
+    func prepareICLGenerationInputs(
+        text: String,
+        conditioning: Qwen3TTSReferenceConditioning
+    ) throws -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+        guard let tokenizer, let talkerConfig = config.talkerConfig else {
+            throw AudioGenerationError.modelNotInitialized(
+                "Qwen3TTS request assembly requires the text tokenizer and talker config to be loaded."
+            )
+        }
 
         let targetChatText = "<|im_start|>assistant\n\(text)<|im_end|>\n<|im_start|>assistant\n"
         let targetIds = MLXArray(tokenizer.encode(text: targetChatText).map { Int32($0) }).reshaped(1, -1)
@@ -538,9 +723,6 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let targetEnd = max(targetStart, targetCount - 5)
         let targetTextIds = targetIds[0..., targetStart ..< targetEnd]
 
-        let refCodes = refContext.refCodes // [1, num_code_groups, ref_time]
-
-        // TTS special tokens
         let ttsTokens = MLXArray(
             [Int32(config.ttsBosTokenId), Int32(config.ttsEosTokenId), Int32(config.ttsPadTokenId)]
         ).reshaped(1, 3)
@@ -549,16 +731,17 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let ttsEosEmbed = ttsEmbeds[0..., 1 ..< 2, 0...]
         let ttsPadEmbed = ttsEmbeds[0..., 2 ..< 3, 0...]
 
-        // Build text embeddings for ref+target
-        let combinedTextIds = concatenated([refTextIds, targetTextIds], axis: 1)
+        let combinedTextIds = concatenated([conditioning.referenceTextTokenIDs, targetTextIds], axis: 1)
         var textEmbed = talker.textProjection(talker.getTextEmbeddings()(combinedTextIds))
         textEmbed = concatenated([textEmbed, ttsEosEmbed], axis: 1)
         let textLen = textEmbed.dim(1)
 
-        let codecEmbedIcl = refContext.codecEmbedIcl
+        let refCodes = conditioning.referenceSpeechCodes
+        let codecEmbedIcl = codecEmbedIcl(from: refCodes, talkerConfig: talkerConfig)
 
-        // Non-streaming overlay of text and codec contexts
-        let codecPadEmbed = talker.getInputEmbeddings()(MLXArray([Int32(talkerConfig.codecPadId)]).reshaped(1, 1))
+        let codecPadEmbed = talker.getInputEmbeddings()(
+            MLXArray([Int32(talkerConfig.codecPadId)]).reshaped(1, 1)
+        )
         let textWithCodecPad = textEmbed + broadcast(
             codecPadEmbed,
             to: [1, textLen, codecPadEmbed.dim(-1)]
@@ -571,13 +754,7 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let iclInputEmbed = concatenated([textWithCodecPad, codecWithTextPad], axis: 1)
         let trailingTextHidden = ttsPadEmbed
 
-        // Language ID
-        var languageId: Int?
-        if language.lowercased() != "auto", let langMap = talkerConfig.codecLanguageId {
-            languageId = langMap[language.lowercased()]
-        }
-
-        let codecPrefill: [Int32] = if let langId = languageId {
+        let codecPrefill: [Int32] = if let langId = conditioning.codecLanguageID {
             [
                 Int32(talkerConfig.codecThinkId),
                 Int32(talkerConfig.codecThinkBosId),
@@ -596,23 +773,20 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         let codecPrefixSuffix = talker.getInputEmbeddings()(
             MLXArray([Int32(talkerConfig.codecPadId), Int32(talkerConfig.codecBosId)]).reshaped(1, 2)
         )
-        if let speakerEmbedding = refContext.speakerEmbedding {
+        if let speakerEmbedding = conditioning.speakerEmbedding {
             let speakerEmbed = speakerEmbedding.reshaped(1, 1, -1)
             codecPrefixEmbed = concatenated([codecPrefixEmbed, speakerEmbed, codecPrefixSuffix], axis: 1)
         } else {
             codecPrefixEmbed = concatenated([codecPrefixEmbed, codecPrefixSuffix], axis: 1)
         }
 
-        // Role embedding
         let roleEmbed = talker.textProjection(talker.getTextEmbeddings()(targetIds[0..., 0 ..< 3]))
 
-        // Build prefix: text side overlayed with codec prefix
         let padCount = codecPrefixEmbed.dim(1) - 2
         let padEmbeds = broadcast(ttsPadEmbed, to: [1, padCount, ttsPadEmbed.dim(-1)])
         var combinedPrefix = concatenated([padEmbeds, ttsBosEmbed], axis: 1)
         combinedPrefix = combinedPrefix + codecPrefixEmbed[0..., 0 ..< (codecPrefixEmbed.dim(1) - 1), 0...]
 
-        // Full input embedding
         let inputEmbeds = concatenated([roleEmbed, combinedPrefix, iclInputEmbed], axis: 1)
 
         return (inputEmbeds, trailingTextHidden, ttsPadEmbed, refCodes)

--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -594,6 +594,20 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         public let referenceTextTokenIDs: MLXArray
         public let resolvedLanguage: String
         public let codecLanguageID: Int?
+
+        public init(
+            speakerEmbedding: MLXArray?,
+            referenceSpeechCodes: MLXArray,
+            referenceTextTokenIDs: MLXArray,
+            resolvedLanguage: String,
+            codecLanguageID: Int?
+        ) {
+            self.speakerEmbedding = speakerEmbedding
+            self.referenceSpeechCodes = referenceSpeechCodes
+            self.referenceTextTokenIDs = referenceTextTokenIDs
+            self.resolvedLanguage = resolvedLanguage
+            self.codecLanguageID = codecLanguageID
+        }
     }
 
     private func requireGenerationComponents() throws {

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -19,6 +19,7 @@ import Testing
 import MLX
 import Metal
 import MLXLMCommon
+import Tokenizers
 import Foundation
 
 private let metalAvailable: Bool = {
@@ -42,6 +43,186 @@ private func loadTTSNetworkFixture(sampleRate: Int, maxSamples: Int) throws -> M
     let (_, audio) = try loadAudioArray(from: audioURL, sampleRate: sampleRate)
     let sampleCount = min(audio.shape[0], maxSamples)
     return audio[0..<sampleCount]
+}
+
+private func writeTestFile(_ url: URL, contents: String) throws {
+    let data = try #require(contents.data(using: .utf8))
+    try data.write(to: url)
+}
+
+private func makeTemporaryArtifactDirectory(prefix: String) throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
+private func cleanupTemporaryArtifactDirectory(_ directory: URL) {
+    try? FileManager.default.removeItem(at: directory)
+}
+
+private func makeTinyQwenTokenizerDirectory() throws -> URL {
+    let directory = try makeTemporaryArtifactDirectory(prefix: "tiny-qwen3-tokenizer")
+
+    let tokenizerConfig = """
+    {
+      "tokenizer_class": "GPT2Tokenizer",
+      "bos_token": "<bos>",
+      "eos_token": "<eos>",
+      "unk_token": "<unk>",
+      "pad_token": "<pad>",
+      "model_max_length": 128,
+      "do_lower_case": false
+    }
+    """
+
+    let tokenizerData = """
+    {
+      "version": "1.0",
+      "truncation": null,
+      "padding": null,
+      "added_tokens": [
+        { "id": 0, "content": "<bos>", "special": true },
+        { "id": 1, "content": "<pad>", "special": true },
+        { "id": 2, "content": "<eos>", "special": true },
+        { "id": 3, "content": "<unk>", "special": true },
+        { "id": 4, "content": "<|im_start|>", "special": true },
+        { "id": 5, "content": "<|im_end|>", "special": true }
+      ],
+      "model": {
+        "type": "BPE",
+        "vocab": {
+          "<bos>": 0,
+          "<pad>": 1,
+          "<eos>": 2,
+          "<unk>": 3,
+          "<|im_start|>": 4,
+          "<|im_end|>": 5,
+          "assistant": 6,
+          "user": 7,
+          "one": 8,
+          "two": 9,
+          "three": 10,
+          "four": 11,
+          "five": 12,
+          "target": 13,
+          "voice": 14,
+          "prompt": 15,
+          "sample": 16,
+          "english": 17
+        },
+        "merges": [],
+        "continuing_subword_prefix": "",
+        "end_of_word_suffix": "",
+        "unk_token": "<unk>"
+      },
+      "normalizer": {
+        "type": "Lowercase"
+      },
+      "pre_tokenizer": {
+        "type": "Whitespace"
+      }
+    }
+    """
+
+    try writeTestFile(directory.appendingPathComponent("tokenizer_config.json"), contents: tokenizerConfig)
+    try writeTestFile(directory.appendingPathComponent("tokenizer.json"), contents: tokenizerData)
+    return directory
+}
+
+private func makeTinyQwen3TTSModel(
+    ttsModelType: String,
+    includeSpeechEncoder: Bool,
+    speakerIDEntries: String = "",
+    dialectEntries: String = ""
+) async throws -> (model: Qwen3TTSModel, tokenizerDirectory: URL) {
+    let tokenizerDirectory = try makeTinyQwenTokenizerDirectory()
+    let encoderConfigJSON = includeSpeechEncoder ? #""encoder_config": {},"# : ""
+    let spkIdJSON = speakerIDEntries.isEmpty ? "" : #""spk_id": {"# + speakerIDEntries + "},"
+    let spkDialectJSON = dialectEntries.isEmpty ? "" : #""spk_is_dialect": {"# + dialectEntries + "},"
+    let configJSON = """
+    {
+      "model_type": "qwen3_tts",
+      "tts_model_type": "\(ttsModelType)",
+      "tts_model_size": "tiny",
+      "tokenizer_type": "qwen3_tts_tokenizer_12hz",
+      "im_start_token_id": 4,
+      "im_end_token_id": 5,
+      "tts_pad_token_id": 21,
+      "tts_bos_token_id": 22,
+      "tts_eos_token_id": 23,
+      "sample_rate": 24000,
+      "talker_config": {
+        "vocab_size": 3072,
+        "hidden_size": 16,
+        "intermediate_size": 32,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "head_dim": 4,
+        "max_position_embeddings": 128,
+        "num_code_groups": 2,
+        "text_hidden_size": 16,
+        "text_vocab_size": 64,
+        "codec_eos_token_id": 3050,
+        "codec_think_id": 3051,
+        "codec_nothink_id": 3052,
+        "codec_think_bos_id": 3053,
+        "codec_think_eos_id": 3054,
+        "codec_pad_id": 3055,
+        "codec_bos_id": 3056,
+        "codec_language_id": {
+          "english": 3057
+        },
+        \(spkIdJSON)
+        \(spkDialectJSON)
+        "code_predictor_config": {
+          "vocab_size": 2048,
+          "hidden_size": 16,
+          "intermediate_size": 32,
+          "num_hidden_layers": 1,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 4,
+          "head_dim": 4,
+          "max_position_embeddings": 128,
+          "num_code_groups": 2
+        }
+      },
+      "tokenizer_config": {
+        "encoder_valid_num_quantizers": 2,
+        \(encoderConfigJSON)
+        "decoder_config": {}
+      }
+    }
+    """
+
+    let configData = Data(configJSON.utf8)
+    let config = try JSONDecoder().decode(Qwen3TTSModelConfig.self, from: configData)
+    let model = Qwen3TTSModel(config: config)
+    model.tokenizer = try await AutoTokenizer.from(modelFolder: tokenizerDirectory)
+    model.speechTokenizer = Qwen3TTSSpeechTokenizer(config: try #require(config.tokenizerConfig))
+    return (model, tokenizerDirectory)
+}
+
+private func collectQwen3TTSStream(
+    _ stream: AsyncThrowingStream<AudioGeneration, Error>
+) async throws -> (tokenCount: Int, infoCount: Int, lastAudio: MLXArray?) {
+    var tokenCount = 0
+    var infoCount = 0
+    var lastAudio: MLXArray?
+
+    for try await event in stream {
+        switch event {
+        case .token:
+            tokenCount += 1
+        case .info:
+            infoCount += 1
+        case .audio(let audio):
+            lastAudio = audio
+        }
+    }
+
+    return (tokenCount, infoCount, lastAudio)
 }
 
 private struct FakeFishTokenizer: FishSpeechTokenizing {
@@ -111,6 +292,161 @@ private func makeTinyFishSpeechConfig() -> FishSpeechConfig {
 
 
 // MARK: - Text Cleaning Unit Tests
+
+@Suite("Qwen3TTS")
+struct Qwen3TTSTests {
+
+    @Test func prepareReferenceConditioningBuildsReusableReferenceState() async throws {
+        let fixture = try await makeTinyQwen3TTSModel(
+            ttsModelType: "voice_design",
+            includeSpeechEncoder: true
+        )
+        defer { cleanupTemporaryArtifactDirectory(fixture.tokenizerDirectory) }
+
+        let refAudio = try loadTTSNetworkFixture(sampleRate: 24_000, maxSamples: 24_000)
+        let conditioning = try fixture.model.prepareReferenceConditioning(
+            refAudio: refAudio,
+            refText: "one two three four five one two three four five",
+            language: "English"
+        )
+
+        #expect(conditioning.speakerEmbedding == nil)
+        #expect(conditioning.referenceSpeechCodes.ndim == 3)
+        #expect(conditioning.referenceSpeechCodes.dim(0) == 1)
+        #expect(conditioning.referenceSpeechCodes.dim(1) == 2)
+        #expect(conditioning.referenceSpeechCodes.dim(2) > 0)
+        #expect(conditioning.referenceTextTokenIDs.ndim == 2)
+        #expect(conditioning.referenceTextTokenIDs.dim(1) > 0)
+        #expect(conditioning.resolvedLanguage == "english")
+        #expect(conditioning.codecLanguageID == 3057)
+    }
+
+    @Test func generateFromPreparedConditioningSupportsDirectAndStreamingCalls() async throws {
+        let fixture = try await makeTinyQwen3TTSModel(
+            ttsModelType: "voice_design",
+            includeSpeechEncoder: true
+        )
+        defer { cleanupTemporaryArtifactDirectory(fixture.tokenizerDirectory) }
+
+        let refAudio = try loadTTSNetworkFixture(sampleRate: 24_000, maxSamples: 24_000)
+        let conditioning = try fixture.model.prepareReferenceConditioning(
+            refAudio: refAudio,
+            refText: "one two three four five one two three four five",
+            language: "English"
+        )
+        let parameters = GenerateParameters(
+            maxTokens: 2,
+            temperature: 0.7,
+            topP: 0.95,
+            repetitionPenalty: 1.0
+        )
+
+        MLXRandom.seed(0)
+        let audio = try await fixture.model.generate(
+            text: "target voice prompt one two three four five",
+            conditioning: conditioning,
+            generationParameters: parameters
+        )
+        #expect(audio.ndim == 1)
+        #expect(audio.shape[0] > 0)
+
+        MLXRandom.seed(0)
+        let streamResult = try await collectQwen3TTSStream(
+            fixture.model.generateStream(
+                text: "target voice prompt one two three four five",
+                conditioning: conditioning,
+                generationParameters: parameters,
+                streamingInterval: 0.05
+            )
+        )
+        #expect(streamResult.tokenCount > 0)
+        #expect(streamResult.infoCount == 1)
+        #expect(streamResult.lastAudio != nil)
+        #expect(streamResult.lastAudio?.ndim == 1)
+    }
+
+    @Test func rawReferenceAPIsStillWorkThroughTheCompatibilityWrapper() async throws {
+        let fixture = try await makeTinyQwen3TTSModel(
+            ttsModelType: "voice_design",
+            includeSpeechEncoder: true
+        )
+        defer { cleanupTemporaryArtifactDirectory(fixture.tokenizerDirectory) }
+
+        let refAudio = try loadTTSNetworkFixture(sampleRate: 24_000, maxSamples: 24_000)
+        let parameters = GenerateParameters(
+            maxTokens: 2,
+            temperature: 0.7,
+            topP: 0.95,
+            repetitionPenalty: 1.0
+        )
+
+        MLXRandom.seed(0)
+        let rawAudio = try await fixture.model.generate(
+            text: "target voice prompt one two three four five",
+            voice: nil,
+            refAudio: refAudio,
+            refText: "one two three four five one two three four five",
+            language: "English",
+            generationParameters: parameters
+        )
+        #expect(rawAudio.ndim == 1)
+        #expect(rawAudio.shape[0] > 0)
+
+        MLXRandom.seed(0)
+        let streamResult = try await collectQwen3TTSStream(
+            fixture.model.generateStream(
+                text: "target voice prompt one two three four five",
+                voice: nil,
+                refAudio: refAudio,
+                refText: "one two three four five one two three four five",
+                language: "English",
+                generationParameters: parameters,
+                streamingInterval: 0.05
+            )
+        )
+        #expect(streamResult.tokenCount > 0)
+        #expect(streamResult.infoCount == 1)
+        #expect(streamResult.lastAudio != nil)
+        #expect(streamResult.lastAudio?.ndim == 1)
+    }
+
+    @Test func customVoiceRemainsSeparateFromReferenceConditioning() async throws {
+        let fixture = try await makeTinyQwen3TTSModel(
+            ttsModelType: "custom_voice",
+            includeSpeechEncoder: false,
+            speakerIDEntries: #""ryan": 100"#,
+            dialectEntries: #""ryan": false"#
+        )
+        defer { cleanupTemporaryArtifactDirectory(fixture.tokenizerDirectory) }
+
+        let parameters = GenerateParameters(
+            maxTokens: 2,
+            temperature: 0.7,
+            topP: 0.95,
+            repetitionPenalty: 1.0
+        )
+
+        let audio = try await fixture.model.generate(
+            text: "target voice prompt one two three four five",
+            voice: "ryan",
+            refAudio: nil,
+            refText: nil,
+            language: "English",
+            generationParameters: parameters
+        )
+        #expect(audio.ndim == 1)
+        #expect(audio.shape[0] > 0)
+
+        let refAudio = try loadTTSNetworkFixture(sampleRate: 24_000, maxSamples: 24_000)
+        #expect(throws: AudioGenerationError.self) {
+            try fixture.model.prepareReferenceConditioning(
+                refAudio: refAudio,
+                refText: "one two three four five one two three four five",
+                language: "English"
+            )
+        }
+    }
+}
 
 struct SopranoTextCleaningTests {
 


### PR DESCRIPTION
## Summary

- add a reusable `Qwen3TTSReferenceConditioning` surface for consumer-managed clone/reference preparation
- split reusable reference-side preparation from request-specific generation input assembly
- add generation overloads that accept `conditioning:`
- keep the existing `refAudio` / `refText` path routed through the same underlying implementation
- add tests covering the reusable conditioning flow

## Why

Presently, when the same `refAudio` and `refText` are reused across multiple generations, the model repeats the same conditioning work each time. This change adds a surface for consumers to do that work once, and receive a type containing the conditioning to store and reuse as they wish, without introducing instance-local cache state.

## Notes

This is the branch I referenced in #149, restored as a clean branch on top of current `main`.
