### PR TITLE
fix: restore AudioPlayer compatibility across Swift actor-isolation variants

### DIFF
--- a/Sources/MLXAudioCore/AudioPlayer.swift
+++ b/Sources/MLXAudioCore/AudioPlayer.swift
@@ -34,8 +34,10 @@ public class AudioPlayer: NSObject, ObservableObject {
         super.init()
     }
 
-    @MainActor deinit {
-        stop()
+    deinit {
+        MainActor.assumeIsolated {
+            stop()
+        }
     }
 
     // MARK: - Playback Control
@@ -389,16 +391,32 @@ public class AudioPlayer: NSObject, ObservableObject {
 @available(*, deprecated, renamed: "AudioPlayer", message: "Use AudioPlayer instead.")
 public typealias AudioPlayerManager = AudioPlayer
 
-extension AudioPlayer: @MainActor AVAudioPlayerDelegate {
-    public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+extension AudioPlayer: AVAudioPlayerDelegate {
+    public nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            self?.handleAudioPlayerDidFinishPlaying()
+        }
+    }
+
+    public nonisolated func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        let message = error?.localizedDescription ?? "unknown"
+        Task { @MainActor [weak self] in
+            self?.handleAudioPlayerDecodeError(message: message)
+        }
+    }
+}
+
+@MainActor
+private extension AudioPlayer {
+    func handleAudioPlayerDidFinishPlaying() {
         isPlaying = false
         setSpeaking(false)
         stopTimer()
         currentTime = 0
     }
 
-    public func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
-        print("Audio decode error: \(error?.localizedDescription ?? "unknown")")
+    func handleAudioPlayerDecodeError(message: String) {
+        print("Audio decode error: \(message)")
         isPlaying = false
         setSpeaking(false)
         stopTimer()


### PR DESCRIPTION
## Summary
- make `AVAudioPlayerDelegate` entrypoints `nonisolated` and hop state updates back to `MainActor`
- replace `@MainActor deinit` with `MainActor.assumeIsolated { stop() }`
- preserve `AudioPlayer` behavior while restoring compatibility across Swift actor-isolation variants

## Why
This keeps the change narrowly focused on `AudioPlayer.swift` and avoids broader packaging or tools-version changes.

The patch was validated in a downstream integration that vendors `mlx-audio-swift`, where these changes fixed compatibility issues in mixed Swift/Xcode environments without changing runtime playback behavior.

## Test Plan
- `swift build --target MLXAudioCore`