### PR TITLE
Add MOSS-TTS-Nano model

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e6e5ffaf7f33f3270fa7160862700ba4774c432ab90a25e65f6ffc53c856351d",
+  "originHash" : "0de47e2efcfdbd2abb306b485c46d6fc9b94854ac10c7413ede360d5ad7e2260",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Sources/MLXAudioCore/SentencePieceTokenizer.swift
+++ b/Sources/MLXAudioCore/SentencePieceTokenizer.swift
@@ -9,6 +9,11 @@ enum SentencePiecePieceType: Int {
     case byte = 6
 }
 
+enum SentencePieceModelType: Int {
+    case unigram = 1
+    case bpe = 2
+}
+
 enum SentencePieceModelError: Error, CustomStringConvertible {
     case malformedVarint
     case truncatedField
@@ -100,10 +105,15 @@ struct SentencePieceProtobufReader {
 }
 
 struct SentencePieceModelParser {
-    static func parsePieces(from data: Data) throws -> (pieces: [SentencePieceToken], unknownTokenId: Int) {
+    static func parsePieces(from data: Data) throws -> (
+        pieces: [SentencePieceToken],
+        unknownTokenId: Int,
+        modelType: SentencePieceModelType
+    ) {
         var reader = SentencePieceProtobufReader(data)
         var pieces: [SentencePieceToken] = []
         var unknownTokenId: Int?
+        var modelType: SentencePieceModelType = .unigram
 
         while !reader.isAtEnd {
             let key = try reader.readVarint()
@@ -118,6 +128,9 @@ struct SentencePieceModelParser {
                     }
                     pieces.append(piece)
                 }
+            } else if fieldNumber == 2, wireType == 2 {
+                let trainerSpecData = try reader.readLengthDelimited()
+                modelType = try parseTrainerSpecModelType(from: trainerSpecData) ?? modelType
             } else {
                 try reader.skipField(wireType: wireType)
             }
@@ -130,7 +143,7 @@ struct SentencePieceModelParser {
         let resolvedUnknownId = unknownTokenId
             ?? pieces.firstIndex(where: { $0.token == "<unk>" })
             ?? 0
-        return (pieces, resolvedUnknownId)
+        return (pieces, resolvedUnknownId, modelType)
     }
 
     private static func parsePiece(from data: Data) throws -> SentencePieceToken? {
@@ -160,6 +173,21 @@ struct SentencePieceModelParser {
 
         guard let token else { return nil }
         return SentencePieceToken(token: token, score: score, type: type)
+    }
+
+    private static func parseTrainerSpecModelType(from data: Data) throws -> SentencePieceModelType? {
+        var reader = SentencePieceProtobufReader(data)
+        while !reader.isAtEnd {
+            let key = try reader.readVarint()
+            let fieldNumber = Int(key >> 3)
+            let wireType = key & 0x7
+
+            if fieldNumber == 3, wireType == 0 {
+                return SentencePieceModelType(rawValue: Int(try reader.readVarint()))
+            }
+            try reader.skipField(wireType: wireType)
+        }
+        return nil
     }
 }
 
@@ -349,16 +377,22 @@ enum TokenizerError: Error, CustomStringConvertible {
     }
 }
 
-public final class UnigramTokenizer {
+public final class SentencePieceTokenizer {
     let vocab: [SentencePieceToken]
     let unknownTokenId: Int
     let unknownTokenScore: Float
+    let modelType: SentencePieceModelType
     let tokensToIds: [String: Int]
     let trie: Trie
 
-    private init(vocab: [SentencePieceToken], unknownTokenId: Int) {
+    private init(
+        vocab: [SentencePieceToken],
+        unknownTokenId: Int,
+        modelType: SentencePieceModelType = .unigram
+    ) {
         self.vocab = vocab
         self.unknownTokenId = unknownTokenId
+        self.modelType = modelType
         let minScore = vocab.reduce(Float.greatestFiniteMagnitude) { min($0, $1.score) }
         self.unknownTokenScore = minScore - 10
 
@@ -395,7 +429,14 @@ public final class UnigramTokenizer {
             pieces.append(SentencePieceToken(token: token, score: Float(score)))
         }
 
-        self.init(vocab: pieces, unknownTokenId: unkId)
+        let modelType: SentencePieceModelType
+        if let type = model["type"] as? String, type.uppercased() == "BPE" {
+            modelType = .bpe
+        } else {
+            modelType = .unigram
+        }
+
+        self.init(vocab: pieces, unknownTokenId: unkId, modelType: modelType)
     }
 
     public convenience init(tokenizerJSONData: Data) throws {
@@ -405,18 +446,26 @@ public final class UnigramTokenizer {
 
     public convenience init(sentencePieceModelData: Data) throws {
         let parsed = try SentencePieceModelParser.parsePieces(from: sentencePieceModelData)
-        self.init(vocab: parsed.pieces, unknownTokenId: parsed.unknownTokenId)
+        self.init(
+            vocab: parsed.pieces,
+            unknownTokenId: parsed.unknownTokenId,
+            modelType: parsed.modelType
+        )
     }
 
-    public static func from(tokenizerJSONURL: URL) throws -> UnigramTokenizer {
-        try UnigramTokenizer(tokenizerJSONData: Data(contentsOf: tokenizerJSONURL))
+    public static func from(tokenizerJSONURL: URL) throws -> SentencePieceTokenizer {
+        try SentencePieceTokenizer(tokenizerJSONData: Data(contentsOf: tokenizerJSONURL))
     }
 
-    public static func from(sentencePieceModelURL: URL) throws -> UnigramTokenizer {
-        try UnigramTokenizer(sentencePieceModelData: Data(contentsOf: sentencePieceModelURL))
+    public static func from(sentencePieceModelURL: URL) throws -> SentencePieceTokenizer {
+        try SentencePieceTokenizer(sentencePieceModelData: Data(contentsOf: sentencePieceModelURL))
     }
 
     public func encodeWithByteFallback(_ text: String) -> [Int] {
+        if modelType == .bpe {
+            return encodeBPEWithByteFallback(text)
+        }
+
         let pre = applyMetaspace(text)
         var lattice = TokenLattice(sentence: pre, bosTokenId: unknownTokenId, eosTokenId: unknownTokenId)
 
@@ -457,6 +506,44 @@ public final class UnigramTokenizer {
                 }
             } else {
                 ids.append(node.tokenId)
+            }
+        }
+        return ids
+    }
+
+    private func encodeBPEWithByteFallback(_ text: String) -> [Int] {
+        let pre = applyMetaspace(text)
+        var symbols = initialBPESymbols(pre)
+
+        while symbols.count > 1 {
+            var bestIndex: Int?
+            var bestPiece = ""
+            var bestScore = -Float.infinity
+
+            for index in 0 ..< symbols.count - 1 {
+                let candidate = symbols[index] + symbols[index + 1]
+                guard let tokenId = tokensToIds[candidate] else { continue }
+                let token = vocab[tokenId]
+                guard token.type == .normal || token.type == .userDefined else { continue }
+                if bestIndex == nil || token.score > bestScore {
+                    bestIndex = index
+                    bestPiece = candidate
+                    bestScore = token.score
+                }
+            }
+
+            guard let index = bestIndex else { break }
+            symbols.replaceSubrange(index ... index + 1, with: [bestPiece])
+        }
+
+        var ids: [Int] = []
+        for symbol in symbols {
+            if let tokenId = tokensToIds[symbol] {
+                ids.append(tokenId)
+            } else {
+                for byte in symbol.utf8 {
+                    ids.append(byteMap[byte] ?? unknownTokenId)
+                }
             }
         }
         return ids
@@ -509,8 +596,34 @@ public final class UnigramTokenizer {
         return map
     }()
 
+    private lazy var bpeAtomicPieces: [String] = vocab
+        .filter { $0.type == .userDefined }
+        .map(\.token)
+        .sorted { $0.count > $1.count }
+
+    private func initialBPESymbols(_ text: String) -> [String] {
+        var symbols: [String] = []
+        var index = text.startIndex
+
+        while index < text.endIndex {
+            if let atomicPiece = bpeAtomicPieces.first(where: { text[index...].hasPrefix($0) }) {
+                symbols.append(atomicPiece)
+                index = text.index(index, offsetBy: atomicPiece.count)
+            } else {
+                let nextIndex = text.index(after: index)
+                symbols.append(String(text[index ..< nextIndex]))
+                index = nextIndex
+            }
+        }
+
+        return symbols
+    }
+
     private func applyMetaspace(_ text: String) -> String {
         let replaced = text.replacingOccurrences(of: " ", with: "▁")
         return "▁" + replaced
     }
 }
+
+@available(*, deprecated, renamed: "SentencePieceTokenizer")
+public typealias UnigramTokenizer = SentencePieceTokenizer

--- a/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribeTokenizer.swift
+++ b/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribeTokenizer.swift
@@ -3,7 +3,7 @@ import MLXAudioCore
 import MLXLMCommon
 
 public final class CohereTranscribeTokenizer {
-    private let tokenizer: UnigramTokenizer
+    private let tokenizer: SentencePieceTokenizer
     private let specialTokenToID: [String: Int]
     private let specialIDs: Set<Int>
 
@@ -11,7 +11,7 @@ public final class CohereTranscribeTokenizer {
         let tokenizerURL = modelDir.appendingPathComponent("tokenizer.model")
         let tokenizerConfigURL = modelDir.appendingPathComponent("tokenizer_config.json")
 
-        self.tokenizer = try UnigramTokenizer.from(sentencePieceModelURL: tokenizerURL)
+        self.tokenizer = try SentencePieceTokenizer.from(sentencePieceModelURL: tokenizerURL)
 
         let configData = try Data(contentsOf: tokenizerConfigURL)
         let parsed = try JSONDecoder().decode(CohereTokenizerConfig.self, from: configData)

--- a/Sources/MLXAudioSTT/Models/SenseVoice/SenseVoiceTokenizer.swift
+++ b/Sources/MLXAudioSTT/Models/SenseVoice/SenseVoiceTokenizer.swift
@@ -2,7 +2,7 @@ import Foundation
 import MLXAudioCore
 
 struct SenseVoiceTokenizer {
-    let tokenizer: UnigramTokenizer?
+    let tokenizer: SentencePieceTokenizer?
     let tokenList: [String]?
 
     init(modelDirectory: URL) throws {
@@ -18,9 +18,9 @@ struct SenseVoiceTokenizer {
         let tokensURL = modelDirectory.appendingPathComponent("tokens.json")
 
         if FileManager.default.fileExists(atPath: tokenizerURL.path) {
-            self.tokenizer = try UnigramTokenizer.from(tokenizerJSONURL: tokenizerURL)
+            self.tokenizer = try SentencePieceTokenizer.from(tokenizerJSONURL: tokenizerURL)
         } else if let sentencePieceURL {
-            self.tokenizer = try UnigramTokenizer.from(sentencePieceModelURL: sentencePieceURL)
+            self.tokenizer = try SentencePieceTokenizer.from(sentencePieceModelURL: sentencePieceURL)
         } else {
             self.tokenizer = nil
         }

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossAudioTokenizer.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossAudioTokenizer.swift
@@ -1,0 +1,1003 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+public let mossDefaultAudioTokenizerRepo = "mlx-community/MOSS-Audio-Tokenizer-Nano"
+
+public struct MossAudioTokenizerConfig: Sendable {
+    public var sampleRate: Int
+    public var samplingRate: Int
+    public var downsampleRate: Int
+    public var causalTransformerContextDuration: Float
+    public var numberChannels: Int
+    public var enableChannelInterleave: Bool
+    public var encoderKwargs: [[String: SendableValue]]
+    public var decoderKwargs: [[String: SendableValue]]
+    public var quantizerType: String
+    public var quantizerKwargs: [String: SendableValue]
+
+    public init(
+        sampleRate: Int = 48_000,
+        samplingRate: Int = 48_000,
+        downsampleRate: Int = 3_840,
+        causalTransformerContextDuration: Float = 10,
+        numberChannels: Int = 2,
+        enableChannelInterleave: Bool = true,
+        encoderKwargs: [[String: SendableValue]] = [],
+        decoderKwargs: [[String: SendableValue]] = [],
+        quantizerType: String = "rlfq",
+        quantizerKwargs: [String: SendableValue] = [:]
+    ) {
+        self.sampleRate = sampleRate
+        self.samplingRate = samplingRate
+        self.downsampleRate = downsampleRate
+        self.causalTransformerContextDuration = causalTransformerContextDuration
+        self.numberChannels = numberChannels
+        self.enableChannelInterleave = enableChannelInterleave
+        self.encoderKwargs = encoderKwargs
+        self.decoderKwargs = decoderKwargs
+        self.quantizerType = quantizerType
+        self.quantizerKwargs = quantizerKwargs
+    }
+
+    public static func fromFile(_ url: URL) throws -> MossAudioTokenizerConfig {
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        guard let json = object as? [String: Any] else {
+            throw MossTTSNanoError.invalidInput("Invalid MOSS audio tokenizer config.")
+        }
+        return try fromDictionary(json)
+    }
+
+    static func fromDictionary(_ json: [String: Any]) throws -> MossAudioTokenizerConfig {
+        let encoderKwargs = (json["encoder_kwargs"] as? [[String: Any]] ?? [])
+            .map { $0.mapValues(SendableValue.init) }
+        let decoderKwargs = (json["decoder_kwargs"] as? [[String: Any]] ?? [])
+            .map { $0.mapValues(SendableValue.init) }
+        let quantizerKwargs = (json["quantizer_kwargs"] as? [String: Any] ?? [:])
+            .mapValues(SendableValue.init)
+
+        return MossAudioTokenizerConfig(
+            sampleRate: json.mossInt("sample_rate", fallback: json.mossInt("sampling_rate", fallback: 48_000)),
+            samplingRate: json.mossInt("sampling_rate", fallback: json.mossInt("sample_rate", fallback: 48_000)),
+            downsampleRate: json.mossInt("downsample_rate", fallback: 3_840),
+            causalTransformerContextDuration: json.mossFloat("causal_transformer_context_duration", fallback: 10),
+            numberChannels: json.mossInt("number_channels", fallback: 2),
+            enableChannelInterleave: json.mossBool("enable_channel_interleave", fallback: true),
+            encoderKwargs: encoderKwargs,
+            decoderKwargs: decoderKwargs,
+            quantizerType: json.mossString("quantizer_type", fallback: "rlfq"),
+            quantizerKwargs: quantizerKwargs
+        )
+    }
+}
+
+public struct SendableValue: @unchecked Sendable {
+    let rawValue: Any
+
+    init(_ rawValue: Any) {
+        self.rawValue = rawValue
+    }
+}
+
+private extension Dictionary where Key == String, Value == Any {
+    func mossInt(_ key: String, fallback: Int) -> Int {
+        if let value = self[key] as? Int { return value }
+        if let value = self[key] as? Double { return Int(value) }
+        if let value = self[key] as? String, let parsed = Int(value) { return parsed }
+        return fallback
+    }
+
+    func mossFloat(_ key: String, fallback: Float) -> Float {
+        if let value = self[key] as? Float { return value }
+        if let value = self[key] as? Double { return Float(value) }
+        if let value = self[key] as? Int { return Float(value) }
+        if let value = self[key] as? String, let parsed = Float(value) { return parsed }
+        return fallback
+    }
+
+    func mossBool(_ key: String, fallback: Bool) -> Bool {
+        if let value = self[key] as? Bool { return value }
+        if let value = self[key] as? String { return ["true", "1", "yes"].contains(value.lowercased()) }
+        return fallback
+    }
+
+    func mossString(_ key: String, fallback: String) -> String {
+        (self[key] as? String) ?? fallback
+    }
+}
+
+private extension Dictionary where Key == String, Value == SendableValue {
+    func int(_ key: String, fallback: Int) -> Int {
+        asAny.mossInt(key, fallback: fallback)
+    }
+
+    func optionalInt(_ key: String) -> Int? {
+        let value = asAny[key]
+        if let value = value as? Int { return value }
+        if let value = value as? Double { return Int(value) }
+        if let value = value as? String { return Int(value) }
+        return nil
+    }
+
+    func float(_ key: String, fallback: Float) -> Float {
+        asAny.mossFloat(key, fallback: fallback)
+    }
+
+    func optionalFloat(_ key: String) -> Float? {
+        let value = asAny[key]
+        if let value = value as? Float { return value }
+        if let value = value as? Double { return Float(value) }
+        if let value = value as? Int { return Float(value) }
+        if let value = value as? String { return Float(value) }
+        return nil
+    }
+
+    func bool(_ key: String, fallback: Bool) -> Bool {
+        asAny.mossBool(key, fallback: fallback)
+    }
+
+    func string(_ key: String, fallback: String) -> String {
+        asAny.mossString(key, fallback: fallback)
+    }
+
+    var asAny: [String: Any] {
+        mapValues(\.rawValue)
+    }
+}
+
+private func mossNormalizeWeightExceptOutput(_ weight: MLXArray) -> MLXArray {
+    sqrt(sum(sum(square(weight), axis: 2, keepDims: true), axis: 1, keepDims: true))
+}
+
+private func mossL2Normalize(_ x: MLXArray, axis: Int = -1, eps: Float = 1e-12) -> MLXArray {
+    x / maximum(sqrt(sum(square(x), axis: axis, keepDims: true)), MLXArray(eps))
+}
+
+private func mossExactGELU(_ x: MLXArray) -> MLXArray {
+    MLXArray(0.5) * x * (MLXArray(1.0) + erf(x / MLXArray(Float(sqrt(2.0)))))
+}
+
+private final class MossWeightParam: Module {
+    @ModuleInfo(key: "original0") var original0: MLXArray
+    @ModuleInfo(key: "original1") var original1: MLXArray
+
+    init(outChannels: Int, inChannels: Int, kernelSize: Int) {
+        _original0.wrappedValue = MLXArray.ones([outChannels, 1, 1])
+        _original1.wrappedValue = MLXArray.zeros([outChannels, inChannels, kernelSize])
+    }
+}
+
+private final class MossWeightParametrizations: Module {
+    @ModuleInfo(key: "weight") var weight: MossWeightParam
+
+    init(outChannels: Int, inChannels: Int, kernelSize: Int) {
+        _weight.wrappedValue = MossWeightParam(
+            outChannels: outChannels,
+            inChannels: inChannels,
+            kernelSize: kernelSize
+        )
+    }
+}
+
+private final class MossWNConv1d: Module {
+    let stride = 1
+    let padding = 0
+    let dilation = 1
+
+    @ModuleInfo(key: "parametrizations") var parametrizations: MossWeightParametrizations
+    @ModuleInfo var bias: MLXArray
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int = 1) {
+        _parametrizations.wrappedValue = MossWeightParametrizations(
+            outChannels: outChannels,
+            inChannels: inChannels,
+            kernelSize: kernelSize
+        )
+        _bias.wrappedValue = MLXArray.zeros([outChannels])
+    }
+
+    private func sourceLayoutWeight() -> MLXArray {
+        let weightG = parametrizations.weight.original0
+        let weightV = parametrizations.weight.original1
+        return weightG * weightV / mossNormalizeWeightExceptOutput(weightV)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let weight = sourceLayoutWeight().transposed(0, 2, 1)
+        let y = MLX.conv1d(
+            x.transposed(0, 2, 1),
+            weight,
+            stride: stride,
+            padding: padding,
+            dilation: dilation
+        )
+        return (y + bias).transposed(0, 2, 1)
+    }
+}
+
+private final class MossLayerScale: Module {
+    @ModuleInfo var scale: MLXArray
+
+    init(channels: Int, initialValue: Float) {
+        _scale.wrappedValue = MLXArray.full([channels], values: MLXArray(initialValue), dtype: .float32)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        x * scale
+    }
+}
+
+private final class MossAudioIdentity: Module {}
+
+private func mossApplyLayerScale(_ module: Module, to x: MLXArray) -> MLXArray {
+    if let scale = module as? MossLayerScale {
+        return scale(x)
+    }
+    return x
+}
+
+private protocol MossAudioTokenizerStage: AnyObject {
+    var downsampleRatio: Int { get }
+    func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) throws -> (MLXArray, MLXArray)
+}
+
+private func mossApplyAudioRoPE(
+    q: MLXArray,
+    k: MLXArray,
+    maxPeriod: Float,
+    offset: Int = 0
+) -> (MLXArray, MLXArray) {
+    let time = q.dim(2)
+    let dim = q.dim(3)
+    let freqs = exp(
+        MLX.arange(dim / 2, dtype: .float32)
+            * (MLXArray(-log(maxPeriod) * 2.0 / Float(dim)))
+    )
+    let positions = (MLX.arange(time, dtype: .float32) + Float(offset))
+    let phase = positions.reshaped([1, 1, time, 1]) * freqs.reshaped([1, 1, 1, dim / 2])
+    let cosPhase = cos(phase)
+    let sinPhase = sin(phase)
+
+    let qPairs = q.asType(.float32).reshaped(q.shape.dropLast() + [dim / 2, 2])
+    let kPairs = k.asType(.float32).reshaped(k.shape.dropLast() + [dim / 2, 2])
+    let qr = qPairs[0..., 0..., 0..., 0..., 0]
+    let qi = qPairs[0..., 0..., 0..., 0..., 1]
+    let kr = kPairs[0..., 0..., 0..., 0..., 0]
+    let ki = kPairs[0..., 0..., 0..., 0..., 1]
+
+    let qOut = MLX.stacked([qr * cosPhase - qi * sinPhase, qr * sinPhase + qi * cosPhase], axis: -1)
+    let kOut = MLX.stacked([kr * cosPhase - ki * sinPhase, kr * sinPhase + ki * cosPhase], axis: -1)
+    return (qOut.reshaped(q.shape).asType(q.dtype), kOut.reshaped(k.shape).asType(k.dtype))
+}
+
+private final class MossAudioMultiheadAttention: Module {
+    let embedDim: Int
+    let numHeads: Int
+    let headDim: Int
+    let causal: Bool
+    let context: Int?
+    let maxPeriod: Float
+    let useRoPE: Bool
+    let scale: Float
+
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    init(
+        embedDim: Int,
+        numHeads: Int,
+        causal: Bool,
+        context: Int?,
+        maxPeriod: Float,
+        useRoPE: Bool
+    ) {
+        precondition(embedDim % numHeads == 0, "embed_dim must be divisible by num_heads")
+        self.embedDim = embedDim
+        self.numHeads = numHeads
+        self.headDim = embedDim / numHeads
+        self.causal = causal
+        self.context = context
+        self.maxPeriod = maxPeriod
+        self.useRoPE = useRoPE
+        self.scale = pow(Float(headDim), -0.5)
+        _inProj.wrappedValue = Linear(embedDim, 3 * embedDim, bias: false)
+        _outProj.wrappedValue = Linear(embedDim, embedDim, bias: false)
+    }
+
+    private func mask(inputLengths: MLXArray, maxSequenceLength: Int, dtype: DType) -> MLXArray {
+        let positions = MLXArray(0 ..< maxSequenceLength).asType(.int32)
+        var allowed = positions.reshaped([1, 1, 1, maxSequenceLength])
+            .< inputLengths.asType(.int32).reshaped([inputLengths.dim(0), 1, 1, 1])
+        let delta = positions.reshaped([1, 1, maxSequenceLength, 1])
+            - positions.reshaped([1, 1, 1, maxSequenceLength])
+        if causal {
+            allowed = logicalAnd(allowed, delta .>= MLXArray(Int32(0)))
+        }
+        if let context {
+            allowed = logicalAnd(allowed, delta .< MLXArray(Int32(context)))
+        }
+        let minimum = MLXArray(Float(dtype.finfo?.min ?? -Double.greatestFiniteMagnitude))
+        return MLX.where(allowed, MLXArray(0.0), minimum).asType(dtype)
+    }
+
+    func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let time = x.dim(1)
+        let qkv = inProj(x).reshaped(batch, time, 3, numHeads, headDim)
+        var q = qkv[0..., 0..., 0, 0..., 0...].transposed(0, 2, 1, 3)
+        var k = qkv[0..., 0..., 1, 0..., 0...].transposed(0, 2, 1, 3)
+        let v = qkv[0..., 0..., 2, 0..., 0...].transposed(0, 2, 1, 3)
+        if useRoPE {
+            (q, k) = mossApplyAudioRoPE(q: q, k: k, maxPeriod: maxPeriod)
+        }
+
+        var out = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: mask(inputLengths: inputLengths, maxSequenceLength: time, dtype: x.dtype)
+        )
+        let validQuery = MLXArray(0 ..< time).asType(.int32).reshaped([1, 1, time, 1])
+            .< inputLengths.asType(.int32).reshaped([inputLengths.dim(0), 1, 1, 1])
+        out = MLX.where(validQuery, out, MLXArray.zeros([], dtype: out.dtype))
+        out = out.transposed(0, 2, 1, 3).reshaped(batch, time, embedDim)
+        return outProj(out)
+    }
+}
+
+private final class MossAudioTransformerLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: MossAudioMultiheadAttention
+    @ModuleInfo var norm1: LayerNorm
+    @ModuleInfo var norm2: LayerNorm
+    @ModuleInfo var ffn: [Module]
+    @ModuleInfo(key: "layer_scale_1") var layerScale1: Module
+    @ModuleInfo(key: "layer_scale_2") var layerScale2: Module
+
+    init(
+        dModel: Int,
+        numHeads: Int,
+        dimFeedforward: Int,
+        causal: Bool,
+        context: Int?,
+        positionalEmbedding: String,
+        maxPeriod: Float,
+        layerScale: Float?,
+        norm: String
+    ) throws {
+        guard norm == "layer_norm" else {
+            throw MossTTSNanoError.invalidInput("Unsupported MOSS audio tokenizer norm: \(norm)")
+        }
+        _selfAttention.wrappedValue = MossAudioMultiheadAttention(
+            embedDim: dModel,
+            numHeads: numHeads,
+            causal: causal,
+            context: context,
+            maxPeriod: maxPeriod,
+            useRoPE: ["rope", "sin_rope"].contains(positionalEmbedding)
+        )
+        _norm1.wrappedValue = LayerNorm(dimensions: dModel, eps: 1e-5)
+        _norm2.wrappedValue = LayerNorm(dimensions: dModel, eps: 1e-5)
+        _ffn.wrappedValue = [
+            Linear(dModel, dimFeedforward, bias: false),
+            MossAudioIdentity(),
+            Linear(dimFeedforward, dModel, bias: false),
+        ]
+        if let layerScale {
+            _layerScale1.wrappedValue = MossLayerScale(channels: dModel, initialValue: layerScale)
+            _layerScale2.wrappedValue = MossLayerScale(channels: dModel, initialValue: layerScale)
+        } else {
+            _layerScale1.wrappedValue = MossAudioIdentity()
+            _layerScale2.wrappedValue = MossAudioIdentity()
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) -> MLXArray {
+        let residual = x
+        let attended = selfAttention(norm1(x), inputLengths: inputLengths)
+        var hidden = residual + mossApplyLayerScale(layerScale1, to: attended)
+        let mlpInput = norm2(hidden)
+        let fcIn = ffn[0] as! Linear
+        let fcOut = ffn[2] as! Linear
+        let mlpOut = fcOut(mossExactGELU(fcIn(mlpInput)))
+        hidden = hidden + mossApplyLayerScale(layerScale2, to: mlpOut)
+        return hidden
+    }
+}
+
+private final class MossAudioTransformer: Module {
+    let positionalEmbedding: String
+    let maxPeriod: Float
+    let positionalScale: Float
+
+    @ModuleInfo(key: "layers") var layers: [MossAudioTransformerLayer]
+
+    init(
+        dModel: Int,
+        numHeads: Int,
+        numLayers: Int,
+        dimFeedforward: Int,
+        causal: Bool,
+        context: Int?,
+        positionalEmbedding: String,
+        maxPeriod: Float,
+        positionalScale: Float,
+        layerScale: Float?,
+        norm: String,
+        gating: String
+    ) throws {
+        guard gating == "none" else {
+            throw MossTTSNanoError.invalidInput("Unsupported MOSS audio tokenizer gating: \(gating)")
+        }
+        self.positionalEmbedding = positionalEmbedding
+        self.maxPeriod = maxPeriod
+        self.positionalScale = positionalScale
+        _layers.wrappedValue = try (0 ..< numLayers).map { _ in
+            try MossAudioTransformerLayer(
+                dModel: dModel,
+                numHeads: numHeads,
+                dimFeedforward: dimFeedforward,
+                causal: causal,
+                context: context,
+                positionalEmbedding: positionalEmbedding,
+                maxPeriod: maxPeriod,
+                layerScale: layerScale,
+                norm: norm
+            )
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) -> MLXArray {
+        var hidden = x
+        if ["sin", "sin_rope"].contains(positionalEmbedding) {
+            let positions = MLX.arange(hidden.dim(1), dtype: hidden.dtype)
+            let half = hidden.dim(2) / 2
+            let scale = pow(MLXArray(maxPeriod), MLX.arange(half, dtype: hidden.dtype) / MLXArray(Float(max(half - 1, 1))))
+            let phase = positions.reshaped([hidden.dim(1), 1]) / scale.reshaped([1, half])
+            let emb = MLX.concatenated([cos(phase), sin(phase)], axis: -1)
+            hidden = hidden + MLXArray(positionalScale).asType(hidden.dtype) * emb.expandedDimensions(axis: 0)
+        }
+        for layer in layers {
+            hidden = layer(hidden, inputLengths: inputLengths)
+        }
+        return hidden
+    }
+}
+
+private final class MossProjectedTransformer: Module, MossAudioTokenizerStage {
+    let downsampleRatio = 1
+
+    @ModuleInfo(key: "input_proj") var inputProj: Linear
+    @ModuleInfo var transformer: MossAudioTransformer
+    @ModuleInfo(key: "output_proj") var outputProj: Linear
+
+    init(kwargs: [String: SendableValue], context: Int) throws {
+        let inputDimension = kwargs.int("input_dimension", fallback: 0)
+        let outputDimension = kwargs.int("output_dimension", fallback: 0)
+        let dModel = kwargs.int("d_model", fallback: 0)
+        _inputProj.wrappedValue = Linear(inputDimension, dModel, bias: false)
+        _transformer.wrappedValue = try MossAudioTransformer(
+            dModel: dModel,
+            numHeads: kwargs.int("num_heads", fallback: 1),
+            numLayers: kwargs.int("num_layers", fallback: 1),
+            dimFeedforward: kwargs.int("dim_feedforward", fallback: 4 * dModel),
+            causal: kwargs.bool("causal", fallback: true),
+            context: context,
+            positionalEmbedding: kwargs.string("positional_embedding", fallback: "rope"),
+            maxPeriod: kwargs.float("max_period", fallback: 10_000),
+            positionalScale: kwargs.float("positional_scale", fallback: 1),
+            layerScale: kwargs.optionalFloat("layer_scale"),
+            norm: kwargs.string("norm", fallback: "layer_norm"),
+            gating: kwargs.string("gating", fallback: "none")
+        )
+        _outputProj.wrappedValue = Linear(dModel, outputDimension, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) throws -> (MLXArray, MLXArray) {
+        var hidden = inputProj(x.transposed(0, 2, 1))
+        hidden = transformer(hidden, inputLengths: inputLengths)
+        let output = outputProj(hidden)
+        return (output.transposed(0, 2, 1), inputLengths)
+    }
+}
+
+private final class MossPatchedPretransform: Module, MossAudioTokenizerStage {
+    let patchSize: Int
+    let isDownsample: Bool
+    var downsampleRatio: Int { patchSize }
+
+    init(patchSize: Int, isDownsample: Bool) {
+        self.patchSize = patchSize
+        self.isDownsample = isDownsample
+    }
+
+    func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) throws -> (MLXArray, MLXArray) {
+        let batch = x.dim(0)
+        if isDownsample {
+            let channels = x.dim(1)
+            var hidden = x.reshaped(batch, channels, -1, patchSize)
+            hidden = hidden.transposed(0, 1, 3, 2).reshaped(batch, channels * patchSize, -1)
+            return (hidden, inputLengths / MLXArray(Int32(patchSize)))
+        } else {
+            let channelsPatch = x.dim(1)
+            let length = x.dim(2)
+            let channels = channelsPatch / patchSize
+            var hidden = x.reshaped(batch, channels, patchSize, length)
+            hidden = hidden.transposed(0, 1, 3, 2).reshaped(batch, channels, length * patchSize)
+            return (hidden, inputLengths * MLXArray(Int32(patchSize)))
+        }
+    }
+}
+
+private final class MossLFQ: Module {
+    let inputDim: Int
+    let codebookSize: Int
+    let codebookDim: Int
+
+    @ModuleInfo(key: "in_proj") var inProj: MossWNConv1d
+    @ModuleInfo(key: "out_proj") var outProj: MossWNConv1d
+    @ModuleInfo var codebook: Embedding
+
+    init(inputDim: Int, codebookSize: Int, codebookDim: Int) {
+        self.inputDim = inputDim
+        self.codebookSize = codebookSize
+        self.codebookDim = codebookDim
+        _inProj.wrappedValue = MossWNConv1d(inChannels: inputDim, outChannels: codebookDim, kernelSize: 1)
+        _outProj.wrappedValue = MossWNConv1d(inChannels: codebookDim, outChannels: inputDim, kernelSize: 1)
+        _codebook.wrappedValue = Embedding(embeddingCount: codebookSize, dimensions: codebookDim)
+    }
+
+    func decodeCodeWithoutOutProjection(_ embedID: MLXArray) -> MLXArray {
+        codebook(embedID).transposed(0, 2, 1)
+    }
+
+    func decodeCode(_ embedID: MLXArray) -> MLXArray {
+        outProj(decodeCodeWithoutOutProjection(embedID).asType(.float32))
+    }
+
+    func decodeLatents(_ latents: MLXArray) -> (MLXArray, MLXArray) {
+        var encodings = latents.transposed(0, 2, 1).reshaped(-1, latents.dim(1))
+        var codebookWeight = codebook.weight.asType(.float32)
+        encodings = mossL2Normalize(encodings.asType(.float32), axis: -1)
+        codebookWeight = mossL2Normalize(codebookWeight, axis: -1)
+        let dist = sum(square(encodings), axis: 1, keepDims: true)
+            - 2.0 * matmul(encodings, codebookWeight.transposed(1, 0))
+            + sum(square(codebookWeight), axis: 1, keepDims: true).transposed(1, 0)
+        let indices = argMax(-dist, axis: 1).reshaped(latents.dim(0), -1)
+        return (decodeCodeWithoutOutProjection(indices).asType(.float32), indices)
+    }
+
+    func callAsFunction(_ z: MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+        let zE = inProj(z.asType(.float32)).asType(.float32)
+        let decoded = decodeLatents(zE)
+        let zQ = outProj(decoded.0.asType(.float32)).asType(.float32)
+        return (zQ, decoded.1, zE)
+    }
+}
+
+private final class MossResidualLFQ: Module {
+    let inputDim: Int
+    let rvqDim: Int
+    let outputDim: Int
+    let numQuantizers: Int
+    let codebookSize: Int
+    let codebookDim: Int
+
+    @ModuleInfo(key: "input_proj") var inputProj: MossWNConv1d
+    @ModuleInfo(key: "output_proj") var outputProj: MossWNConv1d
+    @ModuleInfo var quantizers: [MossLFQ]
+
+    init(kwargs: [String: SendableValue]) {
+        let resolvedInputDim = kwargs.int("input_dim", fallback: 1_024)
+        let resolvedRVQDim = kwargs.int("rvq_dim", fallback: resolvedInputDim)
+        let resolvedOutputDim = kwargs.int("output_dim", fallback: resolvedInputDim)
+        let resolvedNumQuantizers = kwargs.int("num_quantizers", fallback: 32)
+        let resolvedCodebookSize = kwargs.int("codebook_size", fallback: 1_024)
+        let resolvedCodebookDim = kwargs.int("codebook_dim", fallback: 8)
+        self.inputDim = resolvedInputDim
+        self.rvqDim = resolvedRVQDim
+        self.outputDim = resolvedOutputDim
+        self.numQuantizers = resolvedNumQuantizers
+        self.codebookSize = resolvedCodebookSize
+        self.codebookDim = resolvedCodebookDim
+        _inputProj.wrappedValue = MossWNConv1d(inChannels: inputDim, outChannels: rvqDim, kernelSize: 1)
+        _outputProj.wrappedValue = MossWNConv1d(inChannels: rvqDim, outChannels: outputDim, kernelSize: 1)
+        _quantizers.wrappedValue = (0 ..< resolvedNumQuantizers).map { _ in
+            MossLFQ(
+                inputDim: resolvedRVQDim,
+                codebookSize: resolvedCodebookSize,
+                codebookDim: resolvedCodebookDim
+            )
+        }
+    }
+
+    func callAsFunction(
+        _ z: MLXArray,
+        inputLength: MLXArray,
+        nQuantizers: Int? = nil
+    ) -> (MLXArray, MLXArray, MLXArray) {
+        let projected = inputProj(z.asType(.float32)).asType(.float32)
+        let batch = projected.dim(0)
+        let maxTime = projected.dim(2)
+        let mask = MLXArray(0 ..< maxTime).asType(.int32).reshaped([1, maxTime])
+            .< inputLength.asType(.int32).reshaped([inputLength.dim(0), 1])
+        let updateMask = mask.expandedDimensions(axis: 1)
+        var quantizedOut = MLXArray.zeros(projected.shape, dtype: .float32)
+        var residual = projected
+        var indices: [MLXArray] = []
+        let activeQuantizers = min(nQuantizers ?? numQuantizers, numQuantizers)
+        for quantizer in quantizers.prefix(activeQuantizers) {
+            let (zQI, indicesI, _) = quantizer(residual * updateMask)
+            quantizedOut = quantizedOut + zQI * updateMask
+            residual = residual - zQI * updateMask
+            indices.append(indicesI)
+        }
+
+        let allIndices = indices.isEmpty
+            ? MLXArray.zeros([0, batch, maxTime], type: Int32.self)
+            : MLX.stacked(indices, axis: 0).asType(.int32)
+        return (outputProj(quantizedOut).asType(.float32), allIndices, inputLength)
+    }
+
+    func decodeCodes(_ codes: MLXArray) -> MLXArray {
+        let nq = codes.dim(0)
+        let batch = codes.dim(1)
+        let time = codes.dim(2)
+        var emb = MLXArray.zeros([batch, rvqDim, time], dtype: .float32)
+        for (index, quantizer) in quantizers.prefix(nq).enumerated() {
+            emb = emb + quantizer.decodeCode(codes[index]).asType(.float32)
+        }
+        return outputProj(emb).asType(.float32)
+    }
+}
+
+public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecked Sendable {
+    public let config: MossAudioTokenizerConfig
+    public let sampleRate: Int
+    public let samplingRate: Int
+    public let downsampleRate: Int
+    public let channels: Int
+    public let enableChannelInterleave: Bool
+    public let numQuantizers: Int
+
+    @ModuleInfo var encoder: [Module]
+    @ModuleInfo fileprivate var quantizer: MossResidualLFQ
+    @ModuleInfo var decoder: [Module]
+
+    public init(config: MossAudioTokenizerConfig) throws {
+        self.config = config
+        self.sampleRate = config.sampleRate
+        self.samplingRate = config.samplingRate
+        self.downsampleRate = config.downsampleRate
+        self.channels = config.numberChannels
+        self.enableChannelInterleave = config.enableChannelInterleave
+
+        let channelFactor = enableChannelInterleave && channels > 1 ? channels : 1
+        var currentFrameRate = Double(samplingRate * channelFactor)
+        var encoderStages: [Module] = []
+        for kwargs in config.encoderKwargs {
+            let stage = try Self.makeStage(
+                kwargs: kwargs,
+                isDownsample: true,
+                currentFrameRate: currentFrameRate,
+                config: config
+            )
+            encoderStages.append(stage.module)
+            currentFrameRate /= Double(stage.downsampleRatio)
+        }
+
+        let quantizerType = config.quantizerKwargs.string("quantizer_type", fallback: config.quantizerType)
+        guard ["rlfq", "random_prefix_rlfq"].contains(quantizerType) else {
+            throw MossTTSNanoError.invalidInput("Unsupported MOSS quantizer_type: \(quantizerType)")
+        }
+        let quantizer = MossResidualLFQ(kwargs: config.quantizerKwargs)
+        self.numQuantizers = quantizer.numQuantizers
+
+        var decoderStages: [Module] = []
+        for kwargs in config.decoderKwargs {
+            let stage = try Self.makeStage(
+                kwargs: kwargs,
+                isDownsample: false,
+                currentFrameRate: currentFrameRate,
+                config: config
+            )
+            decoderStages.append(stage.module)
+            currentFrameRate *= Double(stage.downsampleRatio)
+        }
+
+        _encoder.wrappedValue = encoderStages
+        _quantizer.wrappedValue = quantizer
+        _decoder.wrappedValue = decoderStages
+    }
+
+    private static func makeStage(
+        kwargs: [String: SendableValue],
+        isDownsample: Bool,
+        currentFrameRate: Double,
+        config: MossAudioTokenizerConfig
+    ) throws -> (module: Module, downsampleRatio: Int) {
+        let moduleType = kwargs.string("module_type", fallback: "")
+        switch moduleType {
+        case "PatchedPretransform":
+            let module = MossPatchedPretransform(
+                patchSize: kwargs.int("patch_size", fallback: 1),
+                isDownsample: isDownsample
+            )
+            return (module, module.downsampleRatio)
+        case "Transformer":
+            let contextDuration = kwargs.float(
+                "context_duration",
+                fallback: config.causalTransformerContextDuration
+            )
+            let context = Int(round(currentFrameRate * Double(contextDuration)))
+            let module = try MossProjectedTransformer(kwargs: kwargs, context: context)
+            return (module, module.downsampleRatio)
+        default:
+            throw MossTTSNanoError.invalidInput("Unsupported MOSS audio tokenizer module_type: \(moduleType)")
+        }
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) throws -> MLXMossAudioTokenizer {
+        let config = try MossAudioTokenizerConfig.fromFile(modelDir.appendingPathComponent("config.json"))
+        let model = try MLXMossAudioTokenizer(config: config)
+        let weights = try loadWeights(from: modelDir)
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: .all)
+        eval(model)
+        return model
+    }
+
+    public static func fromPretrained(
+        _ source: String = mossDefaultAudioTokenizerRepo,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> MLXMossAudioTokenizer {
+        guard let repoID = Repo.ID(rawValue: source) else {
+            let url = URL(fileURLWithPath: NSString(string: source).expandingTildeInPath)
+            return try fromModelDirectory(url)
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["*.json", "*.index.json", "*.md"],
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try fromModelDirectory(modelDir)
+    }
+
+    private func prepareAudioArray(_ audio: MLXArray) throws -> MLXArray {
+        var shape = audio.shape
+        var samples = audio.asType(.float32).asArray(Float.self)
+        var sampleCount: Int
+        var channelCount: Int
+        if audio.ndim == 1 {
+            sampleCount = audio.dim(0)
+            channelCount = 1
+        } else if audio.ndim == 2 {
+            if audio.dim(0) <= 8 && audio.dim(0) < audio.dim(1) {
+                channelCount = audio.dim(0)
+                sampleCount = audio.dim(1)
+                var transposed = Array(repeating: Float(0), count: samples.count)
+                for ch in 0 ..< channelCount {
+                    for i in 0 ..< sampleCount {
+                        transposed[i * channelCount + ch] = samples[ch * sampleCount + i]
+                    }
+                }
+                samples = transposed
+                shape = [sampleCount, channelCount]
+            } else {
+                sampleCount = audio.dim(0)
+                channelCount = audio.dim(1)
+            }
+        } else {
+            throw MossTTSNanoError.invalidInput("Unsupported audio shape: \(audio.shape)")
+        }
+
+        if channelCount != channels {
+            if channelCount == 1 && channels > 1 {
+                var repeated = Array(repeating: Float(0), count: sampleCount * channels)
+                for i in 0 ..< sampleCount {
+                    for ch in 0 ..< channels {
+                        repeated[i * channels + ch] = samples[i]
+                    }
+                }
+                samples = repeated
+                channelCount = channels
+            } else if channelCount > 1 && channels == 1 {
+                var mono = Array(repeating: Float(0), count: sampleCount)
+                for i in 0 ..< sampleCount {
+                    var sum: Float = 0
+                    for ch in 0 ..< channelCount {
+                        sum += samples[i * channelCount + ch]
+                    }
+                    mono[i] = sum / Float(channelCount)
+                }
+                samples = mono
+                channelCount = 1
+            } else {
+                throw MossTTSNanoError.invalidInput(
+                    "Unsupported reference audio channel conversion: \(channelCount) -> \(channels)"
+                )
+            }
+            shape = [sampleCount, channelCount]
+        }
+
+        var channelFirst = Array(repeating: Float(0), count: sampleCount * channelCount)
+        for i in 0 ..< sampleCount {
+            for ch in 0 ..< channelCount {
+                channelFirst[ch * sampleCount + i] = samples[i * channelCount + ch]
+            }
+        }
+        _ = shape
+        return MLXArray(channelFirst, [channelCount, sampleCount]).asType(.float32)
+    }
+
+    private func prepareWaveformBatch(_ waveforms: [MLXArray]) throws -> (MLXArray, MLXArray) {
+        guard !waveforms.isEmpty else {
+            throw MossTTSNanoError.invalidInput("waveforms must not be empty")
+        }
+        let lengths = waveforms.map { $0.dim($0.ndim - 1) }
+        let maxLength = lengths.max() ?? 0
+        var padded: [MLXArray] = []
+        for waveform in waveforms {
+            var current = waveform.ndim == 1 ? waveform.expandedDimensions(axis: 0) : waveform
+            guard current.dim(0) == channels else {
+                throw MossTTSNanoError.invalidInput("Expected waveform shape [\(channels), samples], got \(current.shape)")
+            }
+            let pad = maxLength - current.dim(1)
+            if pad > 0 {
+                current = MLX.padded(current, widths: [.init(0), .init((0, pad))])
+            }
+            padded.append(current)
+        }
+        return (
+            MLX.stacked(padded, axis: 0),
+            MLXArray(lengths.map(Int32.init)).asType(.int32)
+        )
+    }
+
+    private func prepareCodesBatch(
+        _ codesList: [MLXArray],
+        numQuantizers: Int?
+    ) throws -> (MLXArray, MLXArray, Int) {
+        guard !codesList.isEmpty else {
+            throw MossTTSNanoError.invalidInput("codesList must not be empty")
+        }
+        let available = codesList.map { $0.dim(0) }
+        let effectiveNQ = numQuantizers ?? available[0]
+        guard (available.min() ?? 0) >= effectiveNQ else {
+            throw MossTTSNanoError.invalidInput("numQuantizers=\(effectiveNQ) exceeds available quantizers")
+        }
+        let lengths = codesList.map { $0.dim($0.ndim - 1) }
+        let maxLength = lengths.max() ?? 0
+        var flat = Array(repeating: Int32(0), count: effectiveNQ * codesList.count * maxLength)
+        for (batchIndex, codes) in codesList.enumerated() {
+            let time = codes.dim(1)
+            let values = codes.asType(.int32).asArray(Int32.self)
+            for q in 0 ..< effectiveNQ {
+                for t in 0 ..< time {
+                    flat[(q * codesList.count + batchIndex) * maxLength + t] = values[q * time + t]
+                }
+            }
+        }
+        return (
+            MLXArray(flat, [effectiveNQ, codesList.count, maxLength]).asType(.int32),
+            MLXArray(lengths.map(Int32.init)).asType(.int32),
+            effectiveNQ
+        )
+    }
+
+    private func flattenChannelsForCodec(
+        inputValues: MLXArray,
+        inputLengths: MLXArray
+    ) -> (MLXArray, MLXArray) {
+        var values = inputValues
+        var lengths = inputLengths
+        let remainder = values.dim(2) % downsampleRate
+        if remainder != 0 {
+            let padLength = downsampleRate - remainder
+            values = MLX.padded(values, widths: [.init(0), .init(0), .init((0, padLength))])
+        }
+        if channels > 1 && enableChannelInterleave {
+            values = values.transposed(0, 2, 1).reshaped(values.dim(0), 1, -1)
+            lengths = lengths * MLXArray(Int32(channels))
+        }
+        return (values, lengths)
+    }
+
+    private func restoreChannelsFromCodec(
+        outputValues: MLXArray,
+        outputLengths: MLXArray
+    ) -> (MLXArray, MLXArray) {
+        guard channels > 1 && enableChannelInterleave else {
+            return (outputValues.asType(.float32), outputLengths)
+        }
+        let batch = outputValues.dim(0)
+        var values = outputValues[0..., 0, 0...].reshaped(batch, -1, channels)
+        values = values.transposed(0, 2, 1).asType(.float32)
+        return (values, outputLengths / MLXArray(Int32(channels)))
+    }
+
+    private func encodeFrame(
+        inputValues: MLXArray,
+        inputLengths: MLXArray? = nil,
+        nQuantizers: Int? = nil
+    ) throws -> (MLXArray, MLXArray, MLXArray) {
+        var values = inputValues
+        if values.ndim == 1 {
+            values = values.reshaped(1, 1, -1)
+        } else if values.ndim == 2 {
+            values = channels == 1 ? values.expandedDimensions(axis: 1) : values.expandedDimensions(axis: 0)
+        }
+        let lengths = inputLengths ?? MLX.full(
+            [values.dim(0)],
+            values: Int32(values.dim(2)),
+            type: Int32.self
+        )
+        var (hidden, hiddenLengths) = flattenChannelsForCodec(inputValues: values, inputLengths: lengths)
+        for module in encoder {
+            let stage = module as! MossAudioTokenizerStage
+            (hidden, hiddenLengths) = try stage(hidden, inputLengths: hiddenLengths)
+        }
+        let result = quantizer(hidden.asType(.float32), inputLength: hiddenLengths, nQuantizers: nQuantizers)
+        return (result.1, result.2, hidden.asType(.float32))
+    }
+
+    private func decodeFrame(
+        codes: MLXArray,
+        codesLengths: MLXArray? = nil
+    ) throws -> (MLXArray, MLXArray) {
+        guard codes.ndim == 3 else {
+            throw MossTTSNanoError.invalidInput("Expected codes shape [nq, batch, time], got \(codes.shape)")
+        }
+        let lengths = codesLengths ?? MLX.full([codes.dim(1)], values: Int32(codes.dim(2)), type: Int32.self)
+        var audio = quantizer.decodeCodes(codes.asType(.int32))
+        var audioLengths = lengths
+        for module in decoder {
+            let stage = module as! MossAudioTokenizerStage
+            (audio, audioLengths) = try stage(audio, inputLengths: audioLengths)
+        }
+        return restoreChannelsFromCodec(outputValues: audio, outputLengths: audioLengths)
+    }
+
+    public func encodeAudio(_ audio: MLXArray, numQuantizers: Int) throws -> MLXArray {
+        let waveform = try prepareAudioArray(audio)
+        let batch = try prepareWaveformBatch([waveform])
+        let encoded = try encodeFrame(
+            inputValues: batch.0,
+            inputLengths: batch.1,
+            nQuantizers: numQuantizers
+        )
+        eval(encoded.0, encoded.1)
+        let codeLength = encoded.1.asArray(Int32.self).first.map(Int.init) ?? encoded.0.dim(2)
+        return encoded.0[0..., 0, 0..<codeLength].transposed(1, 0).asType(.int32)
+    }
+
+    public func decodeAudioCodes(_ audioTokenIDs: MLXArray, numQuantizers: Int) throws -> MLXArray {
+        var codes = audioTokenIDs.asType(.int32)
+        if codes.ndim == 3 {
+            guard codes.dim(0) == 1 else {
+                throw MossTTSNanoError.notImplemented("Batched MOSS audio-tokenizer decode is not implemented.")
+            }
+            codes = codes[0]
+        }
+        guard codes.ndim == 2 else {
+            throw MossTTSNanoError.invalidInput("Expected codes shape [frames, nq], got \(codes.shape)")
+        }
+        guard codes.dim(0) > 0 else {
+            return MLXArray.zeros([0, channels], dtype: .float32)
+        }
+        let effectiveNQ = min(numQuantizers, codes.dim(1))
+        let prepared = try prepareCodesBatch(
+            [codes[0..., 0..<effectiveNQ].transposed(1, 0)],
+            numQuantizers: effectiveNQ
+        )
+        let decoded = try decodeFrame(codes: prepared.0, codesLengths: prepared.1)
+        eval(decoded.0, decoded.1)
+        let audioLength = decoded.1.asArray(Int32.self).first.map(Int.init) ?? decoded.0.dim(2)
+        return decoded.0[0, 0..., 0..<audioLength].transposed(1, 0).asType(.float32)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossGPT2.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossGPT2.swift
@@ -1,0 +1,263 @@
+import Foundation
+@preconcurrency import MLX
+import MLXFast
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+final class MossRotaryEmbedding: @unchecked Sendable {
+    private let cosCache: MLXArray
+    private let sinCache: MLXArray
+
+    init(headDim: Int, ropeBase: Float, maxPositionEmbeddings: Int) {
+        precondition(headDim % 2 == 0, "RoPE head dimension must be even")
+        let invFreq = 1.0 / pow(
+            MLXArray(ropeBase),
+            MLX.arange(0, headDim, step: 2, dtype: .float32) / MLXArray(Float(headDim))
+        )
+        let positions = MLX.arange(maxPositionEmbeddings, dtype: .float32)
+        let angles = MLX.outer(positions, invFreq)
+        self.cosCache = cos(angles)
+        self.sinCache = sin(angles)
+    }
+
+    func apply(_ x: MLXArray, offset: Int = 0) -> MLXArray {
+        let sequenceLength = x.dim(2)
+        let cosValues = cosCache[offset..<(offset + sequenceLength), 0...]
+            .reshaped([1, 1, sequenceLength, cosCache.dim(1)])
+            .asType(x.dtype)
+        let sinValues = sinCache[offset..<(offset + sequenceLength), 0...]
+            .reshaped([1, 1, sequenceLength, sinCache.dim(1)])
+            .asType(x.dtype)
+
+        let reshaped = x.reshaped(x.shape.dropLast() + [x.shape.last! / 2, 2])
+        let xEven = reshaped[0..., 0..., 0..., 0..., 0]
+        let xOdd = reshaped[0..., 0..., 0..., 0..., 1]
+        let rotated = MLX.stacked([
+            xEven * cosValues - xOdd * sinValues,
+            xOdd * cosValues + xEven * sinValues,
+        ], axis: -1)
+        return rotated.reshaped(x.shape)
+    }
+}
+
+private func mossCausalAdditiveMask(
+    queryLength: Int,
+    keyLength: Int,
+    dtype: DType,
+    attentionMask: MLXArray?
+) -> MLXArray {
+    let offset = max(keyLength - queryLength, 0)
+    let queryPositions = (MLXArray(0 ..< queryLength) + MLXArray(offset)).reshaped([queryLength, 1])
+    let keyPositions = MLXArray(0 ..< keyLength).reshaped([1, keyLength])
+    let visible = keyPositions .<= queryPositions
+    let minimum = MLXArray(Float(dtype.finfo?.min ?? -Double.greatestFiniteMagnitude))
+    var mask = MLX.where(visible, MLXArray(0.0), minimum).asType(dtype)
+        .reshaped([1, 1, queryLength, keyLength])
+
+    if let attentionMask {
+        let keyMask = attentionMask.asType(.bool).reshaped([attentionMask.dim(0), 1, 1, attentionMask.dim(1)])
+        let keyAdditive = MLX.where(keyMask, MLXArray(0.0), minimum).asType(dtype)
+        mask = mask + keyAdditive
+    }
+    return mask
+}
+
+private final class MossGPT2Attention: Module {
+    let embedDim: Int
+    let numHeads: Int
+    let headDim: Int
+    let scale: Float
+    let rope: MossRotaryEmbedding?
+
+    @ModuleInfo(key: "c_attn") var cAttn: Linear
+    @ModuleInfo(key: "c_proj") var cProj: Linear
+
+    init(config: MossGPT2Config, layerIndex: Int) {
+        precondition(config.nEmbd % config.nHead == 0, "n_embd must be divisible by n_head")
+        self.embedDim = config.nEmbd
+        self.numHeads = config.nHead
+        self.headDim = config.nEmbd / config.nHead
+        var scale = config.scaleAttnWeights ? pow(Float(headDim), -0.5) : 1.0
+        if config.scaleAttnByInverseLayerIdx {
+            scale /= Float(layerIndex + 1)
+        }
+        self.scale = scale
+        if config.positionEmbeddingType.lowercased() == "rope" {
+            self.rope = MossRotaryEmbedding(
+                headDim: headDim,
+                ropeBase: config.ropeBase,
+                maxPositionEmbeddings: config.nPositions
+            )
+        } else {
+            self.rope = nil
+        }
+
+        _cAttn.wrappedValue = Linear(embedDim, 3 * embedDim, bias: true)
+        _cProj.wrappedValue = Linear(embedDim, embedDim, bias: true)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        attentionMask: MLXArray? = nil,
+        cache: (any KVCache)? = nil
+    ) -> MLXArray {
+        let batchSize = x.dim(0)
+        let queryLength = x.dim(1)
+        let qkv = cAttn(x)
+
+        var queries = qkv[0..., 0..., ..<embedDim]
+        var keys = qkv[0..., 0..., embedDim..<(2 * embedDim)]
+        var values = qkv[0..., 0..., (2 * embedDim)...]
+
+        queries = queries.reshaped(batchSize, queryLength, numHeads, headDim).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(batchSize, queryLength, numHeads, headDim).transposed(0, 2, 1, 3)
+        values = values.reshaped(batchSize, queryLength, numHeads, headDim).transposed(0, 2, 1, 3)
+
+        let offset = cache?.offset ?? 0
+        if let rope {
+            queries = rope.apply(queries, offset: offset)
+            keys = rope.apply(keys, offset: offset)
+        }
+
+        if let cache {
+            (keys, values) = cache.update(keys: keys, values: values)
+        }
+
+        let keyLength = keys.dim(2)
+        let mask = mossCausalAdditiveMask(
+            queryLength: queryLength,
+            keyLength: keyLength,
+            dtype: x.dtype,
+            attentionMask: attentionMask
+        )
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: mask
+        )
+        return cProj(output.transposed(0, 2, 1, 3).reshaped(batchSize, queryLength, embedDim))
+    }
+}
+
+private final class MossGPT2MLP: Module {
+    let activationFunction: String
+
+    @ModuleInfo(key: "fc_in") var fcIn: Linear
+    @ModuleInfo(key: "fc_out") var fcOut: Linear
+
+    init(config: MossGPT2Config) {
+        self.activationFunction = config.activationFunction
+        _fcIn.wrappedValue = Linear(config.nEmbd, config.intermediateSize, bias: true)
+        _fcOut.wrappedValue = Linear(config.intermediateSize, config.nEmbd, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let hidden = fcIn(x)
+        if activationFunction == "gelu_new" {
+            return fcOut(MLXNN.geluApproximate(hidden))
+        }
+        return fcOut(MLXNN.gelu(hidden))
+    }
+}
+
+private final class MossGPT2Block: Module {
+    @ModuleInfo(key: "ln_1") var ln1: LayerNorm
+    @ModuleInfo(key: "attn") var attention: MossGPT2Attention
+    @ModuleInfo(key: "ln_2") var ln2: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: MossGPT2MLP
+
+    init(config: MossGPT2Config, layerIndex: Int) {
+        _ln1.wrappedValue = LayerNorm(dimensions: config.nEmbd, eps: config.layerNormEpsilon)
+        _attention.wrappedValue = MossGPT2Attention(config: config, layerIndex: layerIndex)
+        _ln2.wrappedValue = LayerNorm(dimensions: config.nEmbd, eps: config.layerNormEpsilon)
+        _mlp.wrappedValue = MossGPT2MLP(config: config)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        attentionMask: MLXArray? = nil,
+        cache: (any KVCache)? = nil
+    ) -> MLXArray {
+        let h = x + attention(ln1(x), attentionMask: attentionMask, cache: cache)
+        return h + mlp(ln2(h))
+    }
+}
+
+final class MossGPT2Model: Module {
+    let config: MossGPT2Config
+    fileprivate let h: [MossGPT2Block]
+
+    @ModuleInfo(key: "wte") var wte: Embedding?
+    @ModuleInfo(key: "wpe") var wpe: Embedding?
+    @ModuleInfo(key: "ln_f") var lnF: LayerNorm
+
+    init(config: MossGPT2Config, useTokenEmbedding: Bool = true) {
+        self.config = config
+        if useTokenEmbedding {
+            _wte.wrappedValue = Embedding(embeddingCount: config.vocabSize, dimensions: config.nEmbd)
+        } else {
+            _wte.wrappedValue = nil
+        }
+        if config.positionEmbeddingType.lowercased() == "absolute" {
+            _wpe.wrappedValue = Embedding(embeddingCount: config.nPositions, dimensions: config.nEmbd)
+        } else {
+            _wpe.wrappedValue = nil
+        }
+        self.h = (0 ..< config.nLayer).map { MossGPT2Block(config: config, layerIndex: $0) }
+        _lnF.wrappedValue = LayerNorm(dimensions: config.nEmbd, eps: config.layerNormEpsilon)
+    }
+
+    var tokenEmbeddingWeight: MLXArray {
+        get throws {
+            guard let wte else {
+                throw MossTTSNanoError.invalidInput("GPT-2 token embedding is not available.")
+            }
+            return wte.weight
+        }
+    }
+
+    func tokenEmbedding(_ inputIDs: MLXArray) throws -> MLXArray {
+        guard let wte else {
+            throw MossTTSNanoError.invalidInput("GPT-2 token embedding is not available.")
+        }
+        return wte(inputIDs)
+    }
+
+    func makeCache() -> [any KVCache] {
+        h.map { _ in KVCacheSimple() }
+    }
+
+    func callAsFunction(
+        inputIDs: MLXArray? = nil,
+        inputsEmbeds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil,
+        cache: [any KVCache]? = nil
+    ) throws -> MLXArray {
+        var hiddenStates: MLXArray
+        if let inputsEmbeds {
+            hiddenStates = inputsEmbeds
+        } else if let inputIDs {
+            hiddenStates = try tokenEmbedding(inputIDs)
+        } else {
+            throw MossTTSNanoError.invalidInput("inputIDs or inputsEmbeds are required.")
+        }
+
+        if let wpe {
+            let seqLen = hiddenStates.dim(1)
+            let offset = cache?.first?.offset ?? 0
+            let positionIDs = MLXArray(Int32(offset)..<Int32(offset + seqLen))
+            hiddenStates = hiddenStates + wpe(positionIDs)
+        }
+
+        for (index, block) in h.enumerated() {
+            hiddenStates = block(
+                hiddenStates,
+                attentionMask: attentionMask,
+                cache: cache?[index]
+            )
+        }
+        return lnF(hiddenStates)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoConfig.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoConfig.swift
@@ -1,0 +1,356 @@
+import Foundation
+
+public struct MossGPT2Config: Codable, Sendable {
+    public var modelType: String
+    public var vocabSize: Int
+    public var nPositions: Int
+    public var nCtx: Int
+    public var nEmbd: Int
+    public var nLayer: Int
+    public var nHead: Int
+    public var nInner: Int?
+    public var activationFunction: String
+    public var residPdrop: Float
+    public var embdPdrop: Float
+    public var attnPdrop: Float
+    public var layerNormEpsilon: Float
+    public var initializerRange: Float
+    public var scaleAttnWeights: Bool
+    public var scaleAttnByInverseLayerIdx: Bool
+    public var positionEmbeddingType: String
+    public var ropeBase: Float
+    public var padTokenID: Int
+    public var bosTokenID: Int
+    public var eosTokenID: Int
+    public var tieWordEmbeddings: Bool
+    public var useCache: Bool
+
+    public init(
+        modelType: String = "gpt2",
+        vocabSize: Int = 16_384,
+        nPositions: Int = 32_768,
+        nCtx: Int = 32_768,
+        nEmbd: Int = 768,
+        nLayer: Int = 12,
+        nHead: Int = 12,
+        nInner: Int? = 3_072,
+        activationFunction: String = "gelu_new",
+        residPdrop: Float = 0,
+        embdPdrop: Float = 0,
+        attnPdrop: Float = 0,
+        layerNormEpsilon: Float = 1e-5,
+        initializerRange: Float = 0.02,
+        scaleAttnWeights: Bool = true,
+        scaleAttnByInverseLayerIdx: Bool = false,
+        positionEmbeddingType: String = "rope",
+        ropeBase: Float = 10_000,
+        padTokenID: Int = 3,
+        bosTokenID: Int = 1,
+        eosTokenID: Int = 2,
+        tieWordEmbeddings: Bool = true,
+        useCache: Bool = true
+    ) {
+        self.modelType = modelType
+        self.vocabSize = vocabSize
+        self.nPositions = nPositions
+        self.nCtx = nCtx
+        self.nEmbd = nEmbd
+        self.nLayer = nLayer
+        self.nHead = nHead
+        self.nInner = nInner
+        self.activationFunction = activationFunction
+        self.residPdrop = residPdrop
+        self.embdPdrop = embdPdrop
+        self.attnPdrop = attnPdrop
+        self.layerNormEpsilon = layerNormEpsilon
+        self.initializerRange = initializerRange
+        self.scaleAttnWeights = scaleAttnWeights
+        self.scaleAttnByInverseLayerIdx = scaleAttnByInverseLayerIdx
+        self.positionEmbeddingType = positionEmbeddingType
+        self.ropeBase = ropeBase
+        self.padTokenID = padTokenID
+        self.bosTokenID = bosTokenID
+        self.eosTokenID = eosTokenID
+        self.tieWordEmbeddings = tieWordEmbeddings
+        self.useCache = useCache
+    }
+
+    public var hiddenSize: Int { nEmbd }
+    public var numAttentionHeads: Int { nHead }
+    public var headDim: Int { nEmbd / nHead }
+    public var intermediateSize: Int { nInner ?? 4 * nEmbd }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case vocabSize = "vocab_size"
+        case nPositions = "n_positions"
+        case nCtx = "n_ctx"
+        case nEmbd = "n_embd"
+        case nLayer = "n_layer"
+        case nHead = "n_head"
+        case nInner = "n_inner"
+        case activationFunction = "activation_function"
+        case residPdrop = "resid_pdrop"
+        case embdPdrop = "embd_pdrop"
+        case attnPdrop = "attn_pdrop"
+        case layerNormEpsilon = "layer_norm_epsilon"
+        case initializerRange = "initializer_range"
+        case scaleAttnWeights = "scale_attn_weights"
+        case scaleAttnByInverseLayerIdx = "scale_attn_by_inverse_layer_idx"
+        case positionEmbeddingType = "position_embedding_type"
+        case ropeBase = "rope_base"
+        case padTokenID = "pad_token_id"
+        case bosTokenID = "bos_token_id"
+        case eosTokenID = "eos_token_id"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case useCache = "use_cache"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case intermediateSize = "intermediate_size"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gpt2"
+        self.vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 16_384
+        self.nPositions = try c.decodeIfPresent(Int.self, forKey: .nPositions) ?? 32_768
+        self.nCtx = try c.decodeIfPresent(Int.self, forKey: .nCtx) ?? nPositions
+        self.nEmbd = try c.decodeIfPresent(Int.self, forKey: .nEmbd)
+            ?? c.decodeIfPresent(Int.self, forKey: .hiddenSize)
+            ?? 768
+        self.nLayer = try c.decodeIfPresent(Int.self, forKey: .nLayer)
+            ?? c.decodeIfPresent(Int.self, forKey: .numHiddenLayers)
+            ?? 12
+        self.nHead = try c.decodeIfPresent(Int.self, forKey: .nHead)
+            ?? c.decodeIfPresent(Int.self, forKey: .numAttentionHeads)
+            ?? 12
+        self.nInner = try c.decodeIfPresent(Int.self, forKey: .nInner)
+            ?? c.decodeIfPresent(Int.self, forKey: .intermediateSize)
+            ?? 3_072
+        self.activationFunction = try c.decodeIfPresent(String.self, forKey: .activationFunction) ?? "gelu_new"
+        self.residPdrop = try c.decodeIfPresent(Float.self, forKey: .residPdrop) ?? 0
+        self.embdPdrop = try c.decodeIfPresent(Float.self, forKey: .embdPdrop) ?? 0
+        self.attnPdrop = try c.decodeIfPresent(Float.self, forKey: .attnPdrop) ?? 0
+        self.layerNormEpsilon = try c.decodeIfPresent(Float.self, forKey: .layerNormEpsilon) ?? 1e-5
+        self.initializerRange = try c.decodeIfPresent(Float.self, forKey: .initializerRange) ?? 0.02
+        self.scaleAttnWeights = try c.decodeIfPresent(Bool.self, forKey: .scaleAttnWeights) ?? true
+        self.scaleAttnByInverseLayerIdx = try c.decodeIfPresent(Bool.self, forKey: .scaleAttnByInverseLayerIdx) ?? false
+        self.positionEmbeddingType = try c.decodeIfPresent(String.self, forKey: .positionEmbeddingType) ?? "rope"
+        self.ropeBase = try c.decodeIfPresent(Float.self, forKey: .ropeBase) ?? 10_000
+        self.padTokenID = try c.decodeIfPresent(Int.self, forKey: .padTokenID) ?? 3
+        self.bosTokenID = try c.decodeIfPresent(Int.self, forKey: .bosTokenID) ?? 1
+        self.eosTokenID = try c.decodeIfPresent(Int.self, forKey: .eosTokenID) ?? 2
+        self.tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+        self.useCache = try c.decodeIfPresent(Bool.self, forKey: .useCache) ?? true
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(modelType, forKey: .modelType)
+        try c.encode(vocabSize, forKey: .vocabSize)
+        try c.encode(nPositions, forKey: .nPositions)
+        try c.encode(nCtx, forKey: .nCtx)
+        try c.encode(nEmbd, forKey: .nEmbd)
+        try c.encode(nLayer, forKey: .nLayer)
+        try c.encode(nHead, forKey: .nHead)
+        try c.encodeIfPresent(nInner, forKey: .nInner)
+        try c.encode(activationFunction, forKey: .activationFunction)
+        try c.encode(residPdrop, forKey: .residPdrop)
+        try c.encode(embdPdrop, forKey: .embdPdrop)
+        try c.encode(attnPdrop, forKey: .attnPdrop)
+        try c.encode(layerNormEpsilon, forKey: .layerNormEpsilon)
+        try c.encode(initializerRange, forKey: .initializerRange)
+        try c.encode(scaleAttnWeights, forKey: .scaleAttnWeights)
+        try c.encode(scaleAttnByInverseLayerIdx, forKey: .scaleAttnByInverseLayerIdx)
+        try c.encode(positionEmbeddingType, forKey: .positionEmbeddingType)
+        try c.encode(ropeBase, forKey: .ropeBase)
+        try c.encode(padTokenID, forKey: .padTokenID)
+        try c.encode(bosTokenID, forKey: .bosTokenID)
+        try c.encode(eosTokenID, forKey: .eosTokenID)
+        try c.encode(tieWordEmbeddings, forKey: .tieWordEmbeddings)
+        try c.encode(useCache, forKey: .useCache)
+    }
+}
+
+public struct MossTTSNanoConfig: Codable, Sendable {
+    public var modelType: String
+    public var modelPath: String?
+    public var gpt2Config: MossGPT2Config
+    public var nVQ: Int
+    public var audioVocabSize: Int
+    public var audioCodebookSizes: [Int]
+    public var audioPadTokenID: Int
+    public var padTokenID: Int
+    public var imStartTokenID: Int
+    public var imEndTokenID: Int
+    public var audioStartTokenID: Int
+    public var audioEndTokenID: Int
+    public var audioUserSlotTokenID: Int
+    public var audioAssistantSlotTokenID: Int
+    public var audioTokenizerType: String
+    public var audioTokenizerPretrainedNameOrPath: String?
+    public var audioTokenizerSampleRate: Int
+    public var tokenizerUseFast: Bool
+    public var attnImplementation: String
+    public var localTransformerLayers: Int
+    public var localTransformerAttnImplementation: String
+    public var initializerRange: Float
+    public var maxPositionEmbeddings: Int
+    public var hiddenSize: Int
+    public var vocabSize: Int
+
+    public init(
+        modelType: String = "moss_tts_nano",
+        modelPath: String? = nil,
+        gpt2Config: MossGPT2Config = MossGPT2Config(),
+        nVQ: Int = 16,
+        audioVocabSize: Int = 1_024,
+        audioCodebookSizes: [Int]? = nil,
+        audioPadTokenID: Int = 1_024,
+        padTokenID: Int = 3,
+        imStartTokenID: Int = 4,
+        imEndTokenID: Int = 5,
+        audioStartTokenID: Int = 6,
+        audioEndTokenID: Int = 7,
+        audioUserSlotTokenID: Int = 8,
+        audioAssistantSlotTokenID: Int = 9,
+        audioTokenizerType: String = "moss-audio-tokenizer-nano",
+        audioTokenizerPretrainedNameOrPath: String? = nil,
+        audioTokenizerSampleRate: Int = 48_000,
+        tokenizerUseFast: Bool = false,
+        attnImplementation: String = "sdpa",
+        localTransformerLayers: Int = 1,
+        localTransformerAttnImplementation: String? = nil,
+        initializerRange: Float = 0.02,
+        maxPositionEmbeddings: Int? = nil,
+        hiddenSize: Int? = nil,
+        vocabSize: Int? = nil
+    ) throws {
+        let sizes = audioCodebookSizes ?? Array(repeating: audioVocabSize, count: nVQ)
+        guard sizes.count == nVQ else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: [],
+                debugDescription: "audio_codebook_sizes must have one entry per VQ channel"
+            ))
+        }
+
+        self.modelType = modelType
+        self.modelPath = modelPath
+        self.gpt2Config = gpt2Config
+        self.nVQ = nVQ
+        self.audioVocabSize = audioVocabSize
+        self.audioCodebookSizes = sizes
+        self.audioPadTokenID = audioPadTokenID
+        self.padTokenID = padTokenID
+        self.imStartTokenID = imStartTokenID
+        self.imEndTokenID = imEndTokenID
+        self.audioStartTokenID = audioStartTokenID
+        self.audioEndTokenID = audioEndTokenID
+        self.audioUserSlotTokenID = audioUserSlotTokenID
+        self.audioAssistantSlotTokenID = audioAssistantSlotTokenID
+        self.audioTokenizerType = audioTokenizerType
+        self.audioTokenizerPretrainedNameOrPath = audioTokenizerPretrainedNameOrPath
+        self.audioTokenizerSampleRate = audioTokenizerSampleRate
+        self.tokenizerUseFast = tokenizerUseFast
+        self.attnImplementation = attnImplementation
+        self.localTransformerLayers = localTransformerLayers
+        self.localTransformerAttnImplementation = localTransformerAttnImplementation ?? attnImplementation
+        self.initializerRange = initializerRange
+        self.maxPositionEmbeddings = maxPositionEmbeddings ?? gpt2Config.nPositions
+        self.hiddenSize = hiddenSize ?? gpt2Config.nEmbd
+        self.vocabSize = vocabSize ?? gpt2Config.vocabSize
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case modelPath = "model_path"
+        case gpt2Config = "gpt2_config"
+        case nVQ = "n_vq"
+        case audioVocabSize = "audio_vocab_size"
+        case audioCodebookSizes = "audio_codebook_sizes"
+        case audioPadTokenID = "audio_pad_token_id"
+        case padTokenID = "pad_token_id"
+        case imStartTokenID = "im_start_token_id"
+        case imEndTokenID = "im_end_token_id"
+        case audioStartTokenID = "audio_start_token_id"
+        case audioEndTokenID = "audio_end_token_id"
+        case audioUserSlotTokenID = "audio_user_slot_token_id"
+        case audioAssistantSlotTokenID = "audio_assistant_slot_token_id"
+        case audioTokenizerType = "audio_tokenizer_type"
+        case audioTokenizerPretrainedNameOrPath = "audio_tokenizer_pretrained_name_or_path"
+        case audioTokenizerSampleRate = "audio_tokenizer_sample_rate"
+        case tokenizerUseFast = "tokenizer_use_fast"
+        case attnImplementation = "attn_implementation"
+        case localTransformerLayers = "local_transformer_layers"
+        case localTransformerAttnImplementation = "local_transformer_attn_implementation"
+        case initializerRange = "initializer_range"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case hiddenSize = "hidden_size"
+        case vocabSize = "vocab_size"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let gpt = try c.decodeIfPresent(MossGPT2Config.self, forKey: .gpt2Config) ?? MossGPT2Config()
+        let nVQ = try c.decodeIfPresent(Int.self, forKey: .nVQ) ?? 16
+        let audioVocabSize = try c.decodeIfPresent(Int.self, forKey: .audioVocabSize) ?? 1_024
+        let audioCodebookSizes = try c.decodeIfPresent([Int].self, forKey: .audioCodebookSizes)
+
+        try self.init(
+            modelType: "moss_tts_nano",
+            modelPath: try c.decodeIfPresent(String.self, forKey: .modelPath),
+            gpt2Config: gpt,
+            nVQ: nVQ,
+            audioVocabSize: audioVocabSize,
+            audioCodebookSizes: audioCodebookSizes,
+            audioPadTokenID: try c.decodeIfPresent(Int.self, forKey: .audioPadTokenID) ?? 1_024,
+            padTokenID: try c.decodeIfPresent(Int.self, forKey: .padTokenID) ?? 3,
+            imStartTokenID: try c.decodeIfPresent(Int.self, forKey: .imStartTokenID) ?? 4,
+            imEndTokenID: try c.decodeIfPresent(Int.self, forKey: .imEndTokenID) ?? 5,
+            audioStartTokenID: try c.decodeIfPresent(Int.self, forKey: .audioStartTokenID) ?? 6,
+            audioEndTokenID: try c.decodeIfPresent(Int.self, forKey: .audioEndTokenID) ?? 7,
+            audioUserSlotTokenID: try c.decodeIfPresent(Int.self, forKey: .audioUserSlotTokenID) ?? 8,
+            audioAssistantSlotTokenID: try c.decodeIfPresent(Int.self, forKey: .audioAssistantSlotTokenID) ?? 9,
+            audioTokenizerType: try c.decodeIfPresent(String.self, forKey: .audioTokenizerType) ?? "moss-audio-tokenizer-nano",
+            audioTokenizerPretrainedNameOrPath: try c.decodeIfPresent(String.self, forKey: .audioTokenizerPretrainedNameOrPath),
+            audioTokenizerSampleRate: try c.decodeIfPresent(Int.self, forKey: .audioTokenizerSampleRate) ?? 48_000,
+            tokenizerUseFast: try c.decodeIfPresent(Bool.self, forKey: .tokenizerUseFast) ?? false,
+            attnImplementation: try c.decodeIfPresent(String.self, forKey: .attnImplementation) ?? "sdpa",
+            localTransformerLayers: try c.decodeIfPresent(Int.self, forKey: .localTransformerLayers) ?? 1,
+            localTransformerAttnImplementation: try c.decodeIfPresent(String.self, forKey: .localTransformerAttnImplementation),
+            initializerRange: try c.decodeIfPresent(Float.self, forKey: .initializerRange) ?? 0.02,
+            maxPositionEmbeddings: try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings),
+            hiddenSize: try c.decodeIfPresent(Int.self, forKey: .hiddenSize),
+            vocabSize: try c.decodeIfPresent(Int.self, forKey: .vocabSize)
+        )
+    }
+
+    public func localGPT2Config() -> MossGPT2Config {
+        MossGPT2Config(
+            modelType: gpt2Config.modelType,
+            vocabSize: gpt2Config.vocabSize,
+            nPositions: nVQ + 1,
+            nCtx: nVQ + 1,
+            nEmbd: gpt2Config.nEmbd,
+            nLayer: localTransformerLayers,
+            nHead: gpt2Config.nHead,
+            nInner: gpt2Config.nInner,
+            activationFunction: gpt2Config.activationFunction,
+            residPdrop: gpt2Config.residPdrop,
+            embdPdrop: gpt2Config.embdPdrop,
+            attnPdrop: gpt2Config.attnPdrop,
+            layerNormEpsilon: gpt2Config.layerNormEpsilon,
+            initializerRange: gpt2Config.initializerRange,
+            scaleAttnWeights: gpt2Config.scaleAttnWeights,
+            scaleAttnByInverseLayerIdx: gpt2Config.scaleAttnByInverseLayerIdx,
+            positionEmbeddingType: gpt2Config.positionEmbeddingType,
+            ropeBase: gpt2Config.ropeBase,
+            padTokenID: gpt2Config.padTokenID,
+            bosTokenID: gpt2Config.bosTokenID,
+            eosTokenID: gpt2Config.eosTokenID,
+            tieWordEmbeddings: gpt2Config.tieWordEmbeddings,
+            useCache: gpt2Config.useCache
+        )
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoError.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum MossTTSNanoError: Error, CustomStringConvertible {
+    case invalidInput(String)
+    case notImplemented(String)
+    case tokenizerNotInitialized
+    case audioTokenizerNotInitialized
+
+    public var description: String {
+        switch self {
+        case .invalidInput(let message):
+            message
+        case .notImplemented(let message):
+            message
+        case .tokenizerNotInitialized:
+            "MOSS-TTS-Nano tokenizer is not initialized."
+        case .audioTokenizerNotInitialized:
+            "MOSS-TTS-Nano audio tokenizer is not initialized."
+        }
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoModel.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoModel.swift
@@ -1,0 +1,580 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+public protocol MossAudioTokenizing: AnyObject {
+    func encodeAudio(_ audio: MLXArray, numQuantizers: Int) throws -> MLXArray
+    func decodeAudioCodes(_ audioTokenIDs: MLXArray, numQuantizers: Int) throws -> MLXArray
+}
+
+public final class MossTTSNanoModel: Module, SpeechGenerationModel, @unchecked Sendable {
+    public let config: MossTTSNanoConfig
+
+    @ModuleInfo(key: "transformer") var transformer: MossGPT2Model
+    @ModuleInfo(key: "audio_embeddings") var audioEmbeddings: [Embedding]
+    @ModuleInfo(key: "local_transformer") var localTransformer: MossGPT2Model
+
+    public var tokenizer: MossTextTokenizing?
+    public var audioTokenizer: MossAudioTokenizing?
+
+    public var sampleRate: Int { config.audioTokenizerSampleRate }
+
+    public var defaultGenerationParameters: GenerateParameters {
+        GenerateParameters(
+            maxTokens: 375,
+            temperature: 0.7,
+            topP: 0.9,
+            topK: 50,
+            repetitionPenalty: 1.1
+        )
+    }
+
+    public init(config: MossTTSNanoConfig) {
+        self.config = config
+        _transformer.wrappedValue = MossGPT2Model(config: config.gpt2Config, useTokenEmbedding: true)
+        _audioEmbeddings.wrappedValue = config.audioCodebookSizes.map {
+            Embedding(embeddingCount: $0, dimensions: config.gpt2Config.nEmbd)
+        }
+        _localTransformer.wrappedValue = MossGPT2Model(config: config.localGPT2Config(), useTokenEmbedding: false)
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.filter { key, _ in
+            if key == "text_lm_head.weight" { return false }
+            if key.hasPrefix("audio_lm_heads.") { return false }
+            if key == "local_transformer.wte.weight" { return false }
+            if key.hasPrefix("transformer.wpe."), transformer.wpe == nil { return false }
+            if key.hasPrefix("local_transformer.wpe."), localTransformer.wpe == nil { return false }
+            return true
+        }
+    }
+
+    public func encodeReferenceAudio(
+        _ refAudio: MLXArray,
+        numQuantizers: Int? = nil
+    ) throws -> MLXArray {
+        guard let audioTokenizer else {
+            throw MossTTSNanoError.audioTokenizerNotInitialized
+        }
+        return try audioTokenizer.encodeAudio(
+            refAudio,
+            numQuantizers: numQuantizers ?? config.nVQ
+        )
+    }
+
+    public func decodeAudioTokenIDs(
+        _ audioTokenIDs: MLXArray,
+        numQuantizers: Int? = nil
+    ) throws -> MLXArray {
+        guard let audioTokenizer else {
+            throw MossTTSNanoError.audioTokenizerNotInitialized
+        }
+        return try audioTokenizer.decodeAudioCodes(
+            audioTokenIDs,
+            numQuantizers: numQuantizers ?? config.nVQ
+        )
+    }
+
+    private func ensureAudioTokenizer() async throws {
+        if audioTokenizer != nil { return }
+        if let modelPath = config.modelPath {
+            let audioTokenizerDirectory = URL(fileURLWithPath: modelPath)
+                .appendingPathComponent("audio_tokenizer", isDirectory: true)
+            if FileManager.default.fileExists(
+                atPath: audioTokenizerDirectory.appendingPathComponent("config.json").path
+            ) {
+                audioTokenizer = try MLXMossAudioTokenizer.fromModelDirectory(audioTokenizerDirectory)
+                return
+            }
+        }
+        let source = resolvedAudioTokenizerSource()
+        audioTokenizer = try await MLXMossAudioTokenizer.fromPretrained(source)
+    }
+
+    private func resolvedAudioTokenizerSource() -> String {
+        guard let source = config.audioTokenizerPretrainedNameOrPath?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !source.isEmpty
+        else {
+            return mossDefaultAudioTokenizerRepo
+        }
+
+        if source.lowercased() == "openmoss-team/moss-audio-tokenizer-nano" {
+            return mossDefaultAudioTokenizerRepo
+        }
+        return source
+    }
+
+    func textLMHead(_ hiddenStates: MLXArray) throws -> MLXArray {
+        try matmul(hiddenStates, transformer.tokenEmbeddingWeight.transposed(1, 0))
+    }
+
+    func audioLMHead(_ hiddenStates: MLXArray, channelIndex: Int) -> MLXArray {
+        matmul(hiddenStates, audioEmbeddings[channelIndex].weight.transposed(1, 0))
+    }
+
+    public func buildInputsEmbeds(_ inputIDs: MLXArray) throws -> MLXArray {
+        guard inputIDs.ndim == 3, inputIDs.dim(2) == config.nVQ + 1 else {
+            throw MossTTSNanoError.invalidInput(
+                "Expected inputIDs shape [batch, seq, \(config.nVQ + 1)], got \(inputIDs.shape)"
+            )
+        }
+
+        let textIDs = inputIDs[0..., 0..., 0]
+        var inputsEmbeds = try transformer.tokenEmbedding(textIDs)
+        for (channelIndex, embedding) in audioEmbeddings.enumerated() {
+            let channelIDs = inputIDs[0..., 0..., channelIndex + 1]
+            let validMask = channelIDs .!= MLXArray(Int32(config.audioPadTokenID))
+            let safeIDs = MLX.where(validMask, channelIDs, MLXArray(Int32(0)))
+            let audioEmbeds = embedding(safeIDs)
+            inputsEmbeds = inputsEmbeds + audioEmbeds * validMask.expandedDimensions(axis: -1).asType(inputsEmbeds.dtype)
+        }
+        return inputsEmbeds
+    }
+
+    public func buildTextRows(_ tokenIDs: [Int]) -> MLXArray {
+        let rowWidth = config.nVQ + 1
+        guard !tokenIDs.isEmpty else {
+            return MLXArray.zeros([0, rowWidth], type: Int32.self)
+        }
+
+        var rows = Array(repeating: Int32(config.audioPadTokenID), count: tokenIDs.count * rowWidth)
+        for (rowIndex, tokenID) in tokenIDs.enumerated() {
+            rows[rowIndex * rowWidth] = Int32(tokenID)
+        }
+        return MLXArray(rows, [tokenIDs.count, rowWidth]).asType(.int32)
+    }
+
+    public func buildAudioPrefixRows(promptAudioCodes: MLXArray, slotTokenID: Int) throws -> MLXArray {
+        guard promptAudioCodes.ndim == 2 else {
+            throw MossTTSNanoError.invalidInput(
+                "promptAudioCodes must have shape [frames, n_vq], got \(promptAudioCodes.shape)"
+            )
+        }
+
+        let frameCount = promptAudioCodes.dim(0)
+        let sourceChannels = promptAudioCodes.dim(1)
+        let rowWidth = config.nVQ + 1
+        let copyChannels = min(sourceChannels, config.nVQ)
+        let codes = promptAudioCodes.asType(.int32).asArray(Int32.self)
+
+        var rows = Array(repeating: Int32(config.audioPadTokenID), count: frameCount * rowWidth)
+        for frameIndex in 0 ..< frameCount {
+            rows[frameIndex * rowWidth] = Int32(slotTokenID)
+            for channel in 0 ..< copyChannels {
+                rows[frameIndex * rowWidth + 1 + channel] = codes[frameIndex * sourceChannels + channel]
+            }
+        }
+        return MLXArray(rows, [frameCount, rowWidth]).asType(.int32)
+    }
+
+    public func buildInferenceInputIDs(
+        text: String,
+        tokenizer: MossTextTokenizing,
+        mode: String = "voice_clone",
+        promptText: String? = nil,
+        promptAudioCodes: MLXArray? = nil
+    ) throws -> (inputIDs: MLXArray, attentionMask: MLXArray) {
+        let normalizedMode = mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalizedMode == "voice_clone" || normalizedMode == "continuation" else {
+            throw MossTTSNanoError.invalidInput("mode must be either 'voice_clone' or 'continuation'")
+        }
+
+        let sections: [MLXArray]
+        if normalizedMode == "voice_clone" {
+            guard let promptAudioCodes else {
+                throw MossTTSNanoError.invalidInput("voice_clone mode requires promptAudioCodes")
+            }
+            if promptText != nil {
+                throw MossTTSNanoError.invalidInput("voice_clone mode does not accept promptText")
+            }
+            let textTokenIDs = mossEncodeText(tokenizer, text)
+            let prefixTokenIDs = mossBuildUserPromptPrefix(tokenizer: tokenizer, config: config)
+                + [config.audioStartTokenID]
+            let suffixTokenIDs = [config.audioEndTokenID]
+                + mossBuildUserPromptAfterReference(tokenizer: tokenizer)
+                + textTokenIDs
+                + mossBuildAssistantPromptPrefix(tokenizer: tokenizer, config: config)
+                + [config.audioStartTokenID]
+            sections = [
+                buildTextRows(prefixTokenIDs),
+                try buildAudioPrefixRows(
+                    promptAudioCodes: promptAudioCodes,
+                    slotTokenID: config.audioUserSlotTokenID
+                ),
+                buildTextRows(suffixTokenIDs),
+            ]
+        } else {
+            if (promptText == nil) != (promptAudioCodes == nil) {
+                throw MossTTSNanoError.invalidInput(
+                    "continuation mode accepts target text only, or both promptText and promptAudioCodes"
+                )
+            }
+            let effectiveText = promptText.map { $0 + text } ?? text
+            let promptTokenIDs = mossBuildPromptTokenIDs(
+                tokenizer: tokenizer,
+                config: config,
+                textTokenIDs: mossEncodeText(tokenizer, effectiveText)
+            )
+            var continuationSections = [
+                buildTextRows(promptTokenIDs),
+                buildTextRows([config.audioStartTokenID]),
+            ]
+            if let promptAudioCodes {
+                continuationSections.append(
+                    try buildAudioPrefixRows(
+                        promptAudioCodes: promptAudioCodes,
+                        slotTokenID: config.audioAssistantSlotTokenID
+                    )
+                )
+            }
+            sections = continuationSections
+        }
+
+        let rows = MLX.concatenated(sections, axis: 0)
+        let inputIDs = rows.expandedDimensions(axis: 0)
+        let attentionMask = MLXArray.ones([1, rows.dim(0)], dtype: .bool)
+        return (inputIDs, attentionMask)
+    }
+
+    public func leftPadInferenceBatch(
+        inputIDBatches: [MLXArray],
+        attentionMaskBatches: [MLXArray]
+    ) throws -> (inputIDs: MLXArray, attentionMask: MLXArray) {
+        guard !inputIDBatches.isEmpty else {
+            throw MossTTSNanoError.invalidInput("inputIDBatches must not be empty")
+        }
+        guard inputIDBatches.count == attentionMaskBatches.count else {
+            throw MossTTSNanoError.invalidInput("inputIDBatches and attentionMaskBatches must have the same count")
+        }
+
+        let batchSize = inputIDBatches.count
+        let maxSeqLen = inputIDBatches.map { $0.dim(1) }.max() ?? 0
+        let rowWidth = config.nVQ + 1
+        var flatIDs: [Int32] = []
+        var flatMask: [Bool] = []
+        flatIDs.reserveCapacity(batchSize * maxSeqLen * rowWidth)
+        flatMask.reserveCapacity(batchSize * maxSeqLen)
+
+        for (inputIDs, attentionMask) in zip(inputIDBatches, attentionMaskBatches) {
+            let seqLen = inputIDs.dim(1)
+            let padLen = maxSeqLen - seqLen
+            for _ in 0 ..< padLen {
+                flatIDs.append(Int32(config.padTokenID))
+                flatIDs.append(contentsOf: Array(repeating: Int32(config.audioPadTokenID), count: config.nVQ))
+                flatMask.append(false)
+            }
+            flatIDs.append(contentsOf: inputIDs.asType(.int32).asArray(Int32.self))
+            flatMask.append(contentsOf: attentionMask.asType(.bool).asArray(Bool.self))
+        }
+
+        return (
+            MLXArray(flatIDs, [batchSize, maxSeqLen, rowWidth]).asType(.int32),
+            MLXArray(flatMask, [batchSize, maxSeqLen]).asType(.bool)
+        )
+    }
+
+    public func resolveNQ(_ nq: Int?) throws -> Int {
+        guard let nq else { return config.nVQ }
+        guard nq >= 1, nq <= config.nVQ else {
+            throw MossTTSNanoError.invalidInput("nq must be in [1, \(config.nVQ)], got \(nq)")
+        }
+        return nq
+    }
+
+    public func generateAudioTokenIDs(
+        promptInputIDs: MLXArray,
+        attentionMask initialAttentionMask: MLXArray? = nil,
+        nq: Int? = nil,
+        maxNewFrames: Int = 375,
+        doSample: Bool = true,
+        textTemperature: Float = 1.0,
+        textTopP: Float = 1.0,
+        textTopK: Int = 50,
+        audioTemperature: Float = 0.8,
+        audioTopP: Float = 0.95,
+        audioTopK: Int = 25,
+        audioRepetitionPenalty: Float = 1.2,
+        useKVCache: Bool = true
+    ) throws -> MLXArray {
+        var promptInputIDs = promptInputIDs
+        if promptInputIDs.ndim == 2 {
+            promptInputIDs = promptInputIDs.expandedDimensions(axis: 0)
+        }
+        guard promptInputIDs.ndim == 3 else {
+            throw MossTTSNanoError.invalidInput(
+                "Expected promptInputIDs with 3 dimensions, got \(promptInputIDs.shape)"
+            )
+        }
+        guard promptInputIDs.dim(0) == 1 else {
+            throw MossTTSNanoError.notImplemented(
+                "Batched MOSS-TTS-Nano token generation is not implemented yet."
+            )
+        }
+
+        let effectiveNQ = try resolveNQ(nq)
+        let cache = useKVCache ? transformer.makeCache() : nil
+        var currentModelInputIDs = promptInputIDs
+        var currentAttentionMask = (initialAttentionMask ?? MLXArray.ones(promptInputIDs.shape.dropLast(), dtype: .bool)).asType(.bool)
+        var generatedFrames: [MLXArray] = []
+        generatedFrames.reserveCapacity(maxNewFrames)
+
+        for _ in 0 ..< maxNewFrames {
+            let globalInputsEmbeds = try buildInputsEmbeds(currentModelInputIDs)
+            let globalOutputs = try transformer(
+                inputsEmbeds: globalInputsEmbeds,
+                attentionMask: currentAttentionMask,
+                cache: cache
+            )
+            let globalHidden = globalOutputs[0..., -1, 0...]
+
+            var localInputsEmbeds = globalHidden.expandedDimensions(axis: 1)
+            var localOutputs = try localTransformer(inputsEmbeds: localInputsEmbeds)
+            var localHidden = localOutputs[0..., -1, 0...]
+            let textLogits = try textLMHead(localHidden)
+            let nextTextToken = try mossSampleAssistantTextToken(
+                textLogits: textLogits,
+                audioAssistantSlotTokenID: config.audioAssistantSlotTokenID,
+                audioEndTokenID: config.audioEndTokenID,
+                doSample: doSample,
+                temperature: textTemperature,
+                topK: textTopK,
+                topP: textTopP
+            )
+            eval(nextTextToken)
+            if nextTextToken[0].item(Int.self) != config.audioAssistantSlotTokenID {
+                break
+            }
+
+            var currentLocalInput = try transformer.tokenEmbedding(nextTextToken)
+            var frameTokens: [MLXArray] = []
+            frameTokens.reserveCapacity(effectiveNQ)
+            let history = generatedFrames.isEmpty ? nil : MLX.stacked(generatedFrames, axis: 1)
+            for channelIndex in 0 ..< effectiveNQ {
+                localInputsEmbeds = MLX.concatenated(
+                    [localInputsEmbeds, currentLocalInput.expandedDimensions(axis: 1)],
+                    axis: 1
+                )
+                localOutputs = try localTransformer(inputsEmbeds: localInputsEmbeds)
+                localHidden = localOutputs[0..., -1, 0...]
+                let channelLogits = audioLMHead(localHidden, channelIndex: channelIndex)
+                let previousTokens = history?[0..., 0..., channelIndex]
+                let channelToken = try mossSampleNextToken(
+                    logits: channelLogits,
+                    doSample: doSample,
+                    temperature: audioTemperature,
+                    topK: audioTopK,
+                    topP: audioTopP,
+                    previousTokenIDs: previousTokens,
+                    repetitionPenalty: audioRepetitionPenalty
+                )
+                frameTokens.append(channelToken)
+                currentLocalInput = audioEmbeddings[channelIndex](channelToken)
+            }
+
+            var frame = MLX.stacked(frameTokens, axis: -1).asType(.int32)
+            if effectiveNQ < config.nVQ {
+                let pad = MLX.full(
+                    [frame.dim(0), config.nVQ - effectiveNQ],
+                    values: Int32(config.audioPadTokenID),
+                    type: Int32.self
+                )
+                frame = MLX.concatenated([frame, pad], axis: -1)
+            }
+            generatedFrames.append(frame)
+
+            let textColumn = MLX.full(
+                [frame.dim(0), 1, 1],
+                values: Int32(config.audioAssistantSlotTokenID),
+                type: Int32.self
+            )
+            let nextRow = MLX.concatenated([textColumn, frame.expandedDimensions(axis: 1)], axis: -1)
+            currentModelInputIDs = nextRow
+            currentAttentionMask = MLX.concatenated(
+                [currentAttentionMask, MLXArray.ones([frame.dim(0), 1], dtype: .bool)],
+                axis: 1
+            )
+            eval(frame)
+
+            if !useKVCache {
+                promptInputIDs = MLX.concatenated([promptInputIDs, nextRow], axis: 1)
+                currentModelInputIDs = promptInputIDs
+            }
+        }
+
+        guard !generatedFrames.isEmpty else {
+            return MLXArray.zeros([1, 0, config.nVQ], type: Int32.self)
+        }
+        return MLX.stacked(generatedFrames, axis: 1).asType(.int32)
+    }
+
+    public func generateAudioTokenIDs(
+        text: String,
+        promptAudioCodes: MLXArray,
+        mode: String = "voice_clone",
+        promptText: String? = nil,
+        maxNewFrames: Int = 375,
+        doSample: Bool = true
+    ) throws -> MLXArray {
+        guard let tokenizer else {
+            throw MossTTSNanoError.tokenizerNotInitialized
+        }
+        let normalizedText = mossLightweightNormalizeText(text)
+        let chunks = try mossSplitTextIntoBestSentences(
+            tokenizer: tokenizer,
+            text: normalizedText,
+            maxTokens: 75
+        )
+        var allAudioTokens: [MLXArray] = []
+        for chunk in chunks {
+            let prepared = try buildInferenceInputIDs(
+                text: chunk,
+                tokenizer: tokenizer,
+                mode: mode,
+                promptText: mode == "continuation" ? promptText : nil,
+                promptAudioCodes: promptAudioCodes
+            )
+            allAudioTokens.append(
+                try generateAudioTokenIDs(
+                    promptInputIDs: prepared.inputIDs,
+                    attentionMask: prepared.attentionMask,
+                    maxNewFrames: maxNewFrames,
+                    doSample: doSample
+                )
+            )
+        }
+        return allAudioTokens.isEmpty
+            ? MLXArray.zeros([1, 0, config.nVQ], type: Int32.self)
+            : MLX.concatenated(allAudioTokens, axis: 1).asType(.int32)
+    }
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        _ = voice
+        _ = refText
+        _ = language
+        guard let tokenizer else {
+            throw MossTTSNanoError.tokenizerNotInitialized
+        }
+        guard let refAudio else {
+            throw MossTTSNanoError.invalidInput("MOSS-TTS-Nano requires refAudio for voice_clone generation.")
+        }
+
+        try await ensureAudioTokenizer()
+        let promptAudioCodes = try encodeReferenceAudio(
+            refAudio,
+            numQuantizers: config.nVQ
+        )
+        let mode = "voice_clone"
+        let normalizedText = mossLightweightNormalizeText(text)
+        let chunks = try mossSplitTextIntoBestSentences(
+            tokenizer: tokenizer,
+            text: normalizedText,
+            maxTokens: 75
+        )
+        var allAudioTokens: [MLXArray] = []
+        for chunk in chunks {
+            let prepared = try buildInferenceInputIDs(
+                text: chunk,
+                tokenizer: tokenizer,
+                mode: mode,
+                promptText: nil,
+                promptAudioCodes: promptAudioCodes
+            )
+            let audioTokens = try generateAudioTokenIDs(
+                promptInputIDs: prepared.inputIDs,
+                attentionMask: prepared.attentionMask,
+                maxNewFrames: generationParameters.maxTokens ?? 375,
+                doSample: generationParameters.temperature > 0,
+                audioTemperature: generationParameters.temperature,
+                audioTopP: generationParameters.topP,
+                audioTopK: generationParameters.topK,
+                audioRepetitionPenalty: generationParameters.repetitionPenalty ?? 1.1
+            )
+            allAudioTokens.append(audioTokens)
+        }
+
+        let audioTokenIDs = allAudioTokens.isEmpty
+            ? MLXArray.zeros([1, 0, config.nVQ], type: Int32.self)
+            : MLX.concatenated(allAudioTokens, axis: 1).asType(.int32)
+        return try decodeAudioTokenIDs(audioTokenIDs, numQuantizers: config.nVQ)
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { @Sendable in
+                do {
+                    let audio = try await self.generate(
+                        text: text,
+                        voice: voice,
+                        refAudio: refAudio,
+                        refText: refText,
+                        language: language,
+                        generationParameters: generationParameters
+                    )
+                    continuation.yield(.audio(audio))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    public static func fromPretrained(
+        _ modelRepo: String,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> MossTTSNanoModel {
+        guard let repoID = Repo.ID(rawValue: modelRepo) else {
+            throw TTSModelError.invalidRepositoryID(modelRepo)
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["*.model", "*.index.json"],
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try await fromModelDirectory(modelDir)
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) async throws -> MossTTSNanoModel {
+        let configData = try Data(contentsOf: modelDir.appendingPathComponent("config.json"))
+        var config = try JSONDecoder().decode(MossTTSNanoConfig.self, from: configData)
+        config.modelPath = modelDir.path
+        let model = MossTTSNanoModel(config: config)
+
+        let weights = try loadWeights(from: modelDir)
+        let sanitizedWeights = model.sanitize(weights: weights)
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
+        eval(model)
+
+        let tokenizerURL = modelDir.appendingPathComponent("tokenizer.model")
+        if FileManager.default.fileExists(atPath: tokenizerURL.path) {
+            model.tokenizer = try MossSentencePieceTokenizer(modelURL: tokenizerURL)
+        }
+        let audioTokenizerURL = modelDir.appendingPathComponent("audio_tokenizer", isDirectory: true)
+        if FileManager.default.fileExists(atPath: audioTokenizerURL.appendingPathComponent("config.json").path) {
+            model.audioTokenizer = try MLXMossAudioTokenizer.fromModelDirectory(audioTokenizerURL)
+        }
+        return model
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoText.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoText.swift
@@ -1,0 +1,350 @@
+import Foundation
+import MLXAudioCore
+
+public protocol MossTextTokenizing {
+    func encode(_ text: String) -> [Int]
+    func decode(_ tokenIDs: [Int]) -> String
+}
+
+public final class MossSentencePieceTokenizer: MossTextTokenizing {
+    private let tokenizer: SentencePieceTokenizer
+
+    public init(modelURL: URL) throws {
+        self.tokenizer = try SentencePieceTokenizer.from(sentencePieceModelURL: modelURL)
+    }
+
+    public func encode(_ text: String) -> [Int] {
+        let normalized = Self.normalizeSentencePieceWhitespace(text)
+        guard !normalized.isEmpty else { return [] }
+        return tokenizer.encodeWithByteFallback(normalized)
+    }
+
+    public func decode(_ tokenIDs: [Int]) -> String {
+        tokenizer.decode(tokenIDs)
+    }
+
+    private static func normalizeSentencePieceWhitespace(_ text: String) -> String {
+        var normalized = ""
+        var previousWasWhitespace = true
+        for scalar in text.unicodeScalars {
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) {
+                if !previousWasWhitespace {
+                    normalized.append(" ")
+                    previousWasWhitespace = true
+                }
+            } else {
+                normalized.unicodeScalars.append(scalar)
+                previousWasWhitespace = false
+            }
+        }
+        if normalized.last == " " {
+            normalized.removeLast()
+        }
+        return normalized
+    }
+}
+
+public let mossUserRolePrefix = "user\n"
+public let mossUserTemplateReferencePrefix = "<user_inst>\n- Reference(s):\n"
+public let mossUserTemplateAfterReference = """
+
+- Instruction:
+None
+- Tokens:
+None
+- Quality:
+None
+- Sound Event:
+None
+- Ambient Sound:
+None
+- Language:
+None
+- Text:
+"""
+public let mossUserTemplateSuffix = "\n</user_inst>"
+public let mossAssistantTurnPrefix = "\n"
+public let mossAssistantRolePrefix = "assistant\n"
+
+private let mossSentenceEndPunctuation = Set(".!?。！？；;")
+private let mossClauseSplitPunctuation = Set(",，、；;：:")
+private let mossClosingPunctuation = Set("\"'\"')]}）】》」』")
+
+public func mossLoadTokenizer(modelDirectory: URL) throws -> MossSentencePieceTokenizer {
+    try MossSentencePieceTokenizer(modelURL: modelDirectory.appendingPathComponent("tokenizer.model"))
+}
+
+public func mossEncodeText(_ tokenizer: MossTextTokenizing, _ text: String) -> [Int] {
+    tokenizer.encode(text)
+}
+
+public func mossBuildUserPromptPrefix(
+    tokenizer: MossTextTokenizing,
+    config: MossTTSNanoConfig
+) -> [Int] {
+    [config.imStartTokenID]
+        + mossEncodeText(tokenizer, mossUserRolePrefix)
+        + mossEncodeText(tokenizer, mossUserTemplateReferencePrefix)
+}
+
+public func mossBuildUserPromptAfterReference(tokenizer: MossTextTokenizing) -> [Int] {
+    mossEncodeText(tokenizer, mossUserTemplateAfterReference)
+}
+
+public func mossBuildAssistantPromptPrefix(
+    tokenizer: MossTextTokenizing,
+    config: MossTTSNanoConfig
+) -> [Int] {
+    mossEncodeText(tokenizer, mossUserTemplateSuffix)
+        + [config.imEndTokenID]
+        + mossEncodeText(tokenizer, mossAssistantTurnPrefix)
+        + [config.imStartTokenID]
+        + mossEncodeText(tokenizer, mossAssistantRolePrefix)
+}
+
+public func mossBuildPromptTokenIDs(
+    tokenizer: MossTextTokenizing,
+    config: MossTTSNanoConfig,
+    textTokenIDs: [Int]
+) -> [Int] {
+    mossBuildUserPromptPrefix(tokenizer: tokenizer, config: config)
+        + mossEncodeText(tokenizer, "None")
+        + mossBuildUserPromptAfterReference(tokenizer: tokenizer)
+        + textTokenIDs
+        + mossBuildAssistantPromptPrefix(tokenizer: tokenizer, config: config)
+}
+
+public func mossContainsCJK(_ text: String) -> Bool {
+    text.unicodeScalars.contains { scalar in
+        let value = scalar.value
+        return (0x4E00...0x9FFF).contains(value)
+            || (0x3400...0x4DBF).contains(value)
+            || (0x3040...0x30FF).contains(value)
+            || (0xAC00...0xD7AF).contains(value)
+    }
+}
+
+public func mossPrepareTextForSentenceChunking(_ text: String) throws -> String {
+    var normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalized.isEmpty else {
+        throw MossTTSNanoError.invalidInput("Text prompt cannot be empty.")
+    }
+
+    normalized = normalized
+        .replacingOccurrences(of: "\r", with: " ")
+        .replacingOccurrences(of: "\n", with: " ")
+    while normalized.contains("  ") {
+        normalized = normalized.replacingOccurrences(of: "  ", with: " ")
+    }
+
+    if mossContainsCJK(normalized) {
+        if let last = normalized.last, !mossSentenceEndPunctuation.contains(last) {
+            normalized.append("。")
+        }
+        return normalized
+    }
+
+    if let first = normalized.first,
+       String(first).lowercased() == String(first),
+       String(first).uppercased() != String(first) {
+        normalized = String(first).uppercased() + normalized.dropFirst()
+    }
+    if let last = normalized.last, last.isLetter || last.isNumber {
+        normalized.append(".")
+    }
+    if normalized.split(whereSeparator: \.isWhitespace).count < 5 {
+        normalized = "        " + normalized
+    }
+    return normalized
+}
+
+public func mossSplitTextByPunctuation(_ text: String, punctuation: Set<Character>) -> [String] {
+    var sentences: [String] = []
+    var current: [Character] = []
+    let chars = Array(text)
+    var index = 0
+
+    while index < chars.count {
+        let character = chars[index]
+        current.append(character)
+        if punctuation.contains(character) {
+            var lookahead = index + 1
+            while lookahead < chars.count, mossClosingPunctuation.contains(chars[lookahead]) {
+                current.append(chars[lookahead])
+                lookahead += 1
+            }
+            let sentence = String(current).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sentence.isEmpty {
+                sentences.append(sentence)
+            }
+            current.removeAll(keepingCapacity: true)
+            while lookahead < chars.count, chars[lookahead].isWhitespace {
+                lookahead += 1
+            }
+            index = lookahead
+            continue
+        }
+        index += 1
+    }
+
+    let tail = String(current).trimmingCharacters(in: .whitespacesAndNewlines)
+    if !tail.isEmpty {
+        sentences.append(tail)
+    }
+    return sentences
+}
+
+public func mossJoinSentenceParts(_ left: String, _ right: String) -> String {
+    if left.isEmpty { return right }
+    if right.isEmpty { return left }
+    if mossContainsCJK(left) || mossContainsCJK(right) {
+        return left + right
+    }
+    return "\(left) \(right)"
+}
+
+public func mossSplitTextByTokenBudget(
+    tokenizer: MossTextTokenizing,
+    text: String,
+    maxTokens: Int
+) -> [String] {
+    var remaining = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !remaining.isEmpty else { return [] }
+
+    let safeMaxTokens = max(1, maxTokens)
+    let preferredBoundaryChars = mossClauseSplitPunctuation
+        .union(mossSentenceEndPunctuation)
+        .union([" "])
+    var pieces: [String] = []
+
+    while !remaining.isEmpty {
+        if mossEncodeText(tokenizer, remaining).count <= safeMaxTokens {
+            pieces.append(remaining)
+            break
+        }
+
+        let chars = Array(remaining)
+        var low = 1
+        var high = chars.count
+        var bestPrefixLength = 1
+        while low <= high {
+            let middle = (low + high) / 2
+            let candidate = String(chars.prefix(middle)).trimmingCharacters(in: .whitespacesAndNewlines)
+            if candidate.isEmpty {
+                low = middle + 1
+                continue
+            }
+            if mossEncodeText(tokenizer, candidate).count <= safeMaxTokens {
+                bestPrefixLength = middle
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+
+        var cutIndex = bestPrefixLength
+        let prefixChars = Array(chars.prefix(bestPrefixLength))
+        let scanStart = prefixChars.count - 1
+        let scanEnd = max(-1, prefixChars.count - 25)
+        if scanStart > scanEnd {
+            for scanIndex in stride(from: scanStart, to: scanEnd, by: -1) {
+                if preferredBoundaryChars.contains(prefixChars[scanIndex]) {
+                    cutIndex = scanIndex + 1
+                    break
+                }
+            }
+        }
+
+        var piece = String(chars.prefix(cutIndex)).trimmingCharacters(in: .whitespacesAndNewlines)
+        if piece.isEmpty {
+            piece = String(chars.prefix(bestPrefixLength)).trimmingCharacters(in: .whitespacesAndNewlines)
+            cutIndex = bestPrefixLength
+        }
+        pieces.append(piece)
+        remaining = String(chars.dropFirst(cutIndex)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    return pieces
+}
+
+public func mossSplitTextIntoBestSentences(
+    tokenizer: MossTextTokenizing,
+    text: String,
+    maxTokens: Int = 75
+) throws -> [String] {
+    let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalized.isEmpty else { return [] }
+
+    let safeMaxTokens = max(1, maxTokens)
+    let prepared = try mossPrepareTextForSentenceChunking(normalized)
+    let sentenceCandidates = mossSplitTextByPunctuation(prepared, punctuation: mossSentenceEndPunctuation)
+    let candidates = sentenceCandidates.isEmpty ? [prepared] : sentenceCandidates
+
+    var sentenceSlices: [(tokenCount: Int, text: String)] = []
+    for sentence in candidates {
+        let normalizedSentence = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedSentence.isEmpty else { continue }
+        let sentenceTokenCount = mossEncodeText(tokenizer, normalizedSentence).count
+        if sentenceTokenCount <= safeMaxTokens {
+            sentenceSlices.append((sentenceTokenCount, normalizedSentence))
+            continue
+        }
+
+        let clauseCandidates = mossSplitTextByPunctuation(normalizedSentence, punctuation: mossClauseSplitPunctuation)
+        let clauses = clauseCandidates.count <= 1 ? [normalizedSentence] : clauseCandidates
+        for clause in clauses {
+            let normalizedClause = clause.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedClause.isEmpty else { continue }
+            let clauseTokenCount = mossEncodeText(tokenizer, normalizedClause).count
+            if clauseTokenCount <= safeMaxTokens {
+                sentenceSlices.append((clauseTokenCount, normalizedClause))
+                continue
+            }
+            for piece in mossSplitTextByTokenBudget(
+                tokenizer: tokenizer,
+                text: normalizedClause,
+                maxTokens: safeMaxTokens
+            ) {
+                let normalizedPiece = piece.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !normalizedPiece.isEmpty {
+                    sentenceSlices.append((mossEncodeText(tokenizer, normalizedPiece).count, normalizedPiece))
+                }
+            }
+        }
+    }
+
+    var chunks: [String] = []
+    var currentChunk = ""
+    var currentTokenCount = 0
+    for slice in sentenceSlices {
+        if currentChunk.isEmpty {
+            currentChunk = slice.text
+            currentTokenCount = slice.tokenCount
+            continue
+        }
+        if currentTokenCount + slice.tokenCount > safeMaxTokens {
+            chunks.append(currentChunk.trimmingCharacters(in: .whitespacesAndNewlines))
+            currentChunk = slice.text
+            currentTokenCount = slice.tokenCount
+        } else {
+            currentChunk = mossJoinSentenceParts(currentChunk, slice.text)
+            currentTokenCount = mossEncodeText(tokenizer, currentChunk).count
+        }
+    }
+    if !currentChunk.isEmpty {
+        chunks.append(currentChunk.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return chunks.count > 1 ? chunks : [normalized]
+}
+
+public func mossLightweightNormalizeText(_ text: String) -> String {
+    let collapsed = text
+        .replacingOccurrences(of: "\r", with: " ")
+        .replacingOccurrences(of: "\n", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    return collapsed.replacingOccurrences(
+        of: #"\s+"#,
+        with: " ",
+        options: .regularExpression
+    )
+}

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSSampling.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSSampling.swift
@@ -1,0 +1,117 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+public func mossApplyRepetitionPenalty(
+    logits: MLXArray,
+    previousTokenIDs: MLXArray?,
+    penalty: Float = 1.0
+) -> MLXArray {
+    guard penalty != 1.0, let previousTokenIDs, previousTokenIDs.size > 0 else {
+        return logits
+    }
+
+    let vocabSize = logits.dim(logits.ndim - 1)
+    let uniqueTokenIDs = Array(Set(previousTokenIDs.asArray(Int32.self).map(Int.init)))
+        .filter { $0 >= 0 && $0 < vocabSize }
+    guard !uniqueTokenIDs.isEmpty else { return logits }
+
+    let tokenIDs = MLXArray(uniqueTokenIDs.map { Int32($0) }).reshaped([1, -1])
+    let selected = takeAlong(logits, tokenIDs, axis: -1)
+    let penalized = MLX.where(
+        selected .< 0,
+        selected * MLXArray(penalty),
+        selected / MLXArray(penalty)
+    )
+    return putAlong(logits, tokenIDs, values: penalized, axis: -1)
+}
+
+public func mossApplyTopK(_ logits: MLXArray, topK: Int?) -> MLXArray {
+    guard let topK, topK > 0 else { return logits }
+    let vocabSize = logits.dim(logits.ndim - 1)
+    let k = min(topK, vocabSize)
+    guard k < vocabSize else { return logits }
+
+    let kth = min(k - 1, max(vocabSize - 1, 0))
+    let maskIndices = argPartition(-logits, kth: kth, axis: -1)[0..., k...]
+    let negInf = MLXArray.full(maskIndices.shape, values: MLXArray(-Float.infinity), dtype: logits.dtype)
+    return putAlong(logits, maskIndices, values: negInf, axis: -1)
+}
+
+public func mossApplyTopP(_ logits: MLXArray, topP: Float?) -> MLXArray {
+    guard let topP, topP > 0, topP < 1 else { return logits }
+    let vocabSize = logits.dim(logits.ndim - 1)
+    guard vocabSize > 1 else { return logits }
+
+    let logProbs = logSoftmax(logits, axis: -1)
+    let sortedIndices = argSort(logProbs, axis: -1)
+    let sortedProbs = exp(takeAlong(logProbs, sortedIndices, axis: -1))
+    let cumulativeProbs = MLX.cumsum(sortedProbs, axis: -1)
+
+    let arangeIndices = MLXArray(0 ..< vocabSize).reshaped([1, -1]).asType(.int32)
+    let inverseIndices = putAlong(
+        MLXArray.zeros(sortedIndices.shape, type: Int32.self),
+        sortedIndices.asType(.int32),
+        values: arangeIndices,
+        axis: -1
+    )
+    let cumulativeOriginalOrder = takeAlong(cumulativeProbs, inverseIndices, axis: -1)
+    return MLX.where(
+        cumulativeOriginalOrder .> MLXArray(1 - topP),
+        logits,
+        MLXArray(-Float.infinity).asType(logits.dtype)
+    )
+}
+
+public func mossSampleNextToken(
+    logits: MLXArray,
+    doSample: Bool,
+    temperature: Float = 1.0,
+    topK: Int? = nil,
+    topP: Float? = nil,
+    previousTokenIDs: MLXArray? = nil,
+    repetitionPenalty: Float = 1.0
+) throws -> MLXArray {
+    var scores = mossApplyRepetitionPenalty(
+        logits: logits,
+        previousTokenIDs: previousTokenIDs,
+        penalty: repetitionPenalty
+    )
+    guard doSample else {
+        return argMax(scores, axis: -1).asType(.int32)
+    }
+    guard temperature > 0 else {
+        throw MossTTSNanoError.invalidInput("temperature must be positive when doSample is true")
+    }
+
+    if temperature != 1.0 {
+        scores = scores / MLXArray(temperature)
+    }
+    scores = mossApplyTopK(scores, topK: topK)
+    scores = mossApplyTopP(scores, topP: topP)
+    return MLXRandom.categorical(scores).asType(.int32)
+}
+
+public func mossSampleAssistantTextToken(
+    textLogits: MLXArray,
+    audioAssistantSlotTokenID: Int,
+    audioEndTokenID: Int,
+    doSample: Bool,
+    temperature: Float,
+    topK: Int,
+    topP: Float
+) throws -> MLXArray {
+    let candidateIDs = MLXArray([
+        Int32(audioAssistantSlotTokenID),
+        Int32(audioEndTokenID),
+    ]).reshaped([1, 2])
+    let candidateScores = takeAlong(textLogits, candidateIDs, axis: -1)
+    let sampledCandidate = try mossSampleNextToken(
+        logits: candidateScores,
+        doSample: doSample,
+        temperature: temperature,
+        topK: min(topK, 2),
+        topP: topP
+    ).reshaped([1, 1])
+    return takeAlong(candidateIDs, sampledCandidate, axis: -1).squeezed(axis: -1)
+}

--- a/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSConditioners.swift
+++ b/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSConditioners.swift
@@ -6,8 +6,8 @@ public struct TokenizedText {
     public let tokens: MLXArray
 }
 
-public final class SentencePieceTokenizer {
-    public let tokenizer: UnigramTokenizer
+public final class PocketTTSSentencePieceTokenizer {
+    public let tokenizer: MLXAudioCore.SentencePieceTokenizer
 
     public init(nBins: Int, modelFolder: URL) async throws {
         let tokenizerJSON = modelFolder.appendingPathComponent("tokenizer.json")
@@ -19,7 +19,7 @@ public final class SentencePieceTokenizer {
                 userInfo: [NSLocalizedDescriptionKey: "Missing tokenizer.json in \(modelFolder.path)"]
             )
         }
-        self.tokenizer = try UnigramTokenizer(tokenizerJSONData: data)
+        self.tokenizer = try MLXAudioCore.SentencePieceTokenizer(tokenizerJSONData: data)
     }
 
     public func callAsFunction(_ text: String) -> TokenizedText {
@@ -38,7 +38,7 @@ public final class SentencePieceTokenizer {
 }
 
 public final class LUTConditioner: Module {
-    public let tokenizer: SentencePieceTokenizer
+    public let tokenizer: PocketTTSSentencePieceTokenizer
     public let dim: Int
     public let outputDim: Int
 
@@ -46,7 +46,7 @@ public final class LUTConditioner: Module {
     @ModuleInfo(key: "output_proj") public var output_proj: Linear?
 
     public init(nBins: Int, modelFolder: URL, dim: Int, outputDim: Int) async throws {
-        self.tokenizer = try await SentencePieceTokenizer(nBins: nBins, modelFolder: modelFolder)
+        self.tokenizer = try await PocketTTSSentencePieceTokenizer(nBins: nBins, modelFolder: modelFolder)
         self.dim = dim
         self.outputDim = outputDim
         self._embed = ModuleInfo(wrappedValue: Embedding(embeddingCount: nBins + 1, dimensions: dim))

--- a/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSTextUtils.swift
+++ b/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSTextUtils.swift
@@ -26,7 +26,7 @@ public enum PocketTTSTextUtils {
     }
 
     public static func splitIntoBestSentences(
-        _ tokenizer: SentencePieceTokenizer,
+        _ tokenizer: PocketTTSSentencePieceTokenizer,
         _ textToGenerate: String
     ) throws -> [String] {
         let (prepared, _) = try prepareTextPrompt(textToGenerate)

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -51,7 +51,7 @@ public enum TTS {
         }
 
         switch resolvedType {
-        case "moss_tts_nano", "moss-tts-nano", "moss_tts":
+        case "moss_tts_nano":
             return try await MossTTSNanoModel.fromPretrained(modelRepo, cache: cache)
         case "echo_tts", "echo":
             return try await EchoTTSModel.fromPretrained(modelRepo, cache: cache)

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -51,6 +51,8 @@ public enum TTS {
         }
 
         switch resolvedType {
+        case "moss_tts_nano", "moss-tts-nano", "moss_tts":
+            return try await MossTTSNanoModel.fromPretrained(modelRepo, cache: cache)
         case "echo_tts", "echo":
             return try await EchoTTSModel.fromPretrained(modelRepo, cache: cache)
         case "qwen3_tts":
@@ -105,6 +107,9 @@ public enum TTS {
         }
         if lower.contains("echo") {
             return "echo_tts"
+        }
+        if lower.contains("moss") && lower.contains("tts") {
+            return "moss_tts_nano"
         }
         if lower.contains("qwen3") || lower.contains("qwen") {
             return "qwen3"

--- a/Sources/Tools/mlx-audio-swift-tts/App.swift
+++ b/Sources/Tools/mlx-audio-swift-tts/App.swift
@@ -9,6 +9,8 @@ import MLXLMCommon
 enum AppError: Error, LocalizedError, CustomStringConvertible {
     case invalidRepositoryID(String)
     case unsupportedModelType(String?)
+    case invalidGeneratedAudioShape([Int])
+    case mismatchedAudioChannelCount(Int, Int)
     case failedToCreateAudioBuffer
     case failedToAccessAudioBufferData
 
@@ -22,6 +24,10 @@ enum AppError: Error, LocalizedError, CustomStringConvertible {
             "Invalid repository ID: \(model)"
         case .unsupportedModelType(let modelType):
             "Unsupported model type: \(String(describing: modelType))"
+        case .invalidGeneratedAudioShape(let shape):
+            "Invalid generated audio shape: \(shape)"
+        case .mismatchedAudioChannelCount(let expected, let actual):
+            "Mismatched generated audio channel count: expected \(expected), got \(actual)"
         case .failedToCreateAudioBuffer:
             "Failed to create audio buffer"
         case .failedToAccessAudioBufferData:
@@ -117,7 +123,7 @@ enum App {
             generationParameters.topP = topP
         }
 
-        let audioData: [Float]
+        let audioFrames: PCMFrames
         var benchmarkMetrics: BenchmarkMetrics?
         if benchmark {
             let sampleRate = Double(loadedModel.sampleRate)
@@ -131,8 +137,8 @@ enum App {
                 streamingInterval: 0.32
             )
 
-            var collectedAudio = [Float]()
-            var totalSamples = 0
+            var collectedAudio = PCMFrames()
+            var totalFrames = 0
             var firstChunkLatency: TimeInterval?
             var generationInfo: AudioGenerationInfo?
 
@@ -143,8 +149,8 @@ enum App {
                 case .info(let info):
                     generationInfo = info
                 case .audio(let chunk):
-                    let chunkSamples = chunk.asArray(Float.self)
-                    guard !chunkSamples.isEmpty else { continue }
+                    let chunkFrames = try PCMFrames(audio: chunk)
+                    guard chunkFrames.frameCount > 0 else { continue }
 
                     let now = CFAbsoluteTimeGetCurrent()
                     let chunkLatency = now - started
@@ -152,14 +158,14 @@ enum App {
                         firstChunkLatency = chunkLatency
                     }
 
-                    collectedAudio.append(contentsOf: chunkSamples)
-                    totalSamples += chunkSamples.count
+                    try collectedAudio.append(chunkFrames)
+                    totalFrames += chunkFrames.frameCount
                 }
             }
 
-            audioData = collectedAudio
+            audioFrames = collectedAudio
             let elapsed = CFAbsoluteTimeGetCurrent() - started
-            let audioDuration = sampleRate > 0 ? Double(totalSamples) / sampleRate : 0
+            let audioDuration = sampleRate > 0 ? Double(totalFrames) / sampleRate : 0
             benchmarkMetrics = BenchmarkMetrics(
                 elapsed: elapsed,
                 audioDuration: audioDuration,
@@ -168,21 +174,22 @@ enum App {
                 generationInfo: generationInfo
             )
         } else {
-            audioData = try await loadedModel.generate(
+            let audio = try await loadedModel.generate(
                 text: text,
                 voice: voice,
                 refAudio: refAudio,
                 refText: refText,
                 language: language,
                 generationParameters: generationParameters
-            ).asArray(Float.self)
+            )
+            audioFrames = try PCMFrames(audio: audio)
         }
 
         print(String(format: "Finished generation in %0.2fs", CFAbsoluteTimeGetCurrent() - started))
 
         let outputURL = makeOutputURL(outputPath: outputPath)
         let sampleRate = Double(loadedModel.sampleRate)
-        try writeWavFile(samples: audioData, sampleRate: sampleRate, outputURL: outputURL)
+        try writeWavFile(audioFrames: audioFrames, sampleRate: sampleRate, outputURL: outputURL)
         print("Wrote WAV to \(outputURL.path)")
 
         if let benchmarkMetrics {
@@ -208,7 +215,7 @@ enum App {
             print("Loading forced aligner (\(forcedAlignerRepo))")
             let forcedAligner = try await Qwen3ForcedAlignerModel.fromPretrained(forcedAlignerRepo)
             let alignmentAudio = try resampleAudio(
-                MLXArray(audioData),
+                MLXArray(audioFrames.monoSamples()),
                 from: Int(loadedModel.sampleRate),
                 to: 16000
             )
@@ -241,6 +248,98 @@ enum App {
         let generationInfo: AudioGenerationInfo?
     }
 
+    private struct PCMFrames {
+        var channels: [[Float]]
+
+        init(channels: [[Float]] = []) {
+            self.channels = channels
+        }
+
+        init(audio: MLXArray) throws {
+            var audio = audio.asType(.float32)
+            if audio.ndim == 3 {
+                guard audio.dim(0) == 1 else {
+                    throw AppError.invalidGeneratedAudioShape(audio.shape)
+                }
+                audio = audio[0]
+            }
+
+            switch audio.ndim {
+            case 1:
+                self.channels = [audio.asArray(Float.self)]
+            case 2:
+                let first = audio.dim(0)
+                let second = audio.dim(1)
+                let values = audio.asArray(Float.self)
+                if second <= 8 {
+                    self.channels = Self.channelsFromSampleMajor(values: values, frameCount: first, channelCount: second)
+                } else if first <= 8 {
+                    self.channels = (0 ..< first).map { channel in
+                        let start = channel * second
+                        return Array(values[start ..< (start + second)])
+                    }
+                } else {
+                    throw AppError.invalidGeneratedAudioShape(audio.shape)
+                }
+            default:
+                throw AppError.invalidGeneratedAudioShape(audio.shape)
+            }
+        }
+
+        var channelCount: Int {
+            channels.count
+        }
+
+        var frameCount: Int {
+            channels.first?.count ?? 0
+        }
+
+        mutating func append(_ other: PCMFrames) throws {
+            guard !channels.isEmpty else {
+                channels = other.channels
+                return
+            }
+            guard other.channelCount == channelCount else {
+                throw AppError.mismatchedAudioChannelCount(channelCount, other.channelCount)
+            }
+            for index in channels.indices {
+                channels[index].append(contentsOf: other.channels[index])
+            }
+        }
+
+        func monoSamples() -> [Float] {
+            guard channelCount > 1 else {
+                return channels.first ?? []
+            }
+            var samples = Array(repeating: Float(0), count: frameCount)
+            for frame in 0 ..< frameCount {
+                var sum: Float = 0
+                for channel in 0 ..< channelCount {
+                    sum += channels[channel][frame]
+                }
+                samples[frame] = sum / Float(channelCount)
+            }
+            return samples
+        }
+
+        private static func channelsFromSampleMajor(
+            values: [Float],
+            frameCount: Int,
+            channelCount: Int
+        ) -> [[Float]] {
+            var channels = Array(
+                repeating: Array(repeating: Float(0), count: frameCount),
+                count: channelCount
+            )
+            for frame in 0 ..< frameCount {
+                for channel in 0 ..< channelCount {
+                    channels[channel][frame] = values[frame * channelCount + channel]
+                }
+            }
+            return channels
+        }
+    }
+
     private static func makeOutputURL(outputPath: String?) -> URL {
         let outputName = outputPath?.isEmpty == false ? outputPath! : "output.wav"
         if outputName.hasPrefix("/") {
@@ -258,20 +357,40 @@ enum App {
             .appendingPathComponent(path)
     }
 
-    private static func writeWavFile(samples: [Float], sampleRate: Double, outputURL: URL) throws {
-        let frameCount = AVAudioFrameCount(samples.count)
-        guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1),
-              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+    private static func writeWavFile(audioFrames: PCMFrames, sampleRate: Double, outputURL: URL) throws {
+        let channelCount = audioFrames.channelCount
+        guard channelCount > 0 else {
+            throw AppError.invalidGeneratedAudioShape([audioFrames.frameCount, channelCount])
+        }
+        let frameCount = AVAudioFrameCount(audioFrames.frameCount)
+        guard let bufferFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: AVAudioChannelCount(channelCount),
+            interleaved: false
+        ), let fileFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: AVAudioChannelCount(channelCount),
+            interleaved: true
+        ), let buffer = AVAudioPCMBuffer(pcmFormat: bufferFormat, frameCapacity: frameCount) else {
             throw AppError.failedToCreateAudioBuffer
         }
         buffer.frameLength = frameCount
         guard let channelData = buffer.floatChannelData else {
             throw AppError.failedToAccessAudioBufferData
         }
-        for i in 0 ..< samples.count {
-            channelData[0][i] = samples[i]
+        for channel in 0 ..< channelCount {
+            for frame in 0 ..< audioFrames.frameCount {
+                channelData[channel][frame] = audioFrames.channels[channel][frame]
+            }
         }
-        let audioFile = try AVAudioFile(forWriting: outputURL, settings: format.settings)
+        let audioFile = try AVAudioFile(
+            forWriting: outputURL,
+            settings: fileFormat.settings,
+            commonFormat: bufferFormat.commonFormat,
+            interleaved: bufferFormat.isInterleaved
+        )
         try audioFile.write(from: buffer)
     }
 

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -61,6 +61,267 @@ private func cleanupTemporaryArtifactDirectory(_ directory: URL) {
     try? FileManager.default.removeItem(at: directory)
 }
 
+private struct MossFakeTokenizer: MossTextTokenizing {
+    func encode(_ text: String) -> [Int] {
+        text.utf8.map { Int($0 % 50) + 10 }
+    }
+
+    func decode(_ tokenIDs: [Int]) -> String {
+        String(tokenIDs.map { Character(UnicodeScalar(($0 - 10) % 50 + 65)!) })
+    }
+}
+
+private func makeTinyMossConfig(nVQ: Int = 2) throws -> MossTTSNanoConfig {
+    try MossTTSNanoConfig(
+        gpt2Config: MossGPT2Config(
+            vocabSize: 128,
+            nPositions: 64,
+            nCtx: 64,
+            nEmbd: 16,
+            nLayer: 1,
+            nHead: 4,
+            nInner: 32,
+            positionEmbeddingType: "rope"
+        ),
+        nVQ: nVQ,
+        audioVocabSize: 8,
+        audioCodebookSizes: Array(repeating: 8, count: nVQ),
+        audioPadTokenID: 8,
+        localTransformerLayers: 1,
+        maxPositionEmbeddings: 64,
+        hiddenSize: 16,
+        vocabSize: 128
+    )
+}
+
+@Suite("MOSS TTS Nano Tests")
+struct MossTTSNanoTests {
+    @Test func configDecodesUpstreamAliases() throws {
+        let json = """
+        {
+          "model_type": "moss_tts_nano",
+          "n_vq": 2,
+          "audio_vocab_size": 8,
+          "audio_codebook_sizes": [8, 9],
+          "gpt2_config": {
+            "vocab_size": 128,
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "intermediate_size": 32,
+            "position_embedding_type": "rope"
+          }
+        }
+        """
+        let config = try JSONDecoder().decode(MossTTSNanoConfig.self, from: Data(json.utf8))
+        #expect(config.nVQ == 2)
+        #expect(config.audioCodebookSizes == [8, 9])
+        #expect(config.gpt2Config.nEmbd == 16)
+        #expect(config.gpt2Config.nLayer == 1)
+        #expect(config.gpt2Config.nHead == 4)
+        #expect(config.localGPT2Config().nPositions == 3)
+    }
+
+    @Test func configRejectsBadCodebookCount() {
+        #expect(throws: DecodingError.self) {
+            _ = try MossTTSNanoConfig(nVQ: 2, audioCodebookSizes: [8])
+        }
+    }
+
+    @Test func textUtilitiesMatchPromptShape() throws {
+        let tokenizer = MossFakeTokenizer()
+        let config = try makeTinyMossConfig()
+
+        let prefix = mossBuildUserPromptPrefix(tokenizer: tokenizer, config: config)
+        #expect(prefix.first == config.imStartTokenID)
+        #expect(prefix.count > 5)
+
+        let prepared = try mossPrepareTextForSentenceChunking("hello world")
+        #expect(prepared == "        Hello world.")
+
+        let chunks = try mossSplitTextIntoBestSentences(
+            tokenizer: tokenizer,
+            text: "one two three, four five six, seven eight nine.",
+            maxTokens: 14
+        )
+        #expect(chunks.count > 1)
+    }
+
+    @Test func sentencePieceBPEUsesMergeScores() throws {
+        let json = """
+        {
+          "model": {
+            "type": "BPE",
+            "unk_id": 0,
+            "vocab": [
+              ["<unk>", 0.0],
+              ["▁", -100.0],
+              ["A", -100.0],
+              ["B", -100.0],
+              ["C", -100.0],
+              ["▁A", -10.0],
+              ["AB", -20.0],
+              ["BC", -1.0]
+            ]
+          }
+        }
+        """
+        let tokenizer = try SentencePieceTokenizer(tokenizerJSONData: Data(json.utf8))
+        #expect(tokenizer.encodeWithByteFallback("ABC") == [5, 7])
+    }
+
+    @Test func promptRowsAndEmbeddingsHaveExpectedShapes() throws {
+        let config = try makeTinyMossConfig()
+        let model = MossTTSNanoModel(config: config)
+
+        let textRows = model.buildTextRows([11, 12]).asArray(Int32.self)
+        #expect(textRows == [11, 8, 8, 12, 8, 8])
+
+        let promptCodes = MLXArray([Int32(1), Int32(2), Int32(3), Int32(4)], [2, 2])
+        let audioRows = try model.buildAudioPrefixRows(
+            promptAudioCodes: promptCodes,
+            slotTokenID: config.audioUserSlotTokenID
+        )
+        #expect(audioRows.asArray(Int32.self) == [8, 1, 2, 8, 3, 4])
+
+        let inputIDs = MLXArray([Int32(11), 1, 8, 12, 8, 2], [1, 2, 3]).asType(.int32)
+        let embeds = try model.buildInputsEmbeds(inputIDs)
+        #expect(embeds.shape == [1, 2, 16])
+    }
+
+    @Test func inferenceInputBuilderCombinesTextAndReferenceAudio() throws {
+        let tokenizer = MossFakeTokenizer()
+        let config = try makeTinyMossConfig()
+        let model = MossTTSNanoModel(config: config)
+        let promptCodes = MLXArray([Int32(1), Int32(2), Int32(3), Int32(4)], [2, 2])
+
+        let prepared = try model.buildInferenceInputIDs(
+            text: "target",
+            tokenizer: tokenizer,
+            promptAudioCodes: promptCodes
+        )
+
+        #expect(prepared.inputIDs.ndim == 3)
+        #expect(prepared.inputIDs.dim(0) == 1)
+        #expect(prepared.inputIDs.dim(2) == config.nVQ + 1)
+        #expect(prepared.attentionMask.shape == [1, prepared.inputIDs.dim(1)])
+    }
+
+    @Test func samplingRestrictsAssistantTextCandidates() throws {
+        var values = Array(repeating: Float(-10), count: 16)
+        values[9] = 3
+        values[7] = 1
+        let logits = MLXArray(values, [1, 16])
+
+        let next = try mossSampleAssistantTextToken(
+            textLogits: logits,
+            audioAssistantSlotTokenID: 9,
+            audioEndTokenID: 7,
+            doSample: false,
+            temperature: 1,
+            topK: 50,
+            topP: 1
+        )
+        #expect(next.asArray(Int32.self) == [9])
+    }
+
+    @Test func samplingAppliesRepetitionPenaltyAndTopK() {
+        let logits = MLXArray([Float(0), Float(2), Float(-2), Float(1)], [1, 4])
+        let penalized = mossApplyRepetitionPenalty(
+            logits: logits,
+            previousTokenIDs: MLXArray([Int32(1), Int32(2)]),
+            penalty: 2
+        ).asArray(Float.self)
+        #expect(abs(penalized[1] - 1) < 0.0001)
+        #expect(abs(penalized[2] + 4) < 0.0001)
+
+        let topK = mossApplyTopK(logits, topK: 2).asArray(Float.self)
+        #expect(topK[0].isInfinite && topK[0] < 0)
+        #expect(topK[1] == 2)
+        #expect(topK[2].isInfinite && topK[2] < 0)
+        #expect(topK[3] == 1)
+    }
+
+    @Test func samplingTopPMatchesPythonTailMask() {
+        let logits = MLXArray(
+            [0.55, 0.25, 0.15, 0.05].map { Float(log($0)) },
+            [1, 4]
+        )
+        let topP = mossApplyTopP(logits, topP: 0.79).asArray(Float.self)
+        #expect(topP[0].isFinite)
+        #expect(topP[1].isFinite)
+        #expect(topP[2].isInfinite && topP[2] < 0)
+        #expect(topP[3].isInfinite && topP[3] < 0)
+    }
+
+    @Test func defaultSamplingParametersMatchPythonCLIForMoss() throws {
+        let model = MossTTSNanoModel(config: try makeTinyMossConfig())
+        #expect(model.defaultGenerationParameters.temperature == 0.7)
+        #expect(model.defaultGenerationParameters.topP == 0.9)
+        #expect(model.defaultGenerationParameters.topK == 50)
+        #expect(model.defaultGenerationParameters.repetitionPenalty == 1.1)
+    }
+
+    @Test func sanitizeDropsUnusedUpstreamHeads() throws {
+        let model = MossTTSNanoModel(config: try makeTinyMossConfig())
+        let tensor = MLXArray.zeros([1], dtype: .float32)
+        let sanitized = model.sanitize(weights: [
+            "text_lm_head.weight": tensor,
+            "audio_lm_heads.0.weight": tensor,
+            "local_transformer.wte.weight": tensor,
+            "transformer.wte.weight": tensor,
+        ])
+
+        #expect(sanitized["text_lm_head.weight"] == nil)
+        #expect(sanitized["audio_lm_heads.0.weight"] == nil)
+        #expect(sanitized["local_transformer.wte.weight"] == nil)
+        #expect(sanitized["transformer.wte.weight"] != nil)
+    }
+
+    @Test func audioTokenizerConfigAndEmptyDecodePath() throws {
+        let directory = try makeTemporaryArtifactDirectory(prefix: "tiny-moss-audio-tokenizer")
+        defer { cleanupTemporaryArtifactDirectory(directory) }
+        let configJSON = """
+        {
+          "sample_rate": 48000,
+          "sampling_rate": 48000,
+          "downsample_rate": 4,
+          "number_channels": 2,
+          "enable_channel_interleave": true,
+          "encoder_kwargs": [
+            { "module_type": "PatchedPretransform", "patch_size": 2 }
+          ],
+          "decoder_kwargs": [
+            { "module_type": "PatchedPretransform", "patch_size": 2 }
+          ],
+          "quantizer_type": "rlfq",
+          "quantizer_kwargs": {
+            "input_dim": 2,
+            "rvq_dim": 2,
+            "output_dim": 2,
+            "num_quantizers": 1,
+            "codebook_size": 4,
+            "codebook_dim": 2
+          }
+        }
+        """
+        try writeTestFile(directory.appendingPathComponent("config.json"), contents: configJSON)
+        let parsed = try MossAudioTokenizerConfig.fromFile(directory.appendingPathComponent("config.json"))
+        #expect(parsed.numberChannels == 2)
+        #expect(parsed.encoderKwargs.count == 1)
+
+        let tokenizer = try MLXMossAudioTokenizer(config: parsed)
+        #expect(tokenizer.numQuantizers == 1)
+        let empty = try tokenizer.decodeAudioCodes(MLXArray.zeros([0, 1], type: Int32.self), numQuantizers: 1)
+        #expect(empty.shape == [0, 2])
+    }
+
+    @Test func ttsModelResolutionIncludesMossNano() {
+        #expect(TTS.resolveModelType(modelRepo: "mlx-community/MOSS-TTS-Nano") == "moss_tts_nano")
+        #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "moss_tts_nano") == "moss_tts_nano")
+    }
+}
+
 private func makeTinyQwenTokenizerDirectory() throws -> URL {
     let directory = try makeTemporaryArtifactDirectory(prefix: "tiny-qwen3-tokenizer")
 


### PR DESCRIPTION
A couple of other changes outside the scope of the model itself:
1) The SentencePiece tokenizer needs to handle BPE models in addition to unigram, so I renamed the tokenizer to be more clear about what it now supports.
2) This is the first model that emits multi-channel audio, so I added support for that in the cli tool.