### PR TITLE
Fix (Qwen3TTS): pass topK and minP from GenerateParameters

### DIFF
--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -626,10 +626,10 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
         VoiceDesignGenerationSettings(
             language: language ?? "auto",
             temperature: generationParameters.temperature,
-            topK: 50,
+            topK: generationParameters.topK,
             topP: generationParameters.topP,
             repetitionPenalty: generationParameters.repetitionPenalty ?? 1.05,
-            minP: 0.0,
+            minP: generationParameters.minP,
             maxTokens: generationParameters.maxTokens ?? 4096
         )
     }


### PR DESCRIPTION
Use `generationParameters.topK` and `generationParameters.minP` instead of hardcoded values (50 and 0.0) in `resolveVoiceDesignGenerationSettings`