### PR TITLE
Fix Qwen3ASR stream cancellation propagation

### DIFF
--- a/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
@@ -1349,7 +1349,7 @@ public class Qwen3ASRModel: Module {
         let sendableModel = UncheckedSendableBox(self)
         let sendableAudio = UncheckedSendableBox(audio)
         return AsyncThrowingStream { continuation in
-            Task.detached {
+            let task = Task.detached {
                 let model = sendableModel.value
                 let audio = sendableAudio.value
                 do {
@@ -1497,6 +1497,7 @@ public class Qwen3ASRModel: Module {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
         }
     }
 


### PR DESCRIPTION
## Summary

PR #157 fixed task cancellation for TTS stream producers. This PR applies the same cancellation bridge to Qwen3ASR.

Qwen3ASR already calls `Task.checkCancellation()` in its chunk and token loops, but its detached producer task was not cancelled when the `AsyncThrowingStream` consumer stopped iterating. This change stores the detached task and cancels it from `continuation.onTermination`.

Other ASR models are left unchanged because their stream implementations do not follow this detached-producer shape and need a broader cancellation pass.

## Verification

```bash
xcodebuild -scheme MLXAudioSTT -destination 'platform=macOS' build
```

Also manually verified in a downstream cancellation flow.
