### PR TITLE
models: escape underscore member reads in EnglishG2P

### DIFF
--- a/Sources/MLXAudioTTS/Models/StyleTTS2/G2P/EnglishG2P.swift
+++ b/Sources/MLXAudioTTS/Models/StyleTTS2/G2P/EnglishG2P.swift
@@ -243,15 +243,15 @@ final class EnglishG2P {
   }
   
   func mergeTokens(_ tokens: [MToken], unk: String? = nil) -> MToken {
-    let stressSet = Set(tokens.compactMap { $0._.stress })
-    let currencySet = Set(tokens.compactMap { $0._.currency })
-    let ratings: Set<Int?> = Set(tokens.map { $0._.rating })
+    let stressSet = Set(tokens.compactMap { $0.`_`.stress })
+    let currencySet = Set(tokens.compactMap { $0.`_`.currency })
+    let ratings: Set<Int?> = Set(tokens.map { $0.`_`.rating })
         
     var phonemes: String? = nil
     if let unk {
       var phonemeBuilder = ""
       for token in tokens {
-        if token._.prespace,
+        if token.`_`.prespace,
            !phonemeBuilder.isEmpty,
            !(phonemeBuilder.last?.isWhitespace ?? false),
            token.phonemes != nil {
@@ -273,7 +273,7 @@ final class EnglishG2P {
     
     let tokenRangeStart = tokens.first!.tokenRange.lowerBound
     let tokenRangeEnd = tokens.last!.tokenRange.upperBound
-    let flagChars = Set(tokens.flatMap { Array($0._.num_flags) })
+    let flagChars = Set(tokens.flatMap { Array($0.`_`.num_flags) })
     
     return MToken(
       text: mergedText,
@@ -284,12 +284,12 @@ final class EnglishG2P {
       start_ts: tokens.first?.start_ts,
       end_ts: tokens.last?.end_ts,
       underscore: Underscore(
-        is_head: tokens.first?._.is_head ?? false,
+        is_head: tokens.first?.`_`.is_head ?? false,
         alias: nil,
         stress: (stressSet.count == 1 ? stressSet.first : nil),
         currency: currencySet.max(),
         num_flags: String(flagChars.sorted()),
-        prespace: tokens.first?._.prespace ?? false,
+        prespace: tokens.first?.`_`.prespace ?? false,
         rating: ratings.contains(where: { $0 == nil }) ? nil : ratings.compactMap { $0 }.min()
       )
     )


### PR DESCRIPTION
## Summary

- escape the remaining underscore-member reads in `EnglishG2P.swift`
- make those reads match the escaped underscore-member writes already used elsewhere in the file
- keep the change syntax-only with no behavior change

## Verification

- `swiftc -frontend -parse Sources/MLXAudioTTS/Models/StyleTTS2/G2P/EnglishG2P.swift`

Closes #160.
