### PR TITLE
Add VoxCPM2 TTS model (2B params, 48kHz, voice cloning)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -121,6 +121,7 @@ let package = Package(
                 "Models/Qwen3/README.md",
                 "Models/Qwen3TTS/README.md",
                 "Models/Soprano/README.md",
+                "Models/VoxCPM2/README.md",
                 "Models/StyleTTS2/KittenTTS/README.md",
                 "Models/StyleTTS2/Kokoro/README.md",
             ]

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM.swift
@@ -281,7 +281,6 @@ class VoxMiniCPMModel: Module {
             fatalError("MiniCPMModel requires either inputsEmbeds or inputIds")
         }
 
-        let B = h.dim(0)
         let L = h.dim(1)
 
         var offset = 0

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM.swift
@@ -241,7 +241,7 @@ class VoxMiniCPMModel: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding?
     let layers: [VoxMiniCPMDecoderLayer]
     @ModuleInfo var norm: VoxRMSNorm
-    var rope: VoxCPMLongRoPE?
+    let rope: VoxCPMLongRoPE?
 
     init(_ config: VoxCPM2LMConfig) {
         self.config = config
@@ -258,9 +258,7 @@ class VoxMiniCPMModel: Module {
         self.layers = (0 ..< config.numHiddenLayers).map { _ in VoxMiniCPMDecoderLayer(config) }
         self._norm.wrappedValue = VoxRMSNorm(dims: config.hiddenSize, eps: config.rmsNormEps)
 
-        if !config.noRope {
-            self.rope = VoxCPMLongRoPE(config)
-        }
+        self.rope = config.noRope ? nil : VoxCPMLongRoPE(config)
 
         super.init()
     }
@@ -305,6 +303,7 @@ class VoxMiniCPMModel: Module {
         }
 
         var newCaches: [(MLXArray, MLXArray)] = []
+        newCaches.reserveCapacity(layers.count)
         for (i, layer) in layers.enumerated() {
             let layerCache = cache?[i]
             let c: (MLXArray, MLXArray)

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM.swift
@@ -1,0 +1,319 @@
+//
+//  MiniCPM.swift
+//  MLXAudio
+//
+//  MiniCPM transformer backbone for VoxCPM2.
+//  Ported from mlx-audio Python: voxcpm2/minicpm.py
+//
+
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+// MARK: - RMS Norm
+
+class VoxRMSNorm: Module {
+    let weight: MLXArray
+    let eps: Float
+
+    init(dims: Int, eps: Float = 1e-6) {
+        self.weight = MLXArray.ones([dims])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: weight, eps: eps)
+    }
+}
+
+// MARK: - LongRoPE
+
+class VoxCPMLongRoPE: Module {
+    let config: VoxCPM2LMConfig
+    let dim: Int
+    let base: Float
+    let maxPositionEmbeddings: Int
+    let originalMaxPositionEmbeddings: Int
+    let shortFactor: MLXArray
+    let longFactor: MLXArray
+    let scalingFactor: Float
+    let invFreq: MLXArray
+
+    init(_ config: VoxCPM2LMConfig) {
+        self.config = config
+        self.dim = config.kvChannels ?? (config.hiddenSize / config.numAttentionHeads)
+        self.base = config.ropeTheta
+        self.maxPositionEmbeddings = config.maxPositionEmbeddings
+        self.originalMaxPositionEmbeddings = config.originalMaxPositionEmbeddings
+
+        self.shortFactor = MLXArray(config.ropeShortFactor)
+        self.longFactor = MLXArray(config.ropeLongFactor)
+
+        let scale = Float(config.maxPositionEmbeddings) / Float(config.originalMaxPositionEmbeddings)
+        self.scalingFactor = Foundation.sqrt(
+            1.0 + log(max(scale, 1.0)) / log(Float(config.originalMaxPositionEmbeddings))
+        )
+
+        let halfDim = dim / 2
+        let exponents = MLXArray(0 ..< halfDim).asType(.float32) / Float(halfDim)
+        self.invFreq = 1.0 / MLX.pow(MLXArray(base), exponents)
+
+        super.init()
+    }
+
+    func callAsFunction(_ positionIds: MLXArray) -> (MLXArray, MLXArray) {
+        let seqLen = positionIds.max().item(Int.self) + 1
+
+        let factors = seqLen > originalMaxPositionEmbeddings ? longFactor : shortFactor
+
+        let t = MLXArray(0 ..< seqLen).asType(.float32)
+
+        let freqs = (t.expandedDimensions(axis: 1) * (1.0 / factors.expandedDimensions(axis: 0)))
+            * invFreq.expandedDimensions(axis: 0)
+        let emb = MLX.concatenated([freqs, freqs], axis: -1)
+
+        let cos = MLX.cos(emb) * scalingFactor
+        let sin = MLX.sin(emb) * scalingFactor
+
+        return (cos[positionIds], sin[positionIds])
+    }
+}
+
+// MARK: - Rotary Embedding Helpers
+
+private func rotateHalf(_ x: MLXArray) -> MLXArray {
+    let half = x.dim(-1) / 2
+    let x1 = x[.ellipsis, ..<half]
+    let x2 = x[.ellipsis, half...]
+    return MLX.concatenated([-x2, x1], axis: -1)
+}
+
+private func applyRotaryPosEmb(
+    _ q: MLXArray, _ k: MLXArray, cos: MLXArray, sin: MLXArray
+) -> (MLXArray, MLXArray) {
+    // cos/sin: (B, L, D) -> (B, L, 1, D) for broadcasting over heads
+    let cosE = cos[0..., 0..., .newAxis, 0...]
+    let sinE = sin[0..., 0..., .newAxis, 0...]
+
+    let qEmb = (q * cosE) + (rotateHalf(q) * sinE)
+    let kEmb = (k * cosE) + (rotateHalf(k) * sinE)
+    return (qEmb, kEmb)
+}
+
+// MARK: - Attention
+
+class VoxAttention: Module {
+    let numHeads: Int
+    let numKVHeads: Int
+    let headDim: Int
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+
+    init(_ config: VoxCPM2LMConfig) {
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.kvChannels ?? (config.hiddenSize / config.numAttentionHeads)
+
+        self._qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: false)
+        self._kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        self._vProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        self._oProj.wrappedValue = Linear(numHeads * headDim, config.hiddenSize, bias: false)
+
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        cos: MLXArray?,
+        sin: MLXArray?,
+        mask: MLXArray?,
+        cache: (MLXArray, MLXArray)?
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        var q = qProj(x).reshaped(B, L, numHeads, headDim)
+        var k = kProj(x).reshaped(B, L, numKVHeads, headDim)
+        let v = vProj(x).reshaped(B, L, numKVHeads, headDim)
+
+        if let cos, let sin {
+            (q, k) = applyRotaryPosEmb(q, k, cos: cos, sin: sin)
+        }
+
+        var kFull = k
+        var vFull = v
+        if let cache {
+            kFull = MLX.concatenated([cache.0, k], axis: 1)
+            vFull = MLX.concatenated([cache.1, v], axis: 1)
+        }
+
+        let newCache = (kFull, vFull)
+
+        let qT = q.transposed(0, 2, 1, 3)
+        let kT = kFull.transposed(0, 2, 1, 3)
+        let vT = vFull.transposed(0, 2, 1, 3)
+
+        let out = MLXFast.scaledDotProductAttention(
+            queries: qT, keys: kT, values: vT,
+            scale: 1.0 / Foundation.sqrt(Float(headDim)),
+            mask: mask
+        )
+
+        let outReshaped = out.transposed(0, 2, 1, 3).reshaped(B, L, -1)
+        return (oProj(outReshaped), newCache)
+    }
+}
+
+// MARK: - MLP (SwiGLU)
+
+class VoxMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(_ config: VoxCPM2LMConfig) {
+        self._gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+// MARK: - Decoder Layer
+
+class VoxMiniCPMDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: VoxAttention
+    @ModuleInfo var mlp: VoxMLP
+    @ModuleInfo(key: "input_layernorm") var inputLayernorm: VoxRMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: VoxRMSNorm
+
+    let scaleDepth: Float
+    let numHiddenLayers: Int
+    let useMup: Bool
+
+    init(_ config: VoxCPM2LMConfig) {
+        self._selfAttn.wrappedValue = VoxAttention(config)
+        self._mlp.wrappedValue = VoxMLP(config)
+        self._inputLayernorm.wrappedValue = VoxRMSNorm(dims: config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayernorm.wrappedValue = VoxRMSNorm(dims: config.hiddenSize, eps: config.rmsNormEps)
+        self.scaleDepth = config.scaleDepth
+        self.numHiddenLayers = config.numHiddenLayers
+        self.useMup = config.useMup
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        cos: MLXArray?,
+        sin: MLXArray?,
+        mask: MLXArray?,
+        cache: (MLXArray, MLXArray)?
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let scale = useMup ? scaleDepth / Foundation.sqrt(Float(numHiddenLayers)) : 1.0
+
+        var r = x
+        var h: MLXArray
+        let newCache: (MLXArray, MLXArray)
+        (h, newCache) = selfAttn(inputLayernorm(x), cos: cos, sin: sin, mask: mask, cache: cache)
+        var out = r + h * scale
+
+        r = out
+        h = mlp(postAttentionLayernorm(out))
+        out = r + h * scale
+
+        return (out, newCache)
+    }
+}
+
+// MARK: - MiniCPM Model
+
+class VoxMiniCPMModel: Module {
+    let config: VoxCPM2LMConfig
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding?
+    let layers: [VoxMiniCPMDecoderLayer]
+    @ModuleInfo var norm: VoxRMSNorm
+    var rope: VoxCPMLongRoPE?
+
+    init(_ config: VoxCPM2LMConfig) {
+        self.config = config
+
+        if config.vocabSize > 0 {
+            self._embedTokens.wrappedValue = Embedding(
+                embeddingCount: config.vocabSize,
+                dimensions: config.hiddenSize
+            )
+        } else {
+            self._embedTokens.wrappedValue = nil
+        }
+
+        self.layers = (0 ..< config.numHiddenLayers).map { _ in VoxMiniCPMDecoderLayer(config) }
+        self._norm.wrappedValue = VoxRMSNorm(dims: config.hiddenSize, eps: config.rmsNormEps)
+
+        if !config.noRope {
+            self.rope = VoxCPMLongRoPE(config)
+        }
+
+        super.init()
+    }
+
+    func callAsFunction(
+        inputsEmbeds: MLXArray? = nil,
+        inputIds: MLXArray? = nil,
+        mask: MLXArray? = nil,
+        cache: [(MLXArray, MLXArray)]? = nil,
+        isCausal: Bool = true
+    ) -> (MLXArray, [(MLXArray, MLXArray)]) {
+        var h: MLXArray
+        if let inputsEmbeds {
+            h = inputsEmbeds
+        } else if let inputIds, let embedTokens {
+            h = embedTokens(inputIds)
+        } else {
+            fatalError("MiniCPMModel requires either inputsEmbeds or inputIds")
+        }
+
+        let B = h.dim(0)
+        let L = h.dim(1)
+
+        var offset = 0
+        if let cache, !cache.isEmpty {
+            offset = cache[0].0.dim(1)
+        }
+
+        var cos: MLXArray?
+        var sin: MLXArray?
+        if let rope {
+            let positionIds = MLXArray(offset ..< (offset + L)).asType(.int32)
+            (cos, sin) = rope(positionIds)
+            cos = cos!.expandedDimensions(axis: 0)
+            sin = sin!.expandedDimensions(axis: 0)
+        }
+
+        var attnMask = mask
+        if attnMask == nil && isCausal && L > 1 {
+            let ones = MLXArray.ones([L, L])
+            let causalMask = triu(ones, k: 1) * Float(-1e9)
+            attnMask = causalMask.expandedDimensions(axes: [0, 1])
+        }
+
+        var newCaches: [(MLXArray, MLXArray)] = []
+        for (i, layer) in layers.enumerated() {
+            let layerCache = cache?[i]
+            let c: (MLXArray, MLXArray)
+            (h, c) = layer(h, cos: cos, sin: sin, mask: attnMask, cache: layerCache)
+            newCaches.append(c)
+        }
+
+        h = norm(h)
+        return (h, newCaches)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
@@ -1,0 +1,70 @@
+# VoxCPM2 TTS
+
+Autoregressive MiniCPM backbone + CFM diffusion + AudioVAE decoder. Produces 48kHz speech with voice cloning from a reference audio clip. 2B parameters, supports 30+ languages.
+
+## Supported Models
+
+- [mlx-community/VoxCPM2-4bit](https://huggingface.co/mlx-community/VoxCPM2-4bit) (4-bit quantized, ~2.3GB)
+
+## Swift Example
+
+```swift
+import MLXAudioTTS
+import MLXAudioCore
+
+// Load model
+let model = try await VoxCPM2Model.fromPretrained("mlx-community/VoxCPM2-4bit")
+
+// Voice cloning requires reference audio
+let (_, refAudio) = try loadAudioArray(from: referenceAudioURL)
+let audio = try await model.generate(
+    text: "Hello, this is a test of VoxCPM2.",
+    voice: nil, refAudio: refAudio, refText: nil, language: nil,
+    generationParameters: GenerateParameters(maxTokens: 100, temperature: 1.0)
+)
+// audio is an MLXArray of Float32 samples at 48kHz
+```
+
+### Zero-Shot (No Reference)
+
+```swift
+let audio = try await model.generate(
+    text: "Zero-shot generation without a reference voice.",
+    voice: nil, refAudio: nil, refText: nil, language: nil,
+    generationParameters: GenerateParameters(maxTokens: 100, temperature: 1.0)
+)
+```
+
+## Streaming Example
+
+VoxCPM2 streaming wraps the full generation and yields the result as a single audio event:
+
+```swift
+for try await event in model.generateStream(
+    text: "Streaming test.", voice: nil, refAudio: refAudio,
+    refText: nil, language: nil,
+    generationParameters: GenerateParameters(maxTokens: 100, temperature: 1.0)
+) {
+    switch event {
+    case .audio(let samples):
+        // Full audio output (48kHz Float32)
+        break
+    case .info(let info):
+        print("Generated in \(info.generateTime)s")
+    case .token(_):
+        break
+    }
+}
+```
+
+## Output Format
+
+- **Sample rate**: 48kHz
+- **Format**: Mono Float32 PCM
+- **VAE encoder rate**: 16kHz (internal; resampling is handled automatically)
+
+## Known Limitations
+
+- The 4-bit quantized stop predictor can be unreliable — callers should set `maxTokens` conservatively to avoid runaway generation.
+- Short prompts (especially in Chinese) may have text-following issues, consistent with the upstream Python implementation.
+- Streaming currently wraps the full `generate()` call rather than yielding incremental audio chunks.

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxAudioVAE.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxAudioVAE.swift
@@ -566,7 +566,7 @@ class VoxAudioVAE: Module {
     }
 
     func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        var filtered = weights.filter { !$0.key.contains("fc_logvar") }
+        let filtered = weights.filter { !$0.key.contains("fc_logvar") }
 
         // Fuse weight_norm: weight_g + weight_v → weight
         var fused = [String: MLXArray]()

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxAudioVAE.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxAudioVAE.swift
@@ -1,0 +1,759 @@
+//
+//  VoxAudioVAE.swift
+//  MLXAudio
+//
+//  VoxCPM2 AudioVAE: causal convolutional encoder/decoder with Snake activations.
+//  Asymmetric: encodes at 16kHz, decodes to 48kHz with sample-rate conditioning.
+//  Ported from mlx-audio Python: voxcpm2/audio_vae.py
+//
+
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+// MARK: - Causal Conv1d
+
+class VoxCausalConv1d: Module {
+    @ModuleInfo var conv: Conv1d
+    let padVal: Int
+
+    init(
+        inChannels: Int,
+        outChannels: Int,
+        kernelSize: Int,
+        stride: Int = 1,
+        dilation: Int = 1,
+        padding: Int = 0,
+        groups: Int = 1,
+        bias: Bool = true
+    ) {
+        self.padVal = padding
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            padding: 0,
+            dilation: dilation,
+            groups: groups,
+            bias: bias
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        if padVal > 0 {
+            let padded = MLX.padded(x, widths: [IntOrPair((0, 0)), IntOrPair((padVal * 2, 0)), IntOrPair((0, 0))])
+            return conv(padded)
+        }
+        return conv(x)
+    }
+}
+
+// MARK: - Causal Transpose Conv1d
+
+class VoxCausalTransposeConv1d: Module {
+    @ModuleInfo var conv: ConvTransposed1d
+    let padVal: Int
+    let outputPadding: Int
+
+    init(
+        inChannels: Int,
+        outChannels: Int,
+        kernelSize: Int,
+        stride: Int = 1,
+        padding: Int = 0,
+        outputPadding: Int = 0,
+        bias: Bool = true
+    ) {
+        self.padVal = padding
+        self.outputPadding = outputPadding
+        self._conv.wrappedValue = ConvTransposed1d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            padding: 0,
+            bias: bias
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = conv(x)
+        let trim = padVal * 2 - outputPadding
+        if trim > 0 {
+            y = y[0..., ..<(-trim), 0...]
+        }
+        return y
+    }
+}
+
+// MARK: - Snake Activation
+
+class VoxSnake1d: Module {
+    let alpha: MLXArray
+
+    init(channels: Int) {
+        self.alpha = MLXArray.ones([1, 1, channels])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        x + (1.0 / (alpha + 1e-9)) * MLX.pow(MLX.sin(alpha * x), 2)
+    }
+}
+
+// MARK: - Causal Residual Unit
+
+class VoxCausalResidualUnit: Module {
+    @ModuleInfo var snake1: VoxSnake1d
+    @ModuleInfo var conv1: VoxCausalConv1d
+    @ModuleInfo var snake2: VoxSnake1d
+    @ModuleInfo var conv2: VoxCausalConv1d
+
+    init(dim: Int = 16, dilation: Int = 1, kernel: Int = 7, groups: Int = 1) {
+        let pad = ((kernel - 1) * dilation) / 2
+
+        self._snake1.wrappedValue = VoxSnake1d(channels: dim)
+        self._conv1.wrappedValue = VoxCausalConv1d(
+            inChannels: dim, outChannels: dim,
+            kernelSize: kernel, dilation: dilation, padding: pad, groups: groups
+        )
+        self._snake2.wrappedValue = VoxSnake1d(channels: dim)
+        self._conv2.wrappedValue = VoxCausalConv1d(
+            inChannels: dim, outChannels: dim, kernelSize: 1
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let res = x
+        var h = snake1(x)
+        h = conv1(h)
+        h = snake2(h)
+        h = conv2(h)
+        return res + h
+    }
+}
+
+// MARK: - Encoder Block
+
+class VoxCausalEncoderBlock: Module {
+    @ModuleInfo var res1: VoxCausalResidualUnit
+    @ModuleInfo var res2: VoxCausalResidualUnit
+    @ModuleInfo var res3: VoxCausalResidualUnit
+    @ModuleInfo var snake: VoxSnake1d
+    @ModuleInfo var conv: VoxCausalConv1d
+
+    init(outputDim: Int = 16, inputDim: Int? = nil, stride: Int = 1, groups: Int = 1) {
+        let inDim = inputDim ?? outputDim / 2
+
+        self._res1.wrappedValue = VoxCausalResidualUnit(dim: inDim, dilation: 1, groups: groups)
+        self._res2.wrappedValue = VoxCausalResidualUnit(dim: inDim, dilation: 3, groups: groups)
+        self._res3.wrappedValue = VoxCausalResidualUnit(dim: inDim, dilation: 9, groups: groups)
+        self._snake.wrappedValue = VoxSnake1d(channels: inDim)
+        self._conv.wrappedValue = VoxCausalConv1d(
+            inChannels: inDim, outChannels: outputDim,
+            kernelSize: 2 * stride, stride: stride,
+            padding: Int(ceil(Double(stride) / 2.0))
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = res1(x)
+        h = res2(h)
+        h = res3(h)
+        h = snake(h)
+        h = conv(h)
+        return h
+    }
+}
+
+// MARK: - Causal Encoder
+
+class VoxCausalEncoder: Module {
+    @ModuleInfo(key: "conv_in") var convIn: VoxCausalConv1d
+    let blocks: [VoxCausalEncoderBlock]
+    @ModuleInfo(key: "fc_mu") var fcMu: VoxCausalConv1d
+
+    init(
+        dModel: Int = 64,
+        latentDim: Int = 32,
+        strides: [Int] = [2, 4, 8, 8],
+        depthwise: Bool = false
+    ) {
+        self._convIn.wrappedValue = VoxCausalConv1d(
+            inChannels: 1, outChannels: dModel, kernelSize: 7, padding: 3
+        )
+
+        var blockList: [VoxCausalEncoderBlock] = []
+        var currDim = dModel
+        for stride in strides {
+            let nextDim = currDim * 2
+            let groups = depthwise ? nextDim / 2 : 1
+            blockList.append(VoxCausalEncoderBlock(
+                outputDim: nextDim, inputDim: currDim, stride: stride, groups: groups
+            ))
+            currDim = nextDim
+        }
+        self.blocks = blockList
+
+        self._fcMu.wrappedValue = VoxCausalConv1d(
+            inChannels: currDim, outChannels: latentDim, kernelSize: 3, padding: 1
+        )
+
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = convIn(x)
+        for block in blocks {
+            h = block(h)
+        }
+        return fcMu(h)
+    }
+}
+
+// MARK: - Noise Block
+
+class VoxNoiseBlock: Module {
+    @ModuleInfo var linear: VoxCausalConv1d
+
+    init(dim: Int) {
+        self._linear.wrappedValue = VoxCausalConv1d(
+            inChannels: dim, outChannels: dim, kernelSize: 1, bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let noise = MLXRandom.normal([x.dim(0), x.dim(1), 1]).asType(x.dtype)
+        let h = linear(x)
+        return x + noise * h
+    }
+}
+
+// MARK: - Decoder Block
+
+class VoxCausalDecoderBlock: Module {
+    let inputChannels: Int
+
+    @ModuleInfo var snake: VoxSnake1d
+    @ModuleInfo(key: "conv_t") var convT: VoxCausalTransposeConv1d
+    var noise: VoxNoiseBlock?
+    @ModuleInfo var res1: VoxCausalResidualUnit
+    @ModuleInfo var res2: VoxCausalResidualUnit
+    @ModuleInfo var res3: VoxCausalResidualUnit
+
+    init(
+        inputDim: Int = 16,
+        outputDim: Int = 8,
+        stride: Int = 1,
+        groups: Int = 1,
+        useNoiseBlock: Bool = false
+    ) {
+        self.inputChannels = inputDim
+
+        self._snake.wrappedValue = VoxSnake1d(channels: inputDim)
+        self._convT.wrappedValue = VoxCausalTransposeConv1d(
+            inChannels: inputDim, outChannels: outputDim,
+            kernelSize: 2 * stride, stride: stride,
+            padding: Int(ceil(Double(stride) / 2.0)),
+            outputPadding: stride % 2
+        )
+
+        if useNoiseBlock {
+            self.noise = VoxNoiseBlock(dim: outputDim)
+        }
+
+        self._res1.wrappedValue = VoxCausalResidualUnit(dim: outputDim, dilation: 1, groups: groups)
+        self._res2.wrappedValue = VoxCausalResidualUnit(dim: outputDim, dilation: 3, groups: groups)
+        self._res3.wrappedValue = VoxCausalResidualUnit(dim: outputDim, dilation: 9, groups: groups)
+
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = snake(x)
+        h = convT(h)
+        if let noise {
+            h = noise(h)
+        }
+        h = res1(h)
+        h = res2(h)
+        h = res3(h)
+        return h
+    }
+}
+
+// MARK: - Sample Rate Conditioning Layer
+
+class VoxSRCondLayer: Module {
+    let condType: String
+
+    @ModuleInfo(key: "scale_embed") var scaleEmbed: Embedding?
+    @ModuleInfo(key: "bias_embed") var biasEmbed: Embedding?
+    @ModuleInfo(key: "cond_embed") var condEmbed: Embedding?
+    @ModuleInfo(key: "out_snake") var outSnake: VoxSnake1d?
+    @ModuleInfo(key: "out_conv") var outConv: VoxCausalConv1d?
+    let hasOutLayer: Bool
+
+    init(
+        inputDim: Int,
+        srBinBuckets: Int,
+        condType: String = "scale_bias",
+        condDim: Int = 128,
+        outLayer: Bool = false
+    ) {
+        self.condType = condType
+        self.hasOutLayer = outLayer
+
+        if condType == "scale_bias" || condType == "scale_bias_init" {
+            self._scaleEmbed.wrappedValue = Embedding(embeddingCount: srBinBuckets, dimensions: inputDim)
+            self._biasEmbed.wrappedValue = Embedding(embeddingCount: srBinBuckets, dimensions: inputDim)
+        } else if condType == "add" {
+            self._condEmbed.wrappedValue = Embedding(embeddingCount: srBinBuckets, dimensions: inputDim)
+        } else if condType == "concat" {
+            self._condEmbed.wrappedValue = Embedding(embeddingCount: srBinBuckets, dimensions: condDim)
+        }
+
+        if outLayer {
+            let outDim = condType == "concat" ? inputDim + condDim : inputDim
+            self._outSnake.wrappedValue = VoxSnake1d(channels: outDim)
+            self._outConv.wrappedValue = VoxCausalConv1d(
+                inChannels: outDim, outChannels: inputDim, kernelSize: 1
+            )
+        }
+
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, srCond: MLXArray) -> MLXArray {
+        var h = x
+        if condType == "scale_bias" || condType == "scale_bias_init", let scaleEmbed, let biasEmbed {
+            let scale = scaleEmbed(srCond)[0..., .newAxis, 0...]
+            let bias = biasEmbed(srCond)[0..., .newAxis, 0...]
+            h = h * scale + bias
+        } else if condType == "add", let condEmbed {
+            h = h + condEmbed(srCond)[0..., .newAxis, 0...]
+        } else if condType == "concat", let condEmbed {
+            var cond = condEmbed(srCond)[0..., .newAxis, 0...]
+            cond = MLX.broadcast(cond, to: [h.dim(0), h.dim(1), cond.dim(-1)])
+            h = MLX.concatenated([h, cond], axis: -1)
+        }
+
+        if hasOutLayer, let outSnake, let outConv {
+            h = outSnake(h)
+            h = outConv(h)
+        }
+
+        return h
+    }
+}
+
+// MARK: - Causal Decoder
+
+class VoxCausalDecoder: Module {
+    @ModuleInfo(key: "conv_in") var convIn: Module
+    let blocks: [VoxCausalDecoderBlock]
+    @ModuleInfo(key: "snake_out") var snakeOut: VoxSnake1d
+    @ModuleInfo(key: "conv_out") var convOut: VoxCausalConv1d
+    let srCondLayers: [VoxSRCondLayer?]
+    var srBoundaries: MLXArray?
+
+    init(
+        inputChannel: Int,
+        channels: Int,
+        rates: [Int],
+        depthwise: Bool = false,
+        dOut: Int = 1,
+        useNoiseBlock: Bool = false,
+        srBinBoundaries: [Int]? = nil,
+        condType: String = "scale_bias",
+        condDim: Int = 128,
+        condOutLayer: Bool = false
+    ) {
+        // Conv in (depthwise: 2-layer sequential, else single conv)
+        if depthwise {
+            let depthConv = VoxCausalConv1d(
+                inChannels: inputChannel, outChannels: inputChannel,
+                kernelSize: 7, padding: 3, groups: inputChannel
+            )
+            let pointConv = VoxCausalConv1d(
+                inChannels: inputChannel, outChannels: channels, kernelSize: 1
+            )
+            self._convIn.wrappedValue = VoxSequential(depthConv, pointConv)
+        } else {
+            self._convIn.wrappedValue = VoxCausalConv1d(
+                inChannels: inputChannel, outChannels: channels, kernelSize: 7, padding: 3
+            )
+        }
+
+        var blockList: [VoxCausalDecoderBlock] = []
+        for (i, stride) in rates.enumerated() {
+            let inDim = channels / (1 << i)
+            let outDim = channels / (1 << (i + 1))
+            let groups = depthwise ? outDim : 1
+            blockList.append(VoxCausalDecoderBlock(
+                inputDim: inDim, outputDim: outDim, stride: stride,
+                groups: groups, useNoiseBlock: useNoiseBlock
+            ))
+        }
+        self.blocks = blockList
+
+        let finalDim = channels / (1 << rates.count)
+        self._snakeOut.wrappedValue = VoxSnake1d(channels: finalDim)
+        self._convOut.wrappedValue = VoxCausalConv1d(
+            inChannels: finalDim, outChannels: dOut, kernelSize: 7, padding: 3
+        )
+
+        // SR conditioning
+        if let boundaries = srBinBoundaries {
+            self.srBoundaries = MLXArray(boundaries.map { Int32($0) })
+            let srBinBuckets = boundaries.count + 1
+            var condLayers: [VoxSRCondLayer?] = []
+            for block in blockList {
+                condLayers.append(VoxSRCondLayer(
+                    inputDim: block.inputChannels,
+                    srBinBuckets: srBinBuckets,
+                    condType: condType,
+                    condDim: condDim,
+                    outLayer: condOutLayer
+                ))
+            }
+            self.srCondLayers = condLayers
+        } else {
+            self.srBoundaries = nil
+            self.srCondLayers = []
+        }
+
+        super.init()
+    }
+
+    func getSRIdx(_ sr: MLXArray) -> MLXArray {
+        guard let boundaries = srBoundaries else {
+            return MLXArray([Int32(0)])
+        }
+        return MLX.sum(sr .>= boundaries).asType(.int32).reshaped([1])
+    }
+
+    func callAsFunction(_ x: MLXArray, srCond: MLXArray? = nil) -> MLXArray {
+        var h: MLXArray
+        if let seq = convIn as? VoxSequential {
+            h = seq(x)
+        } else if let conv = convIn as? VoxCausalConv1d {
+            h = conv(x)
+        } else {
+            fatalError("Unexpected conv_in type")
+        }
+
+        if let srCond, srBoundaries != nil {
+            let srIdx = getSRIdx(srCond)
+            for (block, condLayer) in zip(blocks, srCondLayers) {
+                if let condLayer {
+                    h = condLayer(h, srCond: srIdx)
+                }
+                h = block(h)
+            }
+        } else {
+            for block in blocks {
+                h = block(h)
+            }
+        }
+
+        h = snakeOut(h)
+        h = convOut(h)
+        return MLX.tanh(h)
+    }
+}
+
+// MARK: - Simple Sequential (for depthwise conv_in)
+
+class VoxSequential: Module {
+    let layers: [Module]
+
+    init(_ layers: Module...) {
+        self.layers = layers
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            if let conv = layer as? VoxCausalConv1d {
+                h = conv(h)
+            }
+        }
+        return h
+    }
+}
+
+// MARK: - AudioVAE
+
+class VoxAudioVAE: Module {
+    let config: VoxCPM2AudioVAEConfig
+    let hopLength: Int
+    let latentDim: Int
+    let encodeSampleRate: Int
+    let outSampleRate: Int
+    let chunkSize: Int
+    let decodeChunkSize: Int
+
+    @ModuleInfo var encoder: VoxCausalEncoder
+    @ModuleInfo var decoder: VoxCausalDecoder
+
+    init(_ config: VoxCPM2AudioVAEConfig) {
+        self.config = config
+
+        self.hopLength = config.encoderRates.reduce(1, *)
+        self.latentDim = config.latentDim
+        self.encodeSampleRate = config.sampleRate
+        self.outSampleRate = config.outSampleRate
+        self.chunkSize = config.encoderRates.reduce(1, *)
+        self.decodeChunkSize = config.decoderRates.reduce(1, *)
+
+        self._encoder.wrappedValue = VoxCausalEncoder(
+            dModel: config.encoderDim,
+            latentDim: config.latentDim,
+            strides: config.encoderRates,
+            depthwise: config.depthwise
+        )
+        self._decoder.wrappedValue = VoxCausalDecoder(
+            inputChannel: config.latentDim,
+            channels: config.decoderDim,
+            rates: config.decoderRates,
+            depthwise: config.depthwise,
+            dOut: 1,
+            useNoiseBlock: config.useNoiseBlock,
+            srBinBoundaries: config.srBinBoundaries,
+            condType: config.condType,
+            condDim: config.condDim,
+            condOutLayer: config.condOutLayer
+        )
+
+        super.init()
+    }
+
+    func encode(_ x: MLXArray, sampleRate: Int? = nil) -> MLXArray {
+        var inp = x
+        if inp.ndim == 2 {
+            inp = inp.expandedDimensions(axis: -1)
+        }
+        // Ensure (B, T, C) layout
+        if inp.dim(1) < inp.dim(2) {
+            inp = inp.transposed(0, 2, 1)
+        }
+        inp = preprocess(inp, sampleRate: sampleRate)
+        return encoder(inp)
+    }
+
+    func decode(_ z: MLXArray, srCond: MLXArray? = nil) -> MLXArray {
+        let sr = srCond ?? MLXArray([Int32(outSampleRate)])
+        let out = decoder(z, srCond: sr)
+        return out.squeezed(axis: -1)
+    }
+
+    private func preprocess(_ audioData: MLXArray, sampleRate: Int?) -> MLXArray {
+        let length = audioData.dim(1)
+        let padTo = hopLength
+        let rightPad = (Int(ceil(Double(length) / Double(padTo))) * padTo) - length
+        if rightPad > 0 {
+            return MLX.padded(audioData, widths: [IntOrPair((0, 0)), IntOrPair((0, rightPad)), IntOrPair((0, 0))])
+        }
+        return audioData
+    }
+
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var filtered = weights.filter { !$0.key.contains("fc_logvar") }
+
+        // Fuse weight_norm: weight_g + weight_v → weight
+        var fused = [String: MLXArray]()
+        var processedKeys = Set<String>()
+
+        for (key, value) in filtered {
+            if processedKeys.contains(key) { continue }
+
+            if key.hasSuffix(".weight_g") {
+                let base = String(key.dropLast(9))
+                let vKey = base + ".weight_v"
+                if let g = filtered[key], let v = filtered[vKey] {
+                    let vFlat = v.reshaped(v.dim(0), -1)
+                    let norm = MLX.sqrt(MLX.sum(vFlat * vFlat, axis: 1)).reshaped(g.shape)
+                    let w = g * (v / (norm + 1e-9))
+                    fused[base + ".weight"] = w
+                    processedKeys.insert(key)
+                    processedKeys.insert(vKey)
+                    continue
+                }
+            }
+            if key.hasSuffix(".weight_v") { continue }
+
+            fused[key] = value
+        }
+
+        // Detect whether keys are raw PyTorch format (encoder.block.N)
+        // or already-sanitized MLX Python format (encoder.blocks.layers.N).
+        // Quantized models (e.g. VoxCPM2-4bit) ship with pre-sanitized keys.
+        let isRawPyTorch = fused.keys.contains { $0.hasPrefix("encoder.block.") || $0.hasPrefix("decoder.model.") }
+
+        var remapped: [String: MLXArray]
+        if isRawPyTorch {
+            remapped = remapPyTorchKeys(fused)
+        } else {
+            remapped = fused
+        }
+
+        // Python uses nn.Sequential for blocks → adds "layers" level.
+        // Swift uses plain [Module] arrays → no "layers" level.
+        // Strip "blocks.layers.N" → "blocks.N" for both encoder and decoder.
+        var stripped = [String: MLXArray]()
+        let blocksLayersPattern = try! NSRegularExpression(pattern: #"\bblocks\.layers\.(\d+)"#)
+        for (key, value) in remapped {
+            let range = NSRange(key.startIndex..., in: key)
+            let newKey = blocksLayersPattern.stringByReplacingMatches(
+                in: key, range: range, withTemplate: "blocks.$1"
+            )
+            stripped[newKey] = value
+        }
+        remapped = stripped
+
+        // Remap snake_case property names to Swift camelCase.
+        // The Swift VoxCausalDecoder uses `let srCondLayers` (camelCase),
+        // but safetensors keys use `sr_cond_layers` (snake_case).
+        var camelCased = [String: MLXArray]()
+        for (key, value) in remapped {
+            let newKey = key.replacingOccurrences(of: "sr_cond_layers", with: "srCondLayers")
+            camelCased[newKey] = value
+        }
+        remapped = camelCased
+
+        // Handle sr_boundaries buffer
+        if let srBounds = remapped.removeValue(forKey: "decoder._sr_boundaries") {
+            remapped["decoder.srBoundaries"] = srBounds
+        }
+        if let srBounds = remapped.removeValue(forKey: "decoder.sr_boundaries") {
+            remapped["decoder.srBoundaries"] = srBounds
+        }
+
+        // Swift VoxCausalConv1d/VoxCausalTransposeConv1d wrap inner conv as
+        // @ModuleInfo var conv, adding ".conv." to the key path.
+        // Python uses inheritance (flat). Insert ".conv." for wrapper types.
+        var finalWeights = [String: MLXArray]()
+        let convWrapperSuffixes = [
+            ".conv_t", ".conv_in", ".conv_out", ".fc_mu",
+            ".conv1", ".conv2", ".conv", ".linear", ".out_conv"
+        ]
+        for (key, value) in remapped {
+            var k = key
+            for terminal in [".weight", ".bias"] {
+                guard k.hasSuffix(terminal) else { continue }
+                let stem = String(k.dropLast(terminal.count))
+                let isConvWrapper = convWrapperSuffixes.contains { stem.hasSuffix($0) }
+                let isSeqLayer = stem.range(
+                    of: #"\.conv_in\.layers\.\d+$"#, options: .regularExpression
+                ) != nil
+                if isConvWrapper || isSeqLayer {
+                    k = stem + ".conv" + terminal
+                }
+            }
+            finalWeights[k] = value
+        }
+
+        return finalWeights
+    }
+
+    private func remapPyTorchKeys(_ fused: [String: MLXArray]) -> [String: MLXArray] {
+        var remapped = [String: MLXArray]()
+        let numDecBlocks = config.decoderRates.count
+
+        for (key, value) in fused {
+            let parts = key.split(separator: ".").map(String.init)
+            var newParts: [String]
+
+            if parts[0] == "encoder" {
+                if parts[1] == "block" {
+                    let idx = Int(parts[2])!
+                    if idx == 0 {
+                        newParts = ["encoder", "conv_in"] + Array(parts[3...])
+                    } else {
+                        newParts = ["encoder", "blocks", String(idx - 1)] + Array(parts[3...])
+                    }
+                } else {
+                    newParts = parts
+                }
+            } else if parts[0] == "decoder" {
+                if parts[1] == "model" {
+                    let idx = Int(parts[2])!
+                    if idx == 0 {
+                        newParts = ["decoder", "conv_in", "layers", "0"] + Array(parts[3...])
+                    } else if idx == 1 {
+                        newParts = ["decoder", "conv_in", "layers", "1"] + Array(parts[3...])
+                    } else if idx >= 2 && idx < 2 + numDecBlocks {
+                        newParts = ["decoder", "blocks", String(idx - 2)] + Array(parts[3...])
+                    } else if idx == 2 + numDecBlocks {
+                        newParts = ["decoder", "snake_out"] + Array(parts[3...])
+                    } else if idx == 2 + numDecBlocks + 1 {
+                        newParts = ["decoder", "conv_out"] + Array(parts[3...])
+                    } else {
+                        newParts = parts
+                    }
+                } else if parts[1] == "sr_cond_model" {
+                    let ptIdx = Int(parts[2])!
+                    let offset = config.depthwise ? 2 : 1
+                    let mlxIdx = ptIdx - offset
+                    newParts = ["decoder", "sr_cond_layers", String(mlxIdx)] + Array(parts[3...])
+                } else if parts[1] == "sr_bin_boundaries" {
+                    remapped["decoder.srBoundaries"] = value
+                    continue
+                } else {
+                    newParts = parts
+                }
+            } else {
+                newParts = parts
+            }
+
+            // Sub-block remapping: block.N → named components
+            var finalParts: [String] = []
+            var i = 0
+            while i < newParts.count {
+                let p = newParts[i]
+
+                if p == "block" && i + 1 < newParts.count, let idx = Int(newParts[i + 1]) {
+                    let isEncoder = newParts[..<i].contains("encoder") && newParts[..<i].contains("blocks")
+                    let isDecoder = newParts[..<i].contains("decoder") && newParts[..<i].contains("blocks")
+
+                    if isEncoder && finalParts.count == 3 {
+                        let mapping = [0: "res1", 1: "res2", 2: "res3", 3: "snake", 4: "conv"]
+                        finalParts.append(mapping[idx] ?? "unknown_\(idx)")
+                        i += 2
+                        continue
+                    }
+
+                    if isDecoder && finalParts.count == 3 {
+                        let mapping = [0: "snake", 1: "conv_t", 2: "res1", 3: "res2", 4: "res3"]
+                        finalParts.append(mapping[idx] ?? "unknown_\(idx)")
+                        i += 2
+                        continue
+                    }
+
+                    let resMapping = [0: "snake1", 1: "conv1", 2: "snake2", 3: "conv2"]
+                    if let name = resMapping[idx] {
+                        finalParts.append(name)
+                        i += 2
+                        continue
+                    }
+                }
+
+                finalParts.append(p)
+                i += 1
+            }
+
+            let newKey = finalParts.joined(separator: ".")
+            remapped[newKey] = value
+        }
+
+        return remapped
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxAudioVAE.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxAudioVAE.swift
@@ -493,6 +493,8 @@ class VoxSequential: Module {
 // MARK: - AudioVAE
 
 class VoxAudioVAE: Module {
+    private static let blocksLayersPattern = try! NSRegularExpression(pattern: #"\bblocks\.layers\.(\d+)"#)
+
     let config: VoxCPM2AudioVAEConfig
     let hopLength: Int
     let latentDim: Int
@@ -609,10 +611,9 @@ class VoxAudioVAE: Module {
         // Swift uses plain [Module] arrays → no "layers" level.
         // Strip "blocks.layers.N" → "blocks.N" for both encoder and decoder.
         var stripped = [String: MLXArray]()
-        let blocksLayersPattern = try! NSRegularExpression(pattern: #"\bblocks\.layers\.(\d+)"#)
         for (key, value) in remapped {
             let range = NSRange(key.startIndex..., in: key)
-            let newKey = blocksLayersPattern.stringByReplacingMatches(
+            let newKey = Self.blocksLayersPattern.stringByReplacingMatches(
                 in: key, range: range, withTemplate: "blocks.$1"
             )
             stripped[newKey] = value

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Config.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Config.swift
@@ -1,0 +1,526 @@
+//
+//  VoxCPM2Config.swift
+//  MLXAudio
+//
+//  VoxCPM2 TTS configuration.
+//  Ported from mlx-audio Python: voxcpm2/config.py
+//
+
+import Foundation
+import MLXLMCommon
+
+// MARK: - LM Configuration
+
+public struct VoxCPM2LMConfig: Codable, Sendable {
+    public var hiddenSize: Int
+    public var numHiddenLayers: Int
+    public var numAttentionHeads: Int
+    public var numKeyValueHeads: Int
+    public var intermediateSize: Int
+    public var vocabSize: Int
+    public var rmsNormEps: Float
+    public var ropeTheta: Float
+    public var ropeScalingType: String
+    public var ropeLongFactor: [Float]
+    public var ropeShortFactor: [Float]
+    public var scaleEmb: Int
+    public var dimModelBase: Int
+    public var scaleDepth: Float
+    public var originalMaxPositionEmbeddings: Int
+    public var maxPositionEmbeddings: Int
+    public var bosTokenId: Int
+    public var eosTokenId: Int
+    public var useMup: Bool
+    public var kvChannels: Int?
+    public var noRope: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case intermediateSize = "intermediate_size"
+        case vocabSize = "vocab_size"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeTheta = "rope_theta"
+        case ropeScaling = "rope_scaling"
+        case ropeScalingType = "rope_scaling_type"
+        case ropeLongFactor = "rope_long_factor"
+        case ropeShortFactor = "rope_short_factor"
+        case scaleEmb = "scale_emb"
+        case dimModelBase = "dim_model_base"
+        case scaleDepth = "scale_depth"
+        case originalMaxPositionEmbeddings = "original_max_position_embeddings"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case useMup = "use_mup"
+        case kvChannels = "kv_channels"
+        case noRope = "no_rope"
+    }
+
+    public init(
+        hiddenSize: Int = 1024,
+        numHiddenLayers: Int = 24,
+        numAttentionHeads: Int = 16,
+        numKeyValueHeads: Int = 2,
+        intermediateSize: Int = 4096,
+        vocabSize: Int = 73448,
+        rmsNormEps: Float = 1e-5,
+        ropeTheta: Float = 10000.0,
+        ropeScalingType: String = "longrope",
+        ropeLongFactor: [Float] = [],
+        ropeShortFactor: [Float] = [],
+        scaleEmb: Int = 12,
+        dimModelBase: Int = 256,
+        scaleDepth: Float = 1.4,
+        originalMaxPositionEmbeddings: Int = 32768,
+        maxPositionEmbeddings: Int = 32768,
+        bosTokenId: Int = 1,
+        eosTokenId: Int = 2,
+        useMup: Bool = true,
+        kvChannels: Int? = nil,
+        noRope: Bool = false
+    ) {
+        self.hiddenSize = hiddenSize
+        self.numHiddenLayers = numHiddenLayers
+        self.numAttentionHeads = numAttentionHeads
+        self.numKeyValueHeads = numKeyValueHeads
+        self.intermediateSize = intermediateSize
+        self.vocabSize = vocabSize
+        self.rmsNormEps = rmsNormEps
+        self.ropeTheta = ropeTheta
+        self.ropeScalingType = ropeScalingType
+        self.ropeLongFactor = ropeLongFactor
+        self.ropeShortFactor = ropeShortFactor
+        self.scaleEmb = scaleEmb
+        self.dimModelBase = dimModelBase
+        self.scaleDepth = scaleDepth
+        self.originalMaxPositionEmbeddings = originalMaxPositionEmbeddings
+        self.maxPositionEmbeddings = maxPositionEmbeddings
+        self.bosTokenId = bosTokenId
+        self.eosTokenId = eosTokenId
+        self.useMup = useMup
+        self.kvChannels = kvChannels
+        self.noRope = noRope
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.hiddenSize = try container.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1024
+        self.numHiddenLayers = try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 24
+        self.numAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 16
+        self.numKeyValueHeads = try container.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 2
+        self.intermediateSize = try container.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 4096
+        self.vocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 73448
+        self.rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-5
+        self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10000.0
+        self.scaleEmb = try container.decodeIfPresent(Int.self, forKey: .scaleEmb) ?? 12
+        self.dimModelBase = try container.decodeIfPresent(Int.self, forKey: .dimModelBase) ?? 256
+        self.scaleDepth = try container.decodeIfPresent(Float.self, forKey: .scaleDepth) ?? 1.4
+        self.maxPositionEmbeddings = try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32768
+        self.bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId) ?? 1
+        self.eosTokenId = try container.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 2
+        self.useMup = try container.decodeIfPresent(Bool.self, forKey: .useMup) ?? true
+        self.kvChannels = try container.decodeIfPresent(Int.self, forKey: .kvChannels)
+        self.noRope = try container.decodeIfPresent(Bool.self, forKey: .noRope) ?? false
+
+        // rope_scaling can be a nested dict or flat fields
+        if let ropeScaling = try container.decodeIfPresent(RopeScaling.self, forKey: .ropeScaling) {
+            self.ropeScalingType = ropeScaling.type
+            self.ropeLongFactor = ropeScaling.longFactor
+            self.ropeShortFactor = ropeScaling.shortFactor
+            self.originalMaxPositionEmbeddings = ropeScaling.originalMaxPositionEmbeddings ?? 32768
+        } else {
+            self.ropeScalingType = try container.decodeIfPresent(String.self, forKey: .ropeScalingType) ?? "longrope"
+            self.ropeLongFactor = try container.decodeIfPresent([Float].self, forKey: .ropeLongFactor) ?? []
+            self.ropeShortFactor = try container.decodeIfPresent([Float].self, forKey: .ropeShortFactor) ?? []
+            self.originalMaxPositionEmbeddings = try container.decodeIfPresent(Int.self, forKey: .originalMaxPositionEmbeddings) ?? 32768
+        }
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(hiddenSize, forKey: .hiddenSize)
+        try container.encode(numHiddenLayers, forKey: .numHiddenLayers)
+        try container.encode(numAttentionHeads, forKey: .numAttentionHeads)
+        try container.encode(numKeyValueHeads, forKey: .numKeyValueHeads)
+        try container.encode(intermediateSize, forKey: .intermediateSize)
+        try container.encode(vocabSize, forKey: .vocabSize)
+        try container.encode(rmsNormEps, forKey: .rmsNormEps)
+        try container.encode(ropeTheta, forKey: .ropeTheta)
+        try container.encode(ropeScalingType, forKey: .ropeScalingType)
+        try container.encode(ropeLongFactor, forKey: .ropeLongFactor)
+        try container.encode(ropeShortFactor, forKey: .ropeShortFactor)
+        try container.encode(scaleEmb, forKey: .scaleEmb)
+        try container.encode(dimModelBase, forKey: .dimModelBase)
+        try container.encode(scaleDepth, forKey: .scaleDepth)
+        try container.encode(originalMaxPositionEmbeddings, forKey: .originalMaxPositionEmbeddings)
+        try container.encode(maxPositionEmbeddings, forKey: .maxPositionEmbeddings)
+        try container.encode(bosTokenId, forKey: .bosTokenId)
+        try container.encode(eosTokenId, forKey: .eosTokenId)
+        try container.encode(useMup, forKey: .useMup)
+        try container.encodeIfPresent(kvChannels, forKey: .kvChannels)
+        try container.encode(noRope, forKey: .noRope)
+    }
+
+    /// Head dimension for attention.
+    public var headDim: Int {
+        kvChannels ?? (hiddenSize / numAttentionHeads)
+    }
+}
+
+private struct RopeScaling: Codable {
+    var type: String
+    var longFactor: [Float]
+    var shortFactor: [Float]
+    var originalMaxPositionEmbeddings: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case longFactor = "long_factor"
+        case shortFactor = "short_factor"
+        case originalMaxPositionEmbeddings = "original_max_position_embeddings"
+    }
+}
+
+// MARK: - Encoder Configuration
+
+public struct VoxCPM2EncoderConfig: Codable, Sendable {
+    public var hiddenDim: Int
+    public var ffnDim: Int
+    public var numHeads: Int
+    public var numLayers: Int
+    public var kvChannels: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenDim = "hidden_dim"
+        case ffnDim = "ffn_dim"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case kvChannels = "kv_channels"
+    }
+
+    public init(
+        hiddenDim: Int = 1024,
+        ffnDim: Int = 4096,
+        numHeads: Int = 16,
+        numLayers: Int = 4,
+        kvChannels: Int? = nil
+    ) {
+        self.hiddenDim = hiddenDim
+        self.ffnDim = ffnDim
+        self.numHeads = numHeads
+        self.numLayers = numLayers
+        self.kvChannels = kvChannels
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.hiddenDim = try container.decodeIfPresent(Int.self, forKey: .hiddenDim) ?? 1024
+        self.ffnDim = try container.decodeIfPresent(Int.self, forKey: .ffnDim) ?? 4096
+        self.numHeads = try container.decodeIfPresent(Int.self, forKey: .numHeads) ?? 16
+        self.numLayers = try container.decodeIfPresent(Int.self, forKey: .numLayers) ?? 4
+        self.kvChannels = try container.decodeIfPresent(Int.self, forKey: .kvChannels)
+    }
+}
+
+// MARK: - CFM Configuration
+
+public struct VoxCPM2CFMConfig: Codable, Sendable {
+    public var sigmaMin: Float
+    public var solver: String
+    public var tScheduler: String
+    public var inferenceCfgRate: Float
+
+    enum CodingKeys: String, CodingKey {
+        case sigmaMin = "sigma_min"
+        case solver
+        case tScheduler = "t_scheduler"
+        case inferenceCfgRate = "inference_cfg_rate"
+    }
+
+    public init(
+        sigmaMin: Float = 1e-6,
+        solver: String = "euler",
+        tScheduler: String = "log-norm",
+        inferenceCfgRate: Float = 2.0
+    ) {
+        self.sigmaMin = sigmaMin
+        self.solver = solver
+        self.tScheduler = tScheduler
+        self.inferenceCfgRate = inferenceCfgRate
+    }
+}
+
+// MARK: - DiT Configuration
+
+public struct VoxCPM2DiTConfig: Codable, Sendable {
+    public var hiddenDim: Int
+    public var ffnDim: Int
+    public var numHeads: Int
+    public var numLayers: Int
+    public var kvChannels: Int?
+    public var ditMeanMode: Bool
+    public var cfmConfig: VoxCPM2CFMConfig
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenDim = "hidden_dim"
+        case ffnDim = "ffn_dim"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case kvChannels = "kv_channels"
+        case ditMeanMode = "dit_mean_mode"
+        case meanMode = "mean_mode"
+        case cfmConfig = "cfm_config"
+    }
+
+    public init(
+        hiddenDim: Int = 1024,
+        ffnDim: Int = 4096,
+        numHeads: Int = 16,
+        numLayers: Int = 4,
+        kvChannels: Int? = nil,
+        ditMeanMode: Bool = false,
+        cfmConfig: VoxCPM2CFMConfig = VoxCPM2CFMConfig()
+    ) {
+        self.hiddenDim = hiddenDim
+        self.ffnDim = ffnDim
+        self.numHeads = numHeads
+        self.numLayers = numLayers
+        self.kvChannels = kvChannels
+        self.ditMeanMode = ditMeanMode
+        self.cfmConfig = cfmConfig
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.hiddenDim = try container.decodeIfPresent(Int.self, forKey: .hiddenDim) ?? 1024
+        self.ffnDim = try container.decodeIfPresent(Int.self, forKey: .ffnDim) ?? 4096
+        self.numHeads = try container.decodeIfPresent(Int.self, forKey: .numHeads) ?? 16
+        self.numLayers = try container.decodeIfPresent(Int.self, forKey: .numLayers) ?? 4
+        self.kvChannels = try container.decodeIfPresent(Int.self, forKey: .kvChannels)
+        self.cfmConfig = try container.decodeIfPresent(VoxCPM2CFMConfig.self, forKey: .cfmConfig) ?? VoxCPM2CFMConfig()
+
+        // Handle "mean_mode" → "dit_mean_mode" naming
+        if let ditMM = try container.decodeIfPresent(Bool.self, forKey: .ditMeanMode) {
+            self.ditMeanMode = ditMM
+        } else {
+            self.ditMeanMode = try container.decodeIfPresent(Bool.self, forKey: .meanMode) ?? false
+        }
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(hiddenDim, forKey: .hiddenDim)
+        try container.encode(ffnDim, forKey: .ffnDim)
+        try container.encode(numHeads, forKey: .numHeads)
+        try container.encode(numLayers, forKey: .numLayers)
+        try container.encodeIfPresent(kvChannels, forKey: .kvChannels)
+        try container.encode(ditMeanMode, forKey: .ditMeanMode)
+        try container.encode(cfmConfig, forKey: .cfmConfig)
+    }
+}
+
+// MARK: - AudioVAE Configuration
+
+public struct VoxCPM2AudioVAEConfig: Codable, Sendable {
+    public var encoderDim: Int
+    public var encoderRates: [Int]
+    public var latentDim: Int
+    public var decoderDim: Int
+    public var decoderRates: [Int]
+    public var depthwise: Bool
+    public var sampleRate: Int
+    public var outSampleRate: Int
+    public var useNoiseBlock: Bool
+    public var srBinBoundaries: [Int]?
+    public var condType: String
+    public var condDim: Int
+    public var condOutLayer: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case encoderDim = "encoder_dim"
+        case encoderRates = "encoder_rates"
+        case latentDim = "latent_dim"
+        case decoderDim = "decoder_dim"
+        case decoderRates = "decoder_rates"
+        case depthwise
+        case sampleRate = "sample_rate"
+        case outSampleRate = "out_sample_rate"
+        case useNoiseBlock = "use_noise_block"
+        case srBinBoundaries = "sr_bin_boundaries"
+        case condType = "cond_type"
+        case condDim = "cond_dim"
+        case condOutLayer = "cond_out_layer"
+    }
+
+    public init(
+        encoderDim: Int = 128,
+        encoderRates: [Int] = [2, 5, 8, 8],
+        latentDim: Int = 64,
+        decoderDim: Int = 2048,
+        decoderRates: [Int] = [8, 6, 5, 2, 2, 2],
+        depthwise: Bool = true,
+        sampleRate: Int = 16000,
+        outSampleRate: Int = 48000,
+        useNoiseBlock: Bool = false,
+        srBinBoundaries: [Int]? = [20000, 30000, 40000],
+        condType: String = "scale_bias",
+        condDim: Int = 128,
+        condOutLayer: Bool = false
+    ) {
+        self.encoderDim = encoderDim
+        self.encoderRates = encoderRates
+        self.latentDim = latentDim
+        self.decoderDim = decoderDim
+        self.decoderRates = decoderRates
+        self.depthwise = depthwise
+        self.sampleRate = sampleRate
+        self.outSampleRate = outSampleRate
+        self.useNoiseBlock = useNoiseBlock
+        self.srBinBoundaries = srBinBoundaries
+        self.condType = condType
+        self.condDim = condDim
+        self.condOutLayer = condOutLayer
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.encoderDim = try container.decodeIfPresent(Int.self, forKey: .encoderDim) ?? 128
+        self.encoderRates = try container.decodeIfPresent([Int].self, forKey: .encoderRates) ?? [2, 5, 8, 8]
+        self.latentDim = try container.decodeIfPresent(Int.self, forKey: .latentDim) ?? 64
+        self.decoderDim = try container.decodeIfPresent(Int.self, forKey: .decoderDim) ?? 2048
+        self.decoderRates = try container.decodeIfPresent([Int].self, forKey: .decoderRates) ?? [8, 6, 5, 2, 2, 2]
+        self.depthwise = try container.decodeIfPresent(Bool.self, forKey: .depthwise) ?? true
+        self.sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 16000
+        self.outSampleRate = try container.decodeIfPresent(Int.self, forKey: .outSampleRate) ?? 48000
+        self.useNoiseBlock = try container.decodeIfPresent(Bool.self, forKey: .useNoiseBlock) ?? false
+        self.srBinBoundaries = try container.decodeIfPresent([Int].self, forKey: .srBinBoundaries)
+        self.condType = try container.decodeIfPresent(String.self, forKey: .condType) ?? "scale_bias"
+        self.condDim = try container.decodeIfPresent(Int.self, forKey: .condDim) ?? 128
+        self.condOutLayer = try container.decodeIfPresent(Bool.self, forKey: .condOutLayer) ?? false
+    }
+}
+
+// MARK: - Top-Level Model Configuration
+
+public struct VoxCPM2Configuration: Codable, Sendable {
+    public var modelType: String
+    public var lmConfig: VoxCPM2LMConfig
+    public var encoderConfig: VoxCPM2EncoderConfig
+    public var ditConfig: VoxCPM2DiTConfig
+    public var audioVaeConfig: VoxCPM2AudioVAEConfig
+    public var patchSize: Int
+    public var featDim: Int
+    public var scalarQuantizationLatentDim: Int
+    public var scalarQuantizationScale: Int
+    public var residualLmNumLayers: Int
+    public var residualLmNoRope: Bool
+    public var maxLength: Int
+    public var inferenceTimesteps: Int
+    public var cfgScale: Float
+
+    public var quantization: BaseConfiguration.Quantization?
+    public var perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case lmConfig = "lm_config"
+        case encoderConfig = "encoder_config"
+        case ditConfig = "dit_config"
+        case audioVaeConfig = "audio_vae_config"
+        case patchSize = "patch_size"
+        case featDim = "feat_dim"
+        case scalarQuantizationLatentDim = "scalar_quantization_latent_dim"
+        case scalarQuantizationScale = "scalar_quantization_scale"
+        case residualLmNumLayers = "residual_lm_num_layers"
+        case residualLmNoRope = "residual_lm_no_rope"
+        case maxLength = "max_length"
+        case inferenceTimesteps = "inference_timesteps"
+        case cfgScale = "cfg_scale"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(
+        modelType: String = "voxcpm2",
+        lmConfig: VoxCPM2LMConfig = VoxCPM2LMConfig(),
+        encoderConfig: VoxCPM2EncoderConfig = VoxCPM2EncoderConfig(),
+        ditConfig: VoxCPM2DiTConfig = VoxCPM2DiTConfig(),
+        audioVaeConfig: VoxCPM2AudioVAEConfig = VoxCPM2AudioVAEConfig(),
+        patchSize: Int = 4,
+        featDim: Int = 64,
+        scalarQuantizationLatentDim: Int = 512,
+        scalarQuantizationScale: Int = 9,
+        residualLmNumLayers: Int = 8,
+        residualLmNoRope: Bool = false,
+        maxLength: Int = 8192,
+        inferenceTimesteps: Int = 10,
+        cfgScale: Float = 2.0,
+        quantization: BaseConfiguration.Quantization? = nil,
+        perLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil
+    ) {
+        self.modelType = modelType
+        self.lmConfig = lmConfig
+        self.encoderConfig = encoderConfig
+        self.ditConfig = ditConfig
+        self.audioVaeConfig = audioVaeConfig
+        self.patchSize = patchSize
+        self.featDim = featDim
+        self.scalarQuantizationLatentDim = scalarQuantizationLatentDim
+        self.scalarQuantizationScale = scalarQuantizationScale
+        self.residualLmNumLayers = residualLmNumLayers
+        self.residualLmNoRope = residualLmNoRope
+        self.maxLength = maxLength
+        self.inferenceTimesteps = inferenceTimesteps
+        self.cfgScale = cfgScale
+        self.quantization = quantization
+        self.perLayerQuantization = perLayerQuantization
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "voxcpm2"
+        self.lmConfig = try container.decodeIfPresent(VoxCPM2LMConfig.self, forKey: .lmConfig) ?? VoxCPM2LMConfig()
+        self.encoderConfig = try container.decodeIfPresent(VoxCPM2EncoderConfig.self, forKey: .encoderConfig) ?? VoxCPM2EncoderConfig()
+        self.ditConfig = try container.decodeIfPresent(VoxCPM2DiTConfig.self, forKey: .ditConfig) ?? VoxCPM2DiTConfig()
+        self.audioVaeConfig = try container.decodeIfPresent(VoxCPM2AudioVAEConfig.self, forKey: .audioVaeConfig) ?? VoxCPM2AudioVAEConfig()
+        self.patchSize = try container.decodeIfPresent(Int.self, forKey: .patchSize) ?? 4
+        self.featDim = try container.decodeIfPresent(Int.self, forKey: .featDim) ?? 64
+        self.scalarQuantizationLatentDim = try container.decodeIfPresent(Int.self, forKey: .scalarQuantizationLatentDim) ?? 512
+        self.scalarQuantizationScale = try container.decodeIfPresent(Int.self, forKey: .scalarQuantizationScale) ?? 9
+        self.residualLmNumLayers = try container.decodeIfPresent(Int.self, forKey: .residualLmNumLayers) ?? 8
+        self.residualLmNoRope = try container.decodeIfPresent(Bool.self, forKey: .residualLmNoRope) ?? false
+        self.maxLength = try container.decodeIfPresent(Int.self, forKey: .maxLength) ?? 8192
+        self.inferenceTimesteps = try container.decodeIfPresent(Int.self, forKey: .inferenceTimesteps) ?? 10
+        self.cfgScale = try container.decodeIfPresent(Float.self, forKey: .cfgScale) ?? 2.0
+
+        let baseConfig = try? BaseConfiguration(from: decoder)
+        let globalQuant = try container.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantization)
+        let altGlobalQuant = try container.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantizationConfig)
+        self.quantization = globalQuant ?? altGlobalQuant ?? baseConfig?.perLayerQuantization?.quantization
+        self.perLayerQuantization = baseConfig?.perLayerQuantization
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(modelType, forKey: .modelType)
+        try container.encode(lmConfig, forKey: .lmConfig)
+        try container.encode(encoderConfig, forKey: .encoderConfig)
+        try container.encode(ditConfig, forKey: .ditConfig)
+        try container.encode(audioVaeConfig, forKey: .audioVaeConfig)
+        try container.encode(patchSize, forKey: .patchSize)
+        try container.encode(featDim, forKey: .featDim)
+        try container.encode(scalarQuantizationLatentDim, forKey: .scalarQuantizationLatentDim)
+        try container.encode(scalarQuantizationScale, forKey: .scalarQuantizationScale)
+        try container.encode(residualLmNumLayers, forKey: .residualLmNumLayers)
+        try container.encode(residualLmNoRope, forKey: .residualLmNoRope)
+        try container.encode(maxLength, forKey: .maxLength)
+        try container.encode(inferenceTimesteps, forKey: .inferenceTimesteps)
+        try container.encode(cfgScale, forKey: .cfgScale)
+        try container.encodeIfPresent(quantization, forKey: .quantization)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
@@ -67,7 +67,7 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
 
     // MARK: - State
 
-    public var tokenizer: Tokenizer?
+    public var tokenizer: Tokenizers.Tokenizer?
 
     // MARK: - Special tokens (defined in VoxCPM2 tokenizer config, ids 101-104)
 
@@ -270,7 +270,7 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
         let latentDim = audioVAE.latentDim
 
         // Tokenize text
-        var textIds = try tokenize(text)
+        let textIds = try tokenize(text)
 
         // Determine mode: reference cloning vs zero-shot
         let textToken: MLXArray

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
@@ -346,9 +346,11 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
         var residualHidden = residualOutputs[0..., -1, 0...]
 
         var predFeatSeq: [MLXArray] = []
+        predFeatSeq.reserveCapacity(maxTokens)
 
         // Generation loop
         for i in 0 ..< maxTokens {
+            try Task.checkCancellation()
             // V2: DiT hidden is concatenation
             let ditH1 = lmToDitProj(lmHidden)
             let ditH2 = resToDitProj(residualHidden)
@@ -395,7 +397,7 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
 
             prefixFeatCond = predFeat
 
-            eval(lmHidden, residualHidden)
+            eval(lmHidden, residualHidden, predFeat)
         }
 
         guard !predFeatSeq.isEmpty else {

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
@@ -67,7 +67,7 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
 
     // MARK: - State
 
-    public var tokenizer: Tokenizers.Tokenizer?
+    public let tokenizer: Tokenizers.Tokenizer?
 
     // MARK: - Special tokens (defined in VoxCPM2 tokenizer config, ids 101-104)
 
@@ -86,8 +86,9 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
 
     // MARK: - Initialization
 
-    public init(_ config: VoxCPM2Configuration) {
+    public init(_ config: VoxCPM2Configuration, tokenizer: Tokenizers.Tokenizer? = nil) {
         self.config = config
+        self.tokenizer = tokenizer
         self.patchSize = config.patchSize
         self.featDim = config.featDim
 
@@ -424,7 +425,7 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
 
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else {
                 continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
                 return
@@ -453,6 +454,10 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
             } catch {
                 continuation.finish(throwing: error)
             }
+        }
+
+        continuation.onTermination = { @Sendable _ in
+            task.cancel()
         }
 
         return stream
@@ -518,6 +523,15 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
             }
         }
 
+        let modelParamKeys = Set(flatParams.map(\.0))
+        let quantSuffixes = [".scales", ".biases"]
+        let unmappedKeys = result.keys.filter { key in
+            !modelParamKeys.contains(key) && !quantSuffixes.contains(where: { key.hasSuffix($0) })
+        }
+        if !unmappedKeys.isEmpty {
+            print("[VoxCPM2] \(unmappedKeys.count) weight key(s) not mapped to model parameters: \(unmappedKeys.sorted().prefix(10))")
+        }
+
         return result
     }
 
@@ -558,7 +572,16 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
             config = VoxCPM2Configuration()
         }
 
-        let model = VoxCPM2Model(config)
+        // Load tokenizer before model construction (tokenizer is let)
+        let tokenizer: Tokenizers.Tokenizer?
+        do {
+            tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
+        } catch {
+            print("[VoxCPM2] Warning: Could not load tokenizer: \(error)")
+            tokenizer = nil
+        }
+
+        let model = VoxCPM2Model(config, tokenizer: tokenizer)
 
         // Load weights (single or sharded)
         let weights = try loadWeights(modelDir: modelDir)
@@ -582,13 +605,6 @@ public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Senda
         // Update model parameters
         try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [])
         eval(model)
-
-        // Load tokenizer
-        do {
-            model.tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
-        } catch {
-            print("[VoxCPM2] Warning: Could not load tokenizer: \(error)")
-        }
 
         return model
     }

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Model.swift
@@ -1,0 +1,622 @@
+//
+//  VoxCPM2Model.swift
+//  MLXAudio
+//
+//  VoxCPM2 TTS model: 2B params, 48kHz, 30 languages.
+//  Autoregressive MiniCPM backbone + CFM diffusion + AudioVAE.
+//  Ported from mlx-audio Python: voxcpm2/voxcpm2.py
+//
+
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXNN
+@preconcurrency import MLXLMCommon
+import Tokenizers
+
+// MARK: - Scalar Quantization
+
+class ScalarQuantizationLayer: Module {
+    let scale: Int
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    init(inDim: Int, outDim: Int, latentDim: Int = 64, scale: Int = 9) {
+        self.scale = scale
+        self._inProj.wrappedValue = Linear(inDim, latentDim)
+        self._outProj.wrappedValue = Linear(latentDim, outDim)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = inProj(x)
+        h = MLX.tanh(h)
+        h = MLX.round(h * Float(scale)) / Float(scale)
+        return outProj(h)
+    }
+}
+
+// MARK: - VoxCPM2 Model
+
+public final class VoxCPM2Model: Module, SpeechGenerationModel, @unchecked Sendable {
+
+    // MARK: - Configuration
+
+    public let config: VoxCPM2Configuration
+    let patchSize: Int
+    let featDim: Int
+
+    // MARK: - Sub-models
+
+    @ModuleInfo(key: "base_lm") var baseLM: VoxMiniCPMModel
+    @ModuleInfo(key: "residual_lm") var residualLM: VoxMiniCPMModel
+    @ModuleInfo(key: "feat_encoder") var featEncoder: VoxCPMLocEnc
+    @ModuleInfo(key: "feat_decoder") var featDecoder: VoxUnifiedCFM
+
+    @ModuleInfo(key: "fsq_layer") var fsqLayer: ScalarQuantizationLayer
+    @ModuleInfo(key: "enc_to_lm_proj") var encToLmProj: Linear
+    @ModuleInfo(key: "lm_to_dit_proj") var lmToDitProj: Linear
+    @ModuleInfo(key: "res_to_dit_proj") var resToDitProj: Linear
+    @ModuleInfo(key: "fusion_concat_proj") var fusionConcatProj: Linear
+
+    @ModuleInfo(key: "stop_proj") var stopProj: Linear
+    @ModuleInfo(key: "stop_head") var stopHead: Linear
+
+    @ModuleInfo(key: "audio_vae") var audioVAE: VoxAudioVAE
+
+    // MARK: - State
+
+    public var tokenizer: Tokenizer?
+
+    // MARK: - Special tokens (defined in VoxCPM2 tokenizer config, ids 101-104)
+
+    let audioStartToken: Int32 = 101
+    let audioEndToken: Int32 = 102
+    let refAudioStartToken: Int32 = 103
+    let refAudioEndToken: Int32 = 104
+
+    // MARK: - Protocol conformance
+
+    public var sampleRate: Int { config.audioVaeConfig.outSampleRate }
+
+    public var defaultGenerationParameters: GenerateParameters {
+        GenerateParameters(temperature: 1.0)
+    }
+
+    // MARK: - Initialization
+
+    public init(_ config: VoxCPM2Configuration) {
+        self.config = config
+        self.patchSize = config.patchSize
+        self.featDim = config.featDim
+
+        let lmConfig = config.lmConfig
+
+        // Base LM (full layers, with vocab)
+        self._baseLM.wrappedValue = VoxMiniCPMModel(lmConfig)
+
+        // Residual LM (fewer layers, vocab_size=0, optionally no_rope)
+        var resConfig = lmConfig
+        resConfig.numHiddenLayers = config.residualLmNumLayers
+        resConfig.vocabSize = 0
+        resConfig.noRope = config.residualLmNoRope
+        self._residualLM.wrappedValue = VoxMiniCPMModel(resConfig)
+
+        // Encoder
+        var encConfig = lmConfig
+        encConfig.hiddenSize = config.encoderConfig.hiddenDim
+        encConfig.intermediateSize = config.encoderConfig.ffnDim
+        encConfig.numAttentionHeads = config.encoderConfig.numHeads
+        encConfig.numHiddenLayers = config.encoderConfig.numLayers
+        encConfig.kvChannels = config.encoderConfig.kvChannels
+        encConfig.vocabSize = 0
+        self._featEncoder.wrappedValue = VoxCPMLocEnc(encConfig, inputDim: config.featDim)
+
+        // DiT / CFM
+        var ditConfig = lmConfig
+        ditConfig.hiddenSize = config.ditConfig.hiddenDim
+        ditConfig.intermediateSize = config.ditConfig.ffnDim
+        ditConfig.numAttentionHeads = config.ditConfig.numHeads
+        ditConfig.numHiddenLayers = config.ditConfig.numLayers
+        ditConfig.kvChannels = config.ditConfig.kvChannels
+        ditConfig.vocabSize = 0
+
+        let estimator = VoxCPMLocDiTV2(ditConfig, inChannels: config.featDim)
+        self._featDecoder.wrappedValue = VoxUnifiedCFM(
+            inChannels: config.featDim,
+            cfmParams: config.ditConfig.cfmConfig,
+            estimator: estimator,
+            meanMode: config.ditConfig.ditMeanMode
+        )
+
+        // Projections
+        self._fsqLayer.wrappedValue = ScalarQuantizationLayer(
+            inDim: lmConfig.hiddenSize,
+            outDim: lmConfig.hiddenSize,
+            latentDim: config.scalarQuantizationLatentDim,
+            scale: config.scalarQuantizationScale
+        )
+
+        self._encToLmProj.wrappedValue = Linear(
+            config.encoderConfig.hiddenDim, lmConfig.hiddenSize
+        )
+        self._lmToDitProj.wrappedValue = Linear(
+            lmConfig.hiddenSize, config.ditConfig.hiddenDim
+        )
+        self._resToDitProj.wrappedValue = Linear(
+            lmConfig.hiddenSize, config.ditConfig.hiddenDim
+        )
+
+        // V2: fusion_concat_proj
+        self._fusionConcatProj.wrappedValue = Linear(
+            lmConfig.hiddenSize * 2, lmConfig.hiddenSize
+        )
+
+        // Stop predictor
+        self._stopProj.wrappedValue = Linear(lmConfig.hiddenSize, lmConfig.hiddenSize)
+        self._stopHead.wrappedValue = Linear(lmConfig.hiddenSize, 2, bias: false)
+
+        // Audio VAE
+        self._audioVAE.wrappedValue = VoxAudioVAE(config.audioVaeConfig)
+
+        super.init()
+    }
+
+    // MARK: - Audio Encoding
+
+    func encodeWav(_ audio: MLXArray) throws -> MLXArray {
+        var inp = audio
+
+        // Resample from output rate (48kHz) to encoder rate (16kHz) if needed
+        let outRate = sampleRate
+        let encRate = audioVAE.encodeSampleRate
+        if outRate != encRate {
+            let flat = inp.ndim == 1 ? inp : inp.flattened()
+            let samples = flat.asArray(Float.self)
+            let resampled = try resampleAudio(samples, from: outRate, to: encRate)
+            inp = MLXArray(resampled)
+        }
+
+        if inp.ndim == 1 {
+            inp = inp.expandedDimensions(axes: [0, 1]) // (1, 1, T)
+        } else if inp.ndim == 2 {
+            inp = inp.expandedDimensions(axis: 1) // (1, 1, T) or (B, 1, T)
+        }
+
+        // Pad to patch alignment
+        let patchLen = patchSize * audioVAE.chunkSize
+        let length = inp.dim(-1)
+        let remainder = length % patchLen
+        if remainder != 0 {
+            let padSize = patchLen - remainder
+            inp = MLX.padded(inp, widths: [IntOrPair((0, 0)), IntOrPair((0, 0)), IntOrPair((0, padSize))])
+        }
+
+        // VAE encode: input is (B, 1, T) in channel-first
+        // CausalEncoder expects (B, T, C) in channel-last
+        let channelLast = inp.transposed(0, 2, 1) // (B, T, 1)
+        let feat = audioVAE.encode(channelLast, sampleRate: audioVAE.encodeSampleRate)
+        // feat: (B, T', D) in channel-last
+
+        let squeezed = feat.squeezed(axis: 0) // (T', D)
+
+        // Reshape into patches: (T', D) → (numPatches, patchSize, D)
+        let tPrime = squeezed.dim(0)
+        let numPatches = tPrime / patchSize
+        let trimmed = squeezed[..<(numPatches * patchSize)]
+        return trimmed.reshaped(numPatches, patchSize, -1)
+    }
+
+    func makeRefPrefix(_ refFeat: MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+        let refLen = refFeat.dim(0)
+        let z1 = MLXArray.zeros([1, patchSize, featDim])
+
+        let tokens = MLX.concatenated([
+            MLXArray([refAudioStartToken]),
+            MLXArray.zeros([refLen]).asType(.int32),
+            MLXArray([refAudioEndToken]),
+        ])
+
+        let feats = MLX.concatenated([z1, refFeat, z1], axis: 0)
+
+        let tMask = MLX.concatenated([
+            MLXArray([Float(1)]),
+            MLXArray.zeros([refLen]),
+            MLXArray([Float(1)]),
+        ])
+        let aMask = MLX.concatenated([
+            MLXArray([Float(0)]),
+            MLXArray.ones([refLen]),
+            MLXArray([Float(0)]),
+        ])
+
+        return (tokens, feats, tMask, aMask)
+    }
+
+    // MARK: - Tokenization
+
+    func tokenize(_ text: String) throws -> [Int] {
+        guard let tokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
+        }
+        // Match Python: tokenize + convert_tokens_to_ids (no BOS/EOS)
+        var ids = tokenizer.encode(text: text).map { Int($0) }
+        if let first = ids.first, first == (tokenizer.bosTokenId ?? -1) {
+            ids.removeFirst()
+        }
+        if let last = ids.last, last == (tokenizer.eosTokenId ?? -1) {
+            ids.removeLast()
+        }
+        return ids
+    }
+
+    // MARK: - Generation
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        let maxTokens = generationParameters.maxTokens ?? config.maxLength
+        let minTokens = 2
+        let inferenceTimesteps = config.inferenceTimesteps
+        let cfgValue = config.cfgScale
+
+        let scaleEmb = Float(config.lmConfig.useMup ? config.lmConfig.scaleEmb : 1)
+        let latentDim = audioVAE.latentDim
+
+        // Tokenize text
+        var textIds = try tokenize(text)
+
+        // Determine mode: reference cloning vs zero-shot
+        let textToken: MLXArray
+        let audioFeat: MLXArray
+        let textMask: MLXArray
+        let audioMask: MLXArray
+
+        if let refAudio {
+            // Reference cloning mode
+            let tokenArray = MLXArray((textIds + [Int(audioStartToken)]).map { Int32($0) })
+            let textLength = tokenArray.dim(0)
+
+            let refFeat = try encodeWav(refAudio)
+            let (refTokens, refFeats, refTMask, refAMask) = makeRefPrefix(refFeat)
+
+            let textPadFeat = MLXArray.zeros([textLength, patchSize, latentDim])
+
+            textToken = MLX.concatenated([refTokens, tokenArray])
+            audioFeat = MLX.concatenated([refFeats, textPadFeat], axis: 0)
+            textMask = MLX.concatenated([
+                refTMask,
+                MLXArray.ones([textLength]),
+            ])
+            audioMask = MLX.concatenated([
+                refAMask,
+                MLXArray.zeros([textLength]),
+            ])
+        } else {
+            // Zero-shot mode
+            let tokenArray = MLXArray((textIds + [Int(audioStartToken)]).map { Int32($0) })
+            let textLength = tokenArray.dim(0)
+
+            textToken = tokenArray
+            audioFeat = MLXArray.zeros([textLength, patchSize, latentDim])
+            textMask = MLXArray.ones([textLength])
+            audioMask = MLXArray.zeros([textLength])
+        }
+
+        // Add batch dimension
+        let bTextToken = textToken.expandedDimensions(axis: 0)
+        let bAudioFeat = audioFeat.expandedDimensions(axis: 0)
+        let bTextMask = textMask.expandedDimensions(axis: 0)
+        let bAudioMask = audioMask.expandedDimensions(axis: 0)
+
+        // Encode audio features
+        var featEmbed = featEncoder(bAudioFeat)
+        featEmbed = encToLmProj(featEmbed)
+
+        // Text embedding with scale
+        let textEmbed = baseLM.embedTokens!(bTextToken) * scaleEmb
+
+        // Combine text and audio embeddings
+        let combinedEmbed = bTextMask[0..., 0..., .newAxis] * textEmbed
+            + bAudioMask[0..., 0..., .newAxis] * featEmbed
+
+        var prefixFeatCond = bAudioFeat[0..., -1, 0..., 0...] // (1, P, D)
+
+        // Initial forward pass
+        var (encOutputs, lmCache) = baseLM(inputsEmbeds: combinedEmbed)
+
+        // Apply FSQ to audio positions
+        encOutputs = fsqLayer(encOutputs) * bAudioMask[0..., 0..., .newAxis]
+            + encOutputs * bTextMask[0..., 0..., .newAxis]
+
+        var lmHidden = encOutputs[0..., -1, 0...] // (1, H)
+
+        // V2: fusion_concat_proj for residual input
+        let residualInput = fusionConcatProj(
+            MLX.concatenated([encOutputs, bAudioMask[0..., 0..., .newAxis] * featEmbed], axis: -1)
+        )
+
+        var (residualOutputs, resCache) = residualLM(inputsEmbeds: residualInput)
+        var residualHidden = residualOutputs[0..., -1, 0...]
+
+        var predFeatSeq: [MLXArray] = []
+
+        // Generation loop
+        for i in 0 ..< maxTokens {
+            // V2: DiT hidden is concatenation
+            let ditH1 = lmToDitProj(lmHidden)
+            let ditH2 = resToDitProj(residualHidden)
+            let ditH = MLX.concatenated([ditH1, ditH2], axis: -1) // (1, 2*H_dit)
+
+            let condIn = prefixFeatCond.transposed(0, 2, 1) // (B, D, P)
+
+            var predFeat = featDecoder.sample(
+                mu: ditH,
+                nTimesteps: inferenceTimesteps,
+                patchSize: patchSize,
+                cond: condIn,
+                cfgValue: cfgValue
+            )
+
+            predFeat = predFeat.transposed(0, 2, 1) // (B, P, D)
+
+            predFeatSeq.append(predFeat[0..., .newAxis, 0..., 0...]) // (B, 1, P, D)
+
+            let currEmbed = featEncoder(predFeat[0..., .newAxis, 0..., 0...])
+            let currEmbedProj = encToLmProj(currEmbed)
+
+            // Stop prediction
+            let stopLogits = stopHead(silu(stopProj(lmHidden)))
+            let stopFlag = MLX.argMax(stopLogits, axis: -1).item(Int.self)
+            if i > minTokens && stopFlag == 1 {
+                break
+            }
+
+            // Autoregressive step
+            let newLmOut: MLXArray
+            (newLmOut, lmCache) = baseLM(inputsEmbeds: currEmbedProj, cache: lmCache)
+
+            lmHidden = newLmOut[0..., -1, 0...]
+            lmHidden = fsqLayer(lmHidden)
+
+            // V2: fusion_concat_proj for residual step
+            let currResInput = fusionConcatProj(
+                MLX.concatenated([lmHidden[0..., .newAxis, 0...], currEmbedProj], axis: -1)
+            )
+            let newResOut: MLXArray
+            (newResOut, resCache) = residualLM(inputsEmbeds: currResInput, cache: resCache)
+            residualHidden = newResOut[0..., -1, 0...]
+
+            prefixFeatCond = predFeat
+
+            eval(lmHidden, residualHidden)
+        }
+
+        guard !predFeatSeq.isEmpty else {
+            throw AudioGenerationError.invalidInput("Model generated no audio patches")
+        }
+
+        // Decode
+        let allFeats = MLX.concatenated(predFeatSeq, axis: 1) // (B, Total, P, D)
+        let B = allFeats.dim(0)
+        let allFeatsFlat = allFeats.reshaped(B, -1, featDim) // (B, Total*P, D)
+
+        let audio = audioVAE.decode(allFeatsFlat).flattened()
+        eval(audio)
+        return audio
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+
+        Task { @Sendable [weak self] in
+            guard let self else {
+                continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
+                return
+            }
+            do {
+                let startTime = Date()
+                let audio = try await self.generate(
+                    text: text, voice: voice, refAudio: refAudio,
+                    refText: refText, language: language,
+                    generationParameters: generationParameters
+                )
+                let generateTime = Date().timeIntervalSince(startTime)
+
+                continuation.yield(.audio(audio))
+
+                let info = AudioGenerationInfo(
+                    promptTokenCount: 0,
+                    generationTokenCount: audio.dim(audio.ndim - 1),
+                    prefillTime: 0,
+                    generateTime: generateTime,
+                    tokensPerSecond: Double(audio.dim(audio.ndim - 1)) / max(generateTime, 0.001),
+                    peakMemoryUsage: 0
+                )
+                continuation.yield(.info(info))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        return stream
+    }
+
+    // MARK: - Weight Sanitization
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Delegate VAE sanitization
+        var vaeWeights = [String: MLXArray]()
+        var otherWeights = [String: MLXArray]()
+
+        for (key, value) in weights {
+            if key.hasPrefix("audio_vae.") {
+                let subKey = String(key.dropFirst("audio_vae.".count))
+                vaeWeights[subKey] = value
+            } else {
+                otherWeights[key] = value
+            }
+        }
+
+        // Sanitize VAE weights
+        if !vaeWeights.isEmpty {
+            let sanitizedVAE = audioVAE.sanitize(weights: vaeWeights)
+            for (key, value) in sanitizedVAE {
+                otherWeights["audio_vae.\(key)"] = value
+            }
+        }
+
+        // Extract sr_boundaries buffer
+        let srKey = "audio_vae.decoder.srBoundaries"
+        if let srBounds = otherWeights.removeValue(forKey: srKey) {
+            audioVAE.decoder.srBoundaries = srBounds
+        }
+        // Also handle the Python key name
+        let srKey2 = "audio_vae.decoder._sr_boundaries"
+        if let srBounds = otherWeights.removeValue(forKey: srKey2) {
+            audioVAE.decoder.srBoundaries = srBounds
+        }
+
+        // Remap snake_case Python keys → camelCase Swift property names
+        let keyMap = [
+            "special_token": "specialToken",
+        ]
+        var result = [String: MLXArray]()
+        for (key, value) in otherWeights {
+            var mappedKey = key
+            for (snake, camel) in keyMap {
+                if mappedKey.hasSuffix(".\(snake)") {
+                    mappedKey = String(mappedKey.dropLast(snake.count)) + camel
+                } else if mappedKey == snake {
+                    mappedKey = camel
+                }
+            }
+            result[mappedKey] = value
+        }
+
+        // Add RoPE buffers if missing
+        let flatParams = parameters().flattened()
+        for (key, value) in flatParams {
+            if result[key] == nil && key.contains("rope") {
+                result[key] = value
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - Factory
+
+    public static func fromPretrained(
+        _ modelRepo: String,
+        cache: HubCache = .default
+    ) async throws -> VoxCPM2Model {
+        let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+
+        guard let repoID = Repo.ID(rawValue: modelRepo) else {
+            throw AudioGenerationError.invalidInput("Invalid repository ID: \(modelRepo)")
+        }
+
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            hfToken: hfToken,
+            cache: cache
+        )
+
+        return try await fromModelDirectory(modelDir, hfToken: hfToken)
+    }
+
+    public static func fromModelDirectory(
+        _ modelDir: URL,
+        hfToken: String?
+    ) async throws -> VoxCPM2Model {
+        // Load config
+        let configURL = modelDir.appendingPathComponent("config.json")
+        let config: VoxCPM2Configuration
+        if FileManager.default.fileExists(atPath: configURL.path) {
+            let configData = try Data(contentsOf: configURL)
+            config = try JSONDecoder().decode(VoxCPM2Configuration.self, from: configData)
+        } else {
+            config = VoxCPM2Configuration()
+        }
+
+        let model = VoxCPM2Model(config)
+
+        // Load weights (single or sharded)
+        let weights = try loadWeights(modelDir: modelDir)
+
+        // Sanitize
+        let sanitizedWeights = model.sanitize(weights: weights)
+
+        // Quantization (only base_lm and residual_lm)
+        if config.quantization != nil || config.perLayerQuantization != nil {
+            quantize(model: model) { path, _ in
+                guard sanitizedWeights["\(path).scales"] != nil else { return nil }
+                if let perLayerQuant = config.perLayerQuantization,
+                   let layerQuant = perLayerQuant.quantization(layer: path)
+                {
+                    return layerQuant.asTuple
+                }
+                return config.quantization?.asTuple
+            }
+        }
+
+        // Update model parameters
+        try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: [])
+        eval(model)
+
+        // Load tokenizer
+        do {
+            model.tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
+        } catch {
+            print("[VoxCPM2] Warning: Could not load tokenizer: \(error)")
+        }
+
+        return model
+    }
+
+    private static func loadWeights(modelDir: URL) throws -> [String: MLXArray] {
+        let singleURL = modelDir.appendingPathComponent("model.safetensors")
+        if FileManager.default.fileExists(atPath: singleURL.path) {
+            return try MLX.loadArrays(url: singleURL)
+        }
+
+        // Sharded weights
+        let fm = FileManager.default
+        let files = try fm.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: nil)
+        let safetensorFiles = files
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        guard !safetensorFiles.isEmpty else {
+            throw AudioGenerationError.modelNotInitialized(
+                "No .safetensors files found in \(modelDir.path)"
+            )
+        }
+
+        var allWeights = [String: MLXArray]()
+        for file in safetensorFiles {
+            let shard = try MLX.loadArrays(url: file)
+            for (key, value) in shard {
+                allWeights[key] = value
+            }
+        }
+        return allWeights
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
@@ -14,10 +14,14 @@ import MLXNN
 
 class SinusoidalPosEmb: Module {
     let dim: Int
+    let freqs: MLXArray
 
     init(dim: Int) {
         assert(dim % 2 == 0)
         self.dim = dim
+        let halfDim = dim / 2
+        let emb = log(Float(10000)) / Float(halfDim - 1)
+        self.freqs = MLX.exp(MLXArray(0 ..< halfDim).asType(.float32) * -emb)
         super.init()
     }
 
@@ -26,10 +30,6 @@ class SinusoidalPosEmb: Module {
         if inp.ndim < 1 {
             inp = inp.reshaped([1])
         }
-
-        let halfDim = dim / 2
-        let emb = log(Float(10000)) / Float(halfDim - 1)
-        let freqs = MLX.exp(MLXArray(0 ..< halfDim).asType(.float32) * -emb)
 
         let scaled = scale * inp.expandedDimensions(axis: 1) * freqs.expandedDimensions(axis: 0)
 

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
@@ -182,11 +182,11 @@ class VoxUnifiedCFM: Module {
                 let muIn = MLX.concatenated([mu, MLXArray.zeros(like: mu)], axis: 0)
 
                 let n = xIn.dim(0)
-                let tVal = MLXArray(Array(repeating: t, count: n))
+                let tVal = MLX.broadcast(MLXArray(t), to: [n])
 
                 let dtValIn: MLXArray
                 if meanMode {
-                    dtValIn = MLXArray(Array(repeating: dt, count: n))
+                    dtValIn = MLX.broadcast(MLXArray(dt), to: [n])
                 } else {
                     dtValIn = MLXArray.zeros([n])
                 }

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
@@ -1,0 +1,251 @@
+//
+//  VoxCPMDiT.swift
+//  MLXAudio
+//
+//  VoxCPM2 Diffusion Transformer + Conditional Flow Matching (CFM) decoder.
+//  Ported from mlx-audio Python: voxcpm2/dit.py
+//
+
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+// MARK: - Sinusoidal Position Embedding
+
+class SinusoidalPosEmb: Module {
+    let dim: Int
+
+    init(dim: Int) {
+        assert(dim % 2 == 0)
+        self.dim = dim
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, scale: Float = 1000) -> MLXArray {
+        var inp = x
+        if inp.ndim < 1 {
+            inp = inp.reshaped([1])
+        }
+
+        let halfDim = dim / 2
+        let emb = log(Float(10000)) / Float(halfDim - 1)
+        let freqs = MLX.exp(MLXArray(0 ..< halfDim).asType(.float32) * -emb)
+
+        let scaled = scale * inp.expandedDimensions(axis: 1) * freqs.expandedDimensions(axis: 0)
+
+        return MLX.concatenated([MLX.sin(scaled), MLX.cos(scaled)], axis: -1)
+    }
+}
+
+// MARK: - Timestep Embedding
+
+class TimestepEmbedding: Module {
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+
+    init(inChannels: Int, timeEmbedDim: Int, outDim: Int? = nil) {
+        self._linear1.wrappedValue = Linear(inChannels, timeEmbedDim)
+        self._linear2.wrappedValue = Linear(timeEmbedDim, outDim ?? timeEmbedDim)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(silu(linear1(x)))
+    }
+}
+
+// MARK: - DiT V2
+
+class VoxCPMLocDiTV2: Module {
+    let config: VoxCPM2LMConfig
+    let inChannels: Int
+
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "cond_proj") var condProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+    @ModuleInfo(key: "time_embeddings") var timeEmbeddings: SinusoidalPosEmb
+    @ModuleInfo(key: "time_mlp") var timeMlp: TimestepEmbedding
+    @ModuleInfo(key: "delta_time_mlp") var deltaTimeMlp: TimestepEmbedding
+    @ModuleInfo var decoder: VoxMiniCPMModel
+
+    init(_ config: VoxCPM2LMConfig, inChannels: Int = 64) {
+        self.config = config
+        self.inChannels = inChannels
+
+        self._inProj.wrappedValue = Linear(inChannels, config.hiddenSize)
+        self._condProj.wrappedValue = Linear(inChannels, config.hiddenSize)
+        self._outProj.wrappedValue = Linear(config.hiddenSize, inChannels)
+
+        self._timeEmbeddings.wrappedValue = SinusoidalPosEmb(dim: config.hiddenSize)
+        self._timeMlp.wrappedValue = TimestepEmbedding(inChannels: config.hiddenSize, timeEmbedDim: config.hiddenSize)
+        self._deltaTimeMlp.wrappedValue = TimestepEmbedding(inChannels: config.hiddenSize, timeEmbedDim: config.hiddenSize)
+
+        self._decoder.wrappedValue = VoxMiniCPMModel(config)
+
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - x: (N, C, T) noisy input
+    ///   - mu: (N, 2*H) multi-token conditioning from LM+residual
+    ///   - t: (N,) timestep
+    ///   - cond: (N, C, T') conditioning signal
+    ///   - dt: (N,) delta timestep
+    /// - Returns: (N, C, T) velocity estimate
+    func callAsFunction(
+        _ x: MLXArray,
+        mu: MLXArray,
+        t: MLXArray,
+        cond: MLXArray,
+        dt: MLXArray
+    ) -> MLXArray {
+        // x: (N, C, T) → (N, T, C)
+        let xT = x.transposed(0, 2, 1)
+        let xProj = inProj(xT)
+
+        // cond: (N, C, T') → (N, T', C)
+        let condT = cond.transposed(0, 2, 1)
+        let condProjVal = condProj(condT)
+        let prefix = condT.dim(1)
+
+        let tEmb = timeMlp(timeEmbeddings(t))
+        let dtEmb = deltaTimeMlp(timeEmbeddings(dt))
+        let tComb = tEmb + dtEmb // (N, H)
+
+        // V2: mu is (N, 2*H) → reshape to (N, numMuTokens, H)
+        let H = xProj.dim(-1)
+        let muTokens = mu.reshaped(x.dim(0), -1, H) // (N, numMuTokens, H)
+        let numMuTokens = muTokens.dim(1)
+
+        let hidden = MLX.concatenated(
+            [muTokens, tComb[0..., .newAxis, 0...], condProjVal, xProj],
+            axis: 1
+        )
+
+        let (decoded, _) = decoder(inputsEmbeds: hidden, isCausal: false)
+
+        // Slice: skip mu_tokens + t_token + cond prefix
+        let sliced = decoded[0..., (numMuTokens + 1 + prefix)..., 0...]
+
+        let out = outProj(sliced)
+
+        return out.transposed(0, 2, 1) // (N, C, T)
+    }
+}
+
+// MARK: - Unified CFM
+
+class VoxUnifiedCFM: Module {
+    let inChannels: Int
+    @ModuleInfo(key: "estimator") var estimator: VoxCPMLocDiTV2
+    let cfmParams: VoxCPM2CFMConfig
+    let meanMode: Bool
+
+    init(
+        inChannels: Int,
+        cfmParams: VoxCPM2CFMConfig,
+        estimator: VoxCPMLocDiTV2,
+        meanMode: Bool = false
+    ) {
+        self.inChannels = inChannels
+        self.cfmParams = cfmParams
+        self.meanMode = meanMode
+        self._estimator.wrappedValue = estimator
+        super.init()
+    }
+
+    func solveEuler(
+        _ x: MLXArray,
+        tSpan: MLXArray,
+        mu: MLXArray,
+        cond: MLXArray,
+        cfgValue: Float = 1.0,
+        useCfgZeroStar: Bool = true
+    ) -> MLXArray {
+        var t = tSpan[0].item(Float.self)
+        var dt = tSpan[0].item(Float.self) - tSpan[1].item(Float.self)
+
+        var currentX = x
+
+        let nSteps = tSpan.dim(0)
+        let zeroInitSteps = max(1, Int(Float(nSteps) * 0.04))
+
+        for step in 1 ..< nSteps {
+            let dphiDt: MLXArray
+
+            if useCfgZeroStar && step <= zeroInitSteps {
+                dphiDt = MLXArray.zeros(like: currentX)
+            } else {
+                let b = currentX.dim(0)
+
+                let xIn = MLX.concatenated([currentX, currentX], axis: 0)
+                let muIn = MLX.concatenated([mu, MLXArray.zeros(like: mu)], axis: 0)
+
+                let n = xIn.dim(0)
+                let tVal = MLXArray(Array(repeating: t, count: n))
+
+                let dtValIn: MLXArray
+                if meanMode {
+                    dtValIn = MLXArray(Array(repeating: dt, count: n))
+                } else {
+                    dtValIn = MLXArray.zeros([n])
+                }
+
+                let condIn = MLX.concatenated([cond, cond], axis: 0)
+
+                let out = estimator(xIn, mu: muIn, t: tVal, cond: condIn, dt: dtValIn)
+
+                let chunkSize = b
+                let posOut = out[..<chunkSize]
+                let cfgOut = out[chunkSize...]
+
+                let guided: MLXArray
+                if useCfgZeroStar {
+                    let posFlatOrig = posOut.reshaped(chunkSize, -1)
+                    let negFlat = cfgOut.reshaped(chunkSize, -1)
+
+                    let dotProd = MLX.sum(posFlatOrig * negFlat, axis: 1, keepDims: true)
+                    let sqNorm = MLX.sum(negFlat * negFlat, axis: 1, keepDims: true) + MLXArray(Float(1e-8))
+                    var stStar = dotProd / sqNorm
+                    stStar = stStar.reshaped(chunkSize, 1, 1)
+
+                    guided = cfgOut * stStar + MLXArray(cfgValue) * (posOut - cfgOut * stStar)
+                } else {
+                    guided = cfgOut + MLXArray(cfgValue) * (posOut - cfgOut)
+                }
+
+                dphiDt = guided
+            }
+
+            currentX = currentX - MLXArray(dt) * dphiDt
+            t = t - dt
+
+            if step < nSteps - 1 {
+                dt = t - tSpan[step + 1].item(Float.self)
+            }
+        }
+
+        return currentX
+    }
+
+    func sample(
+        mu: MLXArray,
+        nTimesteps: Int,
+        patchSize: Int,
+        cond: MLXArray,
+        temperature: Float = 1.0,
+        cfgValue: Float = 1.0
+    ) -> MLXArray {
+        let B = mu.dim(0)
+        let T = patchSize
+
+        let z = MLXRandom.normal([B, inChannels, T]) * MLXArray(temperature)
+
+        var tSpan = MLX.linspace(Float(1), Float(0), count: nTimesteps + 1)
+        // Sway scheduling: t + cos(pi/2 * t) - 1 + t = 2t + cos(pi/2 * t) - 1
+        let sway = MLX.cos(MLXArray(Float.pi / 2) * tSpan) - 1 + tSpan
+        tSpan = tSpan + sway
+
+        return solveEuler(z, tSpan: tSpan, mu: mu, cond: cond, cfgValue: cfgValue)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMDiT.swift
@@ -31,7 +31,7 @@ class SinusoidalPosEmb: Module {
             inp = inp.reshaped([1])
         }
 
-        let scaled = scale * inp.expandedDimensions(axis: 1) * freqs.expandedDimensions(axis: 0)
+        let scaled = MLXArray(scale) * inp.expandedDimensions(axis: 1) * freqs.expandedDimensions(axis: 0)
 
         return MLX.concatenated([MLX.sin(scaled), MLX.cos(scaled)], axis: -1)
     }

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMEncoder.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMEncoder.swift
@@ -13,7 +13,7 @@ import MLXNN
 class VoxCPMLocEnc: Module {
     let config: VoxCPM2LMConfig
 
-    var specialToken: MLXArray
+    let specialToken: MLXArray
     @ModuleInfo(key: "in_proj") var inProj: Linear
     @ModuleInfo var encoder: VoxMiniCPMModel
 

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMEncoder.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPMEncoder.swift
@@ -1,0 +1,56 @@
+//
+//  VoxCPMEncoder.swift
+//  MLXAudio
+//
+//  VoxCPM2 feature encoder: patches → CLS token embeddings via MiniCPM.
+//  Ported from mlx-audio Python: voxcpm2/encoder.py
+//
+
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+class VoxCPMLocEnc: Module {
+    let config: VoxCPM2LMConfig
+
+    var specialToken: MLXArray
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo var encoder: VoxMiniCPMModel
+
+    init(_ config: VoxCPM2LMConfig, inputDim: Int = 64) {
+        self.config = config
+
+        self.specialToken = MLXRandom.normal([1, 1, 1, config.hiddenSize])
+        self._inProj.wrappedValue = Linear(inputDim, config.hiddenSize, bias: true)
+
+        self._encoder.wrappedValue = VoxMiniCPMModel(config)
+
+        super.init()
+    }
+
+    /// Encode audio patches to per-timestep embeddings.
+    /// - Parameter x: (B, T, P, D) — batch, timesteps, patches, feature dim
+    /// - Returns: (B, T, H) — CLS token output per timestep
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let B = x.dim(0)
+        let T = x.dim(1)
+        let P = x.dim(2)
+
+        let projected = inProj(x) // (B, T, P, H)
+
+        let specialTokens = MLX.broadcast(
+            specialToken,
+            to: [B, T, 1, config.hiddenSize]
+        )
+
+        let withCLS = MLX.concatenated([specialTokens, projected], axis: 2) // (B, T, P+1, H)
+
+        let flat = withCLS.reshaped(B * T, P + 1, -1) // (B*T, P+1, H)
+
+        let (outputs, _) = encoder(inputsEmbeds: flat, isCausal: false)
+
+        let clsOutput = outputs[0..., 0, 0...] // (B*T, H)
+
+        return clsOutput.reshaped(B, T, -1)
+    }
+}

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -51,8 +51,6 @@ public enum TTS {
         }
 
         switch resolvedType {
-        case "moss_tts_nano":
-            return try await MossTTSNanoModel.fromPretrained(modelRepo, cache: cache)
         case "echo_tts", "echo":
             return try await EchoTTSModel.fromPretrained(modelRepo, cache: cache)
         case "qwen3_tts":
@@ -76,6 +74,8 @@ public enum TTS {
         case "kokoro", "kokoro_tts":
             let processor = textProcessor ?? KokoroMultilingualProcessor()
             return try await KokoroModel.fromPretrained(modelRepo, textProcessor: processor, cache: cache)
+        case "voxcpm2", "vox_cpm2":
+            return try await VoxCPM2Model.fromPretrained(modelRepo, cache: cache)
         default:
             throw TTSModelError.unsupportedModelType(modelType ?? resolvedType)
         }
@@ -108,9 +108,6 @@ public enum TTS {
         if lower.contains("echo") {
             return "echo_tts"
         }
-        if lower.contains("moss") && lower.contains("tts") {
-            return "moss_tts_nano"
-        }
         if lower.contains("qwen3") || lower.contains("qwen") {
             return "qwen3"
         }
@@ -134,6 +131,9 @@ public enum TTS {
         }
         if lower.contains("kokoro") {
             return "kokoro"
+        }
+        if lower.contains("voxcpm") {
+            return "voxcpm2"
         }
         return nil
     }

--- a/Tests/MLXAudioSmokeTests.swift
+++ b/Tests/MLXAudioSmokeTests.swift
@@ -554,6 +554,94 @@ struct TTSSmokeTests {
         print("\u{001B}[32mSaved generated audio to\u{001B}[0m: \(outputURL.path)")
     }
 
+    @Test func voxcpm2Generate() async throws {
+        testHeader("voxcpm2Generate")
+        defer { testCleanup("voxcpm2Generate") }
+
+        guard let audioURL = Bundle.module.url(
+            forResource: "conversational_a", withExtension: "wav", subdirectory: "media"
+        ) else {
+            Issue.record("Test audio file 'conversational_a.wav' not found in bundle")
+            return
+        }
+        let (_, refAudio) = try loadAudioArray(from: audioURL)
+        print("\u{001B}[36mLoaded reference audio: \(refAudio.shape)\u{001B}[0m")
+
+        print("\u{001B}[33mLoading VoxCPM2 model...\u{001B}[0m")
+        let model = try await VoxCPM2Model.fromPretrained("mlx-community/VoxCPM2-4bit")
+        print("\u{001B}[32mVoxCPM2 model loaded!\u{001B}[0m")
+
+        #expect(model.tokenizer != nil, "Tokenizer should be loaded")
+        #expect(model.sampleRate == 48000, "Sample rate should be 48kHz")
+
+        let text = "Hello, this is a test of the VoxCPM2 model."
+        print("\u{001B}[33mGenerating audio for: \"\(text)\"...\u{001B}[0m")
+
+        let audio = try await model.generate(
+            text: text, voice: nil, refAudio: refAudio, refText: nil, language: nil,
+            generationParameters: GenerateParameters(maxTokens: 100, temperature: 1.0)
+        )
+
+        print("\u{001B}[32mGenerated audio shape: \(audio.shape)\u{001B}[0m")
+        let sampleCount = audio.shape[audio.ndim - 1]
+        #expect(sampleCount > 0, "Audio should have samples")
+        let duration = Float(sampleCount) / Float(model.sampleRate)
+        print("\u{001B}[32mGenerated \(String(format: "%.2f", duration))s of audio\u{001B}[0m")
+        #expect(duration > 0.1, "Audio duration should be > 0.1s")
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voxcpm2_test_output.wav")
+        try saveAudioArray(audio, sampleRate: Double(model.sampleRate), to: outputURL)
+        print("\u{001B}[32mSaved generated audio to\u{001B}[0m: \(outputURL.path)")
+    }
+
+    @Test func voxcpm2GenerateStream() async throws {
+        testHeader("voxcpm2GenerateStream")
+        defer { testCleanup("voxcpm2GenerateStream") }
+
+        guard let audioURL = Bundle.module.url(
+            forResource: "conversational_a", withExtension: "wav", subdirectory: "media"
+        ) else {
+            Issue.record("Test audio file 'conversational_a.wav' not found in bundle")
+            return
+        }
+        let (_, refAudio) = try loadAudioArray(from: audioURL)
+
+        print("\u{001B}[33mLoading VoxCPM2 model...\u{001B}[0m")
+        let model = try await VoxCPM2Model.fromPretrained("mlx-community/VoxCPM2-4bit")
+        print("\u{001B}[32mVoxCPM2 model loaded!\u{001B}[0m")
+
+        let text = "Streaming test for VoxCPM2 model."
+        print("\u{001B}[33mStreaming audio for: \"\(text)\"...\u{001B}[0m")
+
+        var finalAudio: MLXArray?
+        for try await event in model.generateStream(
+            text: text, voice: nil, refAudio: refAudio, refText: nil, language: nil,
+            generationParameters: GenerateParameters(maxTokens: 100, temperature: 1.0)
+        ) {
+            switch event {
+            case .audio(let audio):
+                finalAudio = audio
+                print("\u{001B}[32mReceived audio chunk: \(audio.shape)\u{001B}[0m")
+            case .info(let info):
+                print("\u{001B}[36mGeneration info: \(String(format: "%.2f", info.generateTime))s\u{001B}[0m")
+            case .token(_):
+                break
+            }
+        }
+
+        #expect(finalAudio != nil, "Should receive audio from stream")
+        if let audio = finalAudio {
+            let sampleCount = audio.shape[audio.ndim - 1]
+            #expect(sampleCount > 0, "Audio should have samples")
+
+            let outputURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("voxcpm2_stream_test_output.wav")
+            try saveAudioArray(audio, sampleRate: Double(model.sampleRate), to: outputURL)
+            print("\u{001B}[32mSaved streamed audio to\u{001B}[0m: \(outputURL.path)")
+        }
+    }
+
     @Test func chatterboxRegularGenerateStream() async throws {
         testHeader("chatterboxRegularGenerateStream")
         defer { testCleanup("chatterboxRegularGenerateStream") }


### PR DESCRIPTION
Swift port of VoxCPM2, based on the Python implementation in Blaizzy/mlx-audio#641.

Autoregressive MiniCPM backbone + CFM diffusion + AudioVAE decoder.
Supports zero-shot generation and reference-audio voice cloning across 30+ languages.

## Supported model

- [mlx-community/VoxCPM2-4bit](https://huggingface.co/mlx-community/VoxCPM2-4bit) (4-bit quantized, 2.3 GB)

## Example

```swift
import MLXAudioTTS
import MLXAudioCore

let model = try await VoxCPM2Model.fromPretrained("mlx-community/VoxCPM2-4bit")

// Voice cloning
let (_, refAudio) = try loadAudioArray(from: referenceAudioURL)
let audio = try await model.generate(
    text: "Hello, this is VoxCPM2.",
    voice: nil, refAudio: refAudio, refText: nil, language: nil,
    generationParameters: GenerateParameters(maxTokens: 100, temperature: 1.0)
)
```

## Smoke test results (M5 Max, macOS 26.3.2)

| Test | Audio | Duration | Peak Memory | Time |
|------|-------|----------|-------------|------|
| `voxcpm2Generate()` | 92,160 samples @ 48kHz | 1.92s | 3.72 GB | 6.96s |
| `voxcpm2GenerateStream()` | 69,120 samples @ 48kHz | 1.44s | — | 2.03s |

Both produce valid mono Float32 WAV at 48kHz.

## Known limitations

- 4-bit stop predictor can be unreliable — callers should set `maxTokens` conservatively
- Short Chinese prompts may have text-following issues (consistent with Python, see mlx-audio#641)
- Streaming wraps the full `generate()` call rather than yielding incremental chunks
- Voice design and continuation modes from the Python PR are not yet ported

## Checklist

- [x] Conforms to `SpeechGenerationModel`
- [x] Factory registration in `TTSModel.swift`
- [x] Smoke tests for generate + stream
- [x] README.md with usage and limitations
- [x] `swift build` clean (zero warnings)
- [x] Package.swift README exclude
