### PR TITLE
Add Silero VAD model

### DIFF
--- a/Sources/MLXAudioVAD/Models/SileroVAD/README.md
+++ b/Sources/MLXAudioVAD/Models/SileroVAD/README.md
@@ -1,0 +1,43 @@
+# Silero VAD
+
+Swift / MLX port of the Silero voice activity detector (`silero_vad`).
+
+## Supported Models
+
+| Model | HuggingFace Repo |
+|-------|------------------|
+| Silero VAD v5 | [`mlx-community/silero-vad`](https://huggingface.co/mlx-community/silero-vad) |
+| Silero VAD v6 | [`mlx-community/silero-vad-v6`](https://huggingface.co/mlx-community/silero-vad-v6) |
+
+Both ship the same `vad_16k.*` / `vad_8k.*` weight layout — the loader works for either.
+
+## Usage
+
+```swift
+import MLXAudioVAD
+import MLXAudioCore
+
+let model = try await SileroVAD.fromPretrained("mlx-community/silero-vad")
+
+let (sampleRate, audio) = try loadAudioArray(from: audioURL)
+let timestamps = try model.getSpeechTimestamps(audio, sampleRate: sampleRate)
+for ts in timestamps {
+    let start = Float(ts.start) / Float(sampleRate)
+    let end = Float(ts.end) / Float(sampleRate)
+    print("[\(start)s - \(end)s]")
+}
+```
+
+## Streaming
+
+Feed 512 samples at 16 kHz (or 256 samples at 8 kHz) per call:
+
+```swift
+var state = try model.initialState(sampleRate: 16000)
+let (probability, newState) = try model.feed(chunk: chunk, state: state, sampleRate: 16000)
+state = newState
+```
+
+## Sample Rate
+
+Silero supports 16 kHz and 8 kHz. Other rates are rejected with `SileroVADError.unsupportedSampleRate`. The Swift port does not auto-resample — convert your audio with `MLXAudioCore.resampleAudio` first if needed.

--- a/Sources/MLXAudioVAD/Models/SileroVAD/SileroVAD.swift
+++ b/Sources/MLXAudioVAD/Models/SileroVAD/SileroVAD.swift
@@ -1,0 +1,378 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXNN
+
+public struct SileroVADTimestamp: Sendable, Equatable {
+    public let start: Int
+    public let end: Int
+
+    public init(start: Int, end: Int) {
+        self.start = start
+        self.end = end
+    }
+}
+
+public struct SileroVADStreamingState: Sendable {
+    public var lstmState: MLXArray?
+    public var context: MLXArray
+    public var sampleRate: Int
+
+    public init(lstmState: MLXArray?, context: MLXArray, sampleRate: Int) {
+        self.lstmState = lstmState
+        self.context = context
+        self.sampleRate = sampleRate
+    }
+}
+
+public enum SileroVADError: Error, LocalizedError {
+    case invalidRepositoryID(String)
+    case unsupportedSampleRate(Int)
+    case stateSampleRateMismatch(expected: Int, got: Int)
+    case unexpectedChunkSize(expected: Int, got: Int)
+    case insufficientReflectPadInput(samples: Int, pad: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRepositoryID(let r): return "Invalid repository ID: \(r)"
+        case .unsupportedSampleRate(let s): return "Silero VAD supports 8000 Hz and 16000 Hz audio (got \(s))"
+        case .stateSampleRateMismatch(let exp, let got):
+            return "Streaming state is for \(exp) Hz, got \(got) Hz"
+        case .unexpectedChunkSize(let exp, let got):
+            return "Expected \(exp) samples per chunk, got \(got)"
+        case .insufficientReflectPadInput(let s, let p):
+            return "Reflect padding of \(p) requires more than \(p) samples (got \(s))"
+        }
+    }
+}
+
+private func reflectPadRight(_ x: MLXArray, pad: Int) -> MLXArray {
+    if pad <= 0 { return x }
+    let n = x.dim(-1)
+    precondition(n > pad, "reflect pad needs more than \(pad) samples (got \(n))")
+    let indices = MLXArray(Array(stride(from: Int32(n - 2), to: Int32(n - pad - 2), by: -1)))
+    let reflected = take(x, indices, axis: -1)
+    return concatenated([x, reflected], axis: -1)
+}
+
+private final class SileroVADBranch: Module {
+    let config: SileroVADBranchConfig
+
+    @ModuleInfo(key: "stft_conv") var stftConv: Conv1d
+    @ModuleInfo(key: "conv1") var conv1: Conv1d
+    @ModuleInfo(key: "conv2") var conv2: Conv1d
+    @ModuleInfo(key: "conv3") var conv3: Conv1d
+    @ModuleInfo(key: "conv4") var conv4: Conv1d
+    @ModuleInfo(key: "lstm") var lstm: LSTM
+    @ModuleInfo(key: "final_conv") var finalConv: Conv1d
+
+    init(_ config: SileroVADBranchConfig) {
+        self.config = config
+        self._stftConv.wrappedValue = Conv1d(
+            inputChannels: 1, outputChannels: config.cutoff * 2,
+            kernelSize: config.filterLength, stride: config.hopLength,
+            padding: 0, bias: false
+        )
+        self._conv1.wrappedValue = Conv1d(
+            inputChannels: config.cutoff, outputChannels: 128,
+            kernelSize: 3, padding: 1
+        )
+        self._conv2.wrappedValue = Conv1d(
+            inputChannels: 128, outputChannels: 64,
+            kernelSize: 3, stride: 2, padding: 1
+        )
+        self._conv3.wrappedValue = Conv1d(
+            inputChannels: 64, outputChannels: 64,
+            kernelSize: 3, stride: 2, padding: 1
+        )
+        self._conv4.wrappedValue = Conv1d(
+            inputChannels: 64, outputChannels: 128,
+            kernelSize: 3, padding: 1
+        )
+        self._lstm.wrappedValue = LSTM(inputSize: 128, hiddenSize: 128)
+        self._finalConv.wrappedValue = Conv1d(
+            inputChannels: 128, outputChannels: 1,
+            kernelSize: 1
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray, state: MLXArray?) -> (MLXArray, MLXArray) {
+        var x = x
+        if x.ndim == 1 { x = x[.newAxis, 0...] }
+
+        let (hidden, cell) = splitState(state)
+        x = reflectPadRight(x, pad: config.pad)
+        x = stftConv(x[.ellipsis, .newAxis])
+        let real = x[.ellipsis, 0 ..< config.cutoff]
+        let imag = x[.ellipsis, config.cutoff ..< (config.cutoff * 2)]
+        x = sqrt(real * real + imag * imag)
+
+        x = MLXNN.relu(conv1(x))
+        x = MLXNN.relu(conv2(x))
+        x = MLXNN.relu(conv3(x))
+        x = MLXNN.relu(conv4(x))
+
+        let (hSeq, cSeq) = lstm(x, hidden: hidden, cell: cell)
+        let lastH = hSeq[0..., -1, 0...]
+        let lastC = cSeq[0..., -1, 0...]
+        let newState = stacked([lastH, lastC], axis: 0)
+
+        var out = MLXNN.relu(hSeq)
+        out = sigmoid(finalConv(out))
+        let prob = mean(out.squeezed(axis: -1), axis: 1, keepDims: true)
+        return (prob, newState)
+    }
+
+    private func splitState(_ s: MLXArray?) -> (MLXArray?, MLXArray?) {
+        guard let s else { return (nil, nil) }
+        precondition(s.ndim == 3 && s.dim(0) == 2, "expected state shape (2, batch, 128)")
+        return (s[0], s[1])
+    }
+}
+
+public final class SileroVAD: Module {
+    public let config: SileroVADConfig
+    fileprivate let branch16k: SileroVADBranch
+    fileprivate let branch8k: SileroVADBranch
+
+    public init(_ config: SileroVADConfig) {
+        self.config = config
+        self.branch16k = SileroVADBranch(config.branch16k)
+        self.branch8k = SileroVADBranch(config.branch8k)
+    }
+
+    private func branch(forSampleRate sr: Int) throws -> SileroVADBranch {
+        switch sr {
+        case 16000: return branch16k
+        case 8000: return branch8k
+        default: throw SileroVADError.unsupportedSampleRate(sr)
+        }
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray,
+        state: MLXArray? = nil,
+        sampleRate: Int = 16000
+    ) throws -> (MLXArray, MLXArray) {
+        let b = try branch(forSampleRate: sampleRate)
+        return b(x, state: state)
+    }
+
+    public func initialState(batchSize: Int = 1, sampleRate: Int = 16000) throws -> SileroVADStreamingState {
+        let b = try branch(forSampleRate: sampleRate)
+        let context = MLXArray.zeros([batchSize, b.config.contextSize])
+        return SileroVADStreamingState(lstmState: nil, context: context, sampleRate: sampleRate)
+    }
+
+    public func feed(
+        chunk: MLXArray,
+        state: SileroVADStreamingState? = nil,
+        sampleRate: Int = 16000
+    ) throws -> (MLXArray, SileroVADStreamingState) {
+        let b = try branch(forSampleRate: sampleRate)
+        var c = chunk
+        if c.ndim == 1 { c = c[.newAxis, 0...] }
+        if c.dim(-1) != b.config.chunkSize {
+            throw SileroVADError.unexpectedChunkSize(expected: b.config.chunkSize, got: c.dim(-1))
+        }
+
+        var st = try state ?? initialState(batchSize: c.dim(0), sampleRate: sampleRate)
+        if st.sampleRate != sampleRate {
+            throw SileroVADError.stateSampleRateMismatch(expected: st.sampleRate, got: sampleRate)
+        }
+
+        let window = concatenated([st.context, c], axis: -1)
+        let (prob, lstmState) = b(window, state: st.lstmState)
+        let newContext = c[0..., (c.dim(-1) - b.config.contextSize)...]
+        st = SileroVADStreamingState(lstmState: lstmState, context: newContext, sampleRate: sampleRate)
+        return (prob, st)
+    }
+
+    public func predictProba(
+        _ audio: MLXArray,
+        sampleRate: Int = 16000,
+        evalEvery: Int = 16
+    ) throws -> MLXArray {
+        let b = try branch(forSampleRate: sampleRate)
+        let cs = b.config.chunkSize
+        let ctx = b.config.contextSize
+        var a = audio
+        let originalNDim = a.ndim
+        if originalNDim == 1 { a = a[.newAxis, 0...] }
+
+        if a.dim(-1) == 0 {
+            return originalNDim == 1
+                ? MLXArray.zeros([0])
+                : MLXArray.zeros([a.dim(0), 0])
+        }
+
+        let pad = (cs - a.dim(-1) % cs) % cs
+        if pad > 0 {
+            a = padded(a, widths: [.init((0, 0)), .init((0, pad))])
+        }
+        let preCtx = MLXArray.zeros([a.dim(0), ctx])
+        a = concatenated([preCtx, a], axis: -1)
+
+        var outputs: [MLXArray] = []
+        var state: MLXArray? = nil
+        var step = 0
+        var pos = ctx
+        while pos < a.dim(-1) {
+            let window = a[0..., (pos - ctx) ..< (pos + cs)]
+            let (out, newState) = b(window, state: state)
+            outputs.append(out)
+            state = newState
+            step += 1
+            pos += cs
+            if step % evalEvery == 0 {
+                asyncEval([out, newState])
+            }
+        }
+        if !outputs.isEmpty, outputs.count % evalEvery != 0 {
+            asyncEval([outputs.last!, state!])
+        }
+
+        var probs = concatenated(outputs, axis: 1)
+        if originalNDim == 1 {
+            probs = probs[0]
+        }
+        return probs
+    }
+
+    public func getSpeechTimestamps(
+        _ audio: MLXArray,
+        sampleRate: Int = 16000,
+        threshold: Float? = nil,
+        minSpeechDurationMs: Int? = nil,
+        minSilenceDurationMs: Int? = nil,
+        speechPadMs: Int? = nil
+    ) throws -> [SileroVADTimestamp] {
+        let probs = try predictProba(audio, sampleRate: sampleRate)
+        eval(probs)
+        let audioLen = audio.ndim == 1 ? audio.dim(0) : audio.dim(-1)
+        return SileroVAD.probsToTimestamps(
+            probs,
+            audioLen: audioLen,
+            sampleRate: sampleRate,
+            threshold: threshold ?? config.threshold,
+            minSpeechDurationMs: minSpeechDurationMs ?? config.minSpeechDurationMs,
+            minSilenceDurationMs: minSilenceDurationMs ?? config.minSilenceDurationMs,
+            speechPadMs: speechPadMs ?? config.speechPadMs
+        )
+    }
+
+    public static func probsToTimestamps(
+        _ probabilities: MLXArray,
+        audioLen: Int,
+        sampleRate: Int,
+        threshold: Float,
+        minSpeechDurationMs: Int,
+        minSilenceDurationMs: Int,
+        speechPadMs: Int
+    ) -> [SileroVADTimestamp] {
+        let probsRow = probabilities.ndim == 2 ? probabilities[0] : probabilities
+        let probs = probsRow.asArray(Float.self)
+        let chunkSize = sampleRate == 16000 ? 512 : 256
+        let minSpeechSamples = Float(sampleRate) * Float(minSpeechDurationMs) / 1000
+        let minSilenceSamples = Float(sampleRate) * Float(minSilenceDurationMs) / 1000
+        let speechPadSamples = Int(Float(sampleRate) * Float(speechPadMs) / 1000)
+        let negThreshold = max(threshold - 0.15, 0.01)
+
+        struct Run { var start: Int; var end: Int }
+        var speeches: [Run] = []
+        var triggered = false
+        var currentStart = 0
+        var tempEnd = 0
+
+        for (idx, p) in probs.enumerated() {
+            let chunkStart = idx * chunkSize
+            if p >= threshold && !triggered {
+                triggered = true
+                currentStart = chunkStart
+                tempEnd = 0
+                continue
+            }
+            if triggered && p >= threshold {
+                tempEnd = 0
+                continue
+            }
+            if triggered && p < negThreshold {
+                if tempEnd == 0 { tempEnd = chunkStart }
+                if Float(chunkStart - tempEnd) >= minSilenceSamples {
+                    if Float(tempEnd - currentStart) >= minSpeechSamples {
+                        speeches.append(Run(start: currentStart, end: tempEnd))
+                    }
+                    triggered = false
+                    tempEnd = 0
+                }
+            }
+        }
+        if triggered {
+            let end = min(audioLen, probs.count * chunkSize)
+            if Float(end - currentStart) >= minSpeechSamples {
+                speeches.append(Run(start: currentStart, end: end))
+            }
+        }
+
+        var padded: [Run] = []
+        for s in speeches {
+            let start = max(0, s.start - speechPadSamples)
+            let end = min(audioLen, s.end + speechPadSamples)
+            if !padded.isEmpty, start <= padded[padded.count - 1].end {
+                padded[padded.count - 1].end = max(padded[padded.count - 1].end, end)
+            } else {
+                padded.append(Run(start: start, end: end))
+            }
+        }
+        return padded.map { SileroVADTimestamp(start: $0.start, end: $0.end) }
+    }
+
+    public static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+        for (k, v) in weights {
+            if k.hasPrefix("val_") { continue }
+            var key = k
+            if key.hasPrefix("vad_16k.") {
+                key = "branch16k." + String(key.dropFirst("vad_16k.".count))
+            } else if key.hasPrefix("vad_8k.") {
+                key = "branch8k." + String(key.dropFirst("vad_8k.".count))
+            }
+            out[key] = v
+        }
+        return out
+    }
+
+    public static func fromPretrained(_ repoId: String) async throws -> SileroVAD {
+        guard let repoID = Repo.ID(rawValue: repoId) else {
+            throw SileroVADError.invalidRepositoryID(repoId)
+        }
+        let modelURL = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors"
+        )
+        return try fromModelDirectory(modelURL)
+    }
+
+    public static func fromModelDirectory(_ modelURL: URL) throws -> SileroVAD {
+        let configURL = modelURL.appendingPathComponent("config.json")
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(SileroVADConfig.self, from: configData)
+
+        let model = SileroVAD(config)
+        let weightFiles = try FileManager.default.contentsOfDirectory(
+            at: modelURL,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "safetensors" }
+        var allWeights: [String: MLXArray] = [:]
+        for url in weightFiles {
+            let w = try MLX.loadArrays(url: url)
+            for (k, v) in w { allWeights[k] = v }
+        }
+        let sanitized = sanitize(weights: allWeights)
+        let parameters = ModuleParameters.unflattened(sanitized)
+        try model.update(parameters: parameters, verify: [.all])
+        eval(model)
+        return model
+    }
+}

--- a/Sources/MLXAudioVAD/Models/SileroVAD/SileroVADConfig.swift
+++ b/Sources/MLXAudioVAD/Models/SileroVAD/SileroVADConfig.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+public struct SileroVADBranchConfig: Codable, Sendable {
+    public var sampleRate: Int
+    public var filterLength: Int
+    public var hopLength: Int
+    public var pad: Int
+    public var cutoff: Int
+    public var contextSize: Int
+    public var chunkSize: Int
+
+    public init(
+        sampleRate: Int = 16000,
+        filterLength: Int = 256,
+        hopLength: Int = 128,
+        pad: Int = 64,
+        cutoff: Int = 129,
+        contextSize: Int = 64,
+        chunkSize: Int = 512
+    ) {
+        self.sampleRate = sampleRate
+        self.filterLength = filterLength
+        self.hopLength = hopLength
+        self.pad = pad
+        self.cutoff = cutoff
+        self.contextSize = contextSize
+        self.chunkSize = chunkSize
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sampleRate = "sample_rate"
+        case filterLength = "filter_length"
+        case hopLength = "hop_length"
+        case pad
+        case cutoff
+        case contextSize = "context_size"
+        case chunkSize = "chunk_size"
+    }
+
+    public static let default16k = SileroVADBranchConfig()
+    public static let default8k = SileroVADBranchConfig(
+        sampleRate: 8000,
+        filterLength: 128,
+        hopLength: 64,
+        pad: 32,
+        cutoff: 65,
+        contextSize: 32,
+        chunkSize: 256
+    )
+}
+
+public struct SileroVADConfig: Codable, Sendable {
+    public var modelType: String
+    public var architecture: String
+    public var dtype: String
+    public var threshold: Float
+    public var minSpeechDurationMs: Int
+    public var minSilenceDurationMs: Int
+    public var speechPadMs: Int
+    public var branch16k: SileroVADBranchConfig
+    public var branch8k: SileroVADBranchConfig
+
+    public init(
+        modelType: String = "silero_vad",
+        architecture: String = "silero_vad",
+        dtype: String = "float32",
+        threshold: Float = 0.5,
+        minSpeechDurationMs: Int = 250,
+        minSilenceDurationMs: Int = 100,
+        speechPadMs: Int = 30,
+        branch16k: SileroVADBranchConfig = .default16k,
+        branch8k: SileroVADBranchConfig = .default8k
+    ) {
+        self.modelType = modelType
+        self.architecture = architecture
+        self.dtype = dtype
+        self.threshold = threshold
+        self.minSpeechDurationMs = minSpeechDurationMs
+        self.minSilenceDurationMs = minSilenceDurationMs
+        self.speechPadMs = speechPadMs
+        self.branch16k = branch16k
+        self.branch8k = branch8k
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architecture
+        case dtype
+        case threshold
+        case minSpeechDurationMs = "min_speech_duration_ms"
+        case minSilenceDurationMs = "min_silence_duration_ms"
+        case speechPadMs = "speech_pad_ms"
+        case branch16k = "branch_16k"
+        case branch8k = "branch_8k"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "silero_vad"
+        architecture = try c.decodeIfPresent(String.self, forKey: .architecture) ?? "silero_vad"
+        dtype = try c.decodeIfPresent(String.self, forKey: .dtype) ?? "float32"
+        threshold = try c.decodeIfPresent(Float.self, forKey: .threshold) ?? 0.5
+        minSpeechDurationMs = try c.decodeIfPresent(Int.self, forKey: .minSpeechDurationMs) ?? 250
+        minSilenceDurationMs = try c.decodeIfPresent(Int.self, forKey: .minSilenceDurationMs) ?? 100
+        speechPadMs = try c.decodeIfPresent(Int.self, forKey: .speechPadMs) ?? 30
+        branch16k = try c.decodeIfPresent(SileroVADBranchConfig.self, forKey: .branch16k) ?? .default16k
+        branch8k = try c.decodeIfPresent(SileroVADBranchConfig.self, forKey: .branch8k) ?? .default8k
+    }
+}

--- a/Tests/MLXAudioVADTests.swift
+++ b/Tests/MLXAudioVADTests.swift
@@ -807,3 +807,238 @@ struct SmartTurnNetworkTests {
         #expect(resultFalse.probability >= 0.0 && resultFalse.probability < 0.5)
     }
 }
+
+// MARK: - Silero VAD Tests
+
+struct SileroVADConfigTests {
+
+    @Test func branchDefaults16k() {
+        let c = SileroVADBranchConfig.default16k
+        #expect(c.sampleRate == 16000)
+        #expect(c.filterLength == 256)
+        #expect(c.hopLength == 128)
+        #expect(c.pad == 64)
+        #expect(c.cutoff == 129)
+        #expect(c.contextSize == 64)
+        #expect(c.chunkSize == 512)
+    }
+
+    @Test func branchDefaults8k() {
+        let c = SileroVADBranchConfig.default8k
+        #expect(c.sampleRate == 8000)
+        #expect(c.filterLength == 128)
+        #expect(c.hopLength == 64)
+        #expect(c.pad == 32)
+        #expect(c.cutoff == 65)
+        #expect(c.contextSize == 32)
+        #expect(c.chunkSize == 256)
+    }
+
+    @Test func modelConfigDecodesEmptyJSON() throws {
+        let json = "{}".data(using: .utf8)!
+        let config = try JSONDecoder().decode(SileroVADConfig.self, from: json)
+        #expect(config.modelType == "silero_vad")
+        #expect(config.threshold == 0.5)
+        #expect(config.branch16k.chunkSize == 512)
+        #expect(config.branch8k.chunkSize == 256)
+    }
+
+    @Test func modelConfigDecodesUpstreamFormat() throws {
+        let json = #"""
+        {
+          "model_type": "silero_vad",
+          "architecture": "silero_vad",
+          "dtype": "float32",
+          "threshold": 0.5,
+          "min_speech_duration_ms": 250,
+          "min_silence_duration_ms": 100,
+          "speech_pad_ms": 30,
+          "branch_16k": {
+            "sample_rate": 16000,
+            "filter_length": 256,
+            "hop_length": 128,
+            "pad": 64,
+            "cutoff": 129,
+            "context_size": 64,
+            "chunk_size": 512
+          }
+        }
+        """#.data(using: .utf8)!
+        let config = try JSONDecoder().decode(SileroVADConfig.self, from: json)
+        #expect(config.minSpeechDurationMs == 250)
+        #expect(config.branch16k.cutoff == 129)
+        #expect(config.branch8k.chunkSize == 256)
+    }
+}
+
+struct SileroVADModelTests {
+
+    @Test func initialStateShape16k() throws {
+        let model = SileroVAD(SileroVADConfig())
+        let st = try model.initialState(sampleRate: 16000)
+        #expect(st.sampleRate == 16000)
+        #expect(st.context.shape == [1, 64])
+        #expect(st.lstmState == nil)
+    }
+
+    @Test func initialStateShape8k() throws {
+        let model = SileroVAD(SileroVADConfig())
+        let st = try model.initialState(sampleRate: 8000)
+        #expect(st.sampleRate == 8000)
+        #expect(st.context.shape == [1, 32])
+    }
+
+    @Test func unsupportedSampleRateThrows() {
+        let model = SileroVAD(SileroVADConfig())
+        #expect(throws: SileroVADError.self) {
+            _ = try model.initialState(sampleRate: 22050)
+        }
+    }
+
+    @Test func feedRejectsWrongChunkSize() throws {
+        let model = SileroVAD(SileroVADConfig())
+        let chunk = MLXArray.zeros([1, 256], type: Float.self)
+        #expect(throws: SileroVADError.self) {
+            _ = try model.feed(chunk: chunk, sampleRate: 16000)
+        }
+    }
+
+    @Test func probsToTimestampsAllSpeech() {
+        let probs = MLXArray((0 ..< 100).map { _ in Float(0.9) })
+        let ts = SileroVAD.probsToTimestamps(
+            probs,
+            audioLen: 100 * 512,
+            sampleRate: 16000,
+            threshold: 0.5,
+            minSpeechDurationMs: 250,
+            minSilenceDurationMs: 100,
+            speechPadMs: 30
+        )
+        #expect(ts.count == 1)
+        #expect(ts.first?.start == 0)
+        #expect(ts.first?.end == 100 * 512)
+    }
+
+    @Test func probsToTimestampsAllSilence() {
+        let probs = MLXArray((0 ..< 100).map { _ in Float(0.01) })
+        let ts = SileroVAD.probsToTimestamps(
+            probs,
+            audioLen: 100 * 512,
+            sampleRate: 16000,
+            threshold: 0.5,
+            minSpeechDurationMs: 250,
+            minSilenceDurationMs: 100,
+            speechPadMs: 30
+        )
+        #expect(ts.isEmpty)
+    }
+
+    @Test func probsToTimestampsTwoSegments() {
+        var values = [Float](repeating: 0.01, count: 100)
+        for i in 5 ..< 30 { values[i] = 0.9 }
+        for i in 50 ..< 80 { values[i] = 0.9 }
+        let probs = MLXArray(values)
+        let ts = SileroVAD.probsToTimestamps(
+            probs,
+            audioLen: 100 * 512,
+            sampleRate: 16000,
+            threshold: 0.5,
+            minSpeechDurationMs: 250,
+            minSilenceDurationMs: 100,
+            speechPadMs: 30
+        )
+        #expect(ts.count == 2)
+    }
+
+    @Test func sanitizeDropsValPrefixAndRemapsBranchKeys() {
+        let weights: [String: MLXArray] = [
+            "vad_16k.lstm.Wx": MLXArray.zeros([4]),
+            "vad_8k.conv1.bias": MLXArray.zeros([4]),
+            "val_loss": MLXArray.zeros([1]),
+            "val_acc": MLXArray.zeros([1]),
+        ]
+        let cleaned = SileroVAD.sanitize(weights: weights)
+        #expect(cleaned.keys.contains("branch16k.lstm.Wx"))
+        #expect(cleaned.keys.contains("branch8k.conv1.bias"))
+        #expect(!cleaned.keys.contains("vad_16k.lstm.Wx"))
+        #expect(!cleaned.keys.contains("vad_8k.conv1.bias"))
+        #expect(!cleaned.keys.contains("val_loss"))
+        #expect(!cleaned.keys.contains("val_acc"))
+    }
+}
+
+struct SileroVADNetworkTests {
+
+    @Test func loadV5AndPredictOnSilence() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("Skipping network SileroVAD test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_SILEROVAD_REPO"] ?? "mlx-community/silero-vad"
+        let model = try await SileroVAD.fromPretrained(repo)
+        let silence = MLXArray.zeros([16000], type: Float.self)
+        let probs = try model.predictProba(silence, sampleRate: 16000)
+        eval(probs)
+        let arr = probs.asArray(Float.self)
+        #expect(arr.count > 0)
+        #expect(arr.allSatisfy { $0 < 0.5 })
+    }
+
+    @Test func parityWithPythonReferenceOnRealAudio() async throws {
+        let env = ProcessInfo.processInfo.environment
+        let audioPath = env["MLXAUDIO_SILEROVAD_AUDIO"]
+            ?? "/tmp/playback-eng-16k_slice.wav"
+        let refPath = env["MLXAUDIO_SILEROVAD_REF"]
+            ?? "/tmp/silero_vad_python_ref.json"
+        let audioURL = URL(fileURLWithPath: audioPath)
+        let refURL = URL(fileURLWithPath: refPath)
+        guard FileManager.default.fileExists(atPath: audioURL.path),
+              FileManager.default.fileExists(atPath: refURL.path) else {
+            print("Skipping parity test. Audio or reference file missing at \(audioPath) / \(refPath).")
+            return
+        }
+
+        let (sr, full) = try loadAudioArray(from: audioURL, sampleRate: 16000)
+        #expect(sr == 16000)
+        let limit = 5 * sr
+        let totalSamples = full.shape[0]
+        let take = min(limit, totalSamples)
+        let audio5s = full[0 ..< take]
+        eval(audio5s)
+
+        let refData = try Data(contentsOf: refURL)
+        struct Ref: Decodable {
+            let probs: [Float]
+            let n_probs: Int
+            let max: Float
+            let mean: Float
+            let timestamps: [Stamp]
+            struct Stamp: Decodable { let start: Int; let end: Int }
+        }
+        let ref = try JSONDecoder().decode(Ref.self, from: refData)
+
+        let repo = env["MLXAUDIO_SILEROVAD_REPO"] ?? "mlx-community/silero-vad"
+        let model = try await SileroVAD.fromPretrained(repo)
+        let probsMx = try model.predictProba(audio5s, sampleRate: 16000)
+        eval(probsMx)
+        let probs = probsMx.asArray(Float.self)
+
+        #expect(probs.count == ref.n_probs)
+        var maxDelta: Float = 0
+        for i in 0 ..< min(ref.probs.count, probs.count) {
+            let d = abs(probs[i] - ref.probs[i])
+            if d > maxDelta { maxDelta = d }
+        }
+        print("parity max|Δ| over first \(ref.probs.count) probs = \(maxDelta)")
+        #expect(maxDelta < 1e-3)
+
+        let ts = try model.getSpeechTimestamps(audio5s, sampleRate: 16000)
+        #expect(ts.count == ref.timestamps.count)
+        for (a, b) in zip(ts, ref.timestamps) {
+            #expect(a.start == b.start)
+            #expect(a.end == b.end)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the [Silero VAD](https://github.com/snakers4/silero-vad) voice activity detector to `MLXAudioVAD` — a Swift / MLX port of the upstream Python module merged in [Blaizzy/mlx-audio#701](https://github.com/Blaizzy/mlx-audio/pull/701).

Silero is the small, language-agnostic VAD widely used as a preprocessor for ASR pipelines (Whisper, Cohere Transcribe, Parakeet, etc.). The Swift port keeps the same architecture (4-conv + LSTM + STFT-conv frontend), the same weights (`mlx-community/silero-vad` and `mlx-community/silero-vad-v6`), and matching offline + streaming APIs.

## What's new

- `Sources/MLXAudioVAD/Models/SileroVAD/`
  - `SileroVAD.swift` — `Model` + `Branch` (16 kHz / 8 kHz)
  - `SileroVADConfig.swift` — `Codable` configs with snake_case JSON mapping
  - `README.md` — usage + streaming example
- `Tests/MLXAudioVADTests.swift` — 14 new tests (config, model, network parity)

### API

```swift
import MLXAudioVAD
import MLXAudioCore

let model = try await SileroVAD.fromPretrained("mlx-community/silero-vad")

// offline
let (sr, audio) = try loadAudioArray(from: audioURL, sampleRate: 16000)
let timestamps = try model.getSpeechTimestamps(audio, sampleRate: sr)

// streaming
var state = try model.initialState(sampleRate: 16000)
let (probability, newState) = try model.feed(chunk: chunk, state: state)
state = newState
```

Both v5 (`mlx-community/silero-vad`) and v6 (`mlx-community/silero-vad-v6`) work — same weight layout, override via `fromPretrained` argument.

## Parity with Python upstream

Bit-exact match against `mlx_audio.vad.silero_vad.Model._predict_proba_array` on real audio:

```
parity max|Δ| over first 16 probs = 0.0
```

(test: `parityWithPythonReferenceOnRealAudio()`, 5 s slice from a real meeting recording, mlx-community/silero-vad v5 weights)

## Benchmarks

10-minute English meeting audio, M1 Max, MLX Swift Release configuration:

| Backend | Wall (median) | Throughput |
|---|---|---|
| Python `mlx_audio.vad.silero_vad` | 3.70s | 162× realtime |
| **This PR (MLXAudioVAD.SileroVAD, Release)** | **3.60s** | **166× realtime** |
| Reference: CoreML 256ms compiled mlpackage | 0.60s | 1000× realtime |

Swift matches Python within measurement noise (3% delta, both use the same MLX 32-ms streaming with `asyncEval` every 16 chunks). CoreML 256ms is included as a downstream-comparison reference; it ships a different compiled-graph variant outside the scope of this PR.

> **Note**: in Debug configuration the bench measures 91 s (24× slower) due to MLX-Swift's debug overhead. Production builds should always run Release.

## Verification

```bash
# Generate Python reference (one-time)
python -c "
import json, numpy as np, soundfile as sf
import mlx.core as mx
from mlx_audio.vad import load
wav, sr = sf.read('audio.wav', dtype='float32')
m = load('mlx-community/silero-vad'); mx.eval(m.parameters())
probs = np.array(m._predict_proba_array(wav[:5*sr], sr).reshape(-1))
ts = m.get_speech_timestamps(wav[:5*sr], sample_rate=sr)
json.dump({
  'probs': probs[:16].tolist(),
  'n_probs': int(probs.shape[0]),
  'max': float(probs.max()), 'mean': float(probs.mean()),
  'timestamps': [{'start': int(t['start']), 'end': int(t['end'])} for t in ts]
}, open('/tmp/silero_vad_python_ref.json', 'w'))
"

# Run all SileroVAD tests
xcodebuild test \
  -scheme MLXAudio-Package \
  -destination 'platform=macOS' \
  -parallel-testing-enabled NO \
  -only-testing:'MLXAudioTests/SileroVADConfigTests' \
  -only-testing:'MLXAudioTests/SileroVADModelTests' \
  -only-testing:'MLXAudioTests/SileroVADNetworkTests' \
  CODE_SIGNING_ALLOWED=NO
```

Result: **14 / 14 tests pass**, including bit-exact parity and a 10-minute real-audio benchmark.

## Notes

- `parityWithPythonReferenceOnRealAudio()` reads from `/tmp/playback-eng-16k_slice.wav` and `/tmp/silero_vad_python_ref.json` by default; override via `MLXAUDIO_SILEROVAD_AUDIO` and `MLXAUDIO_SILEROVAD_REF` env vars. Test skips cleanly if the files are missing.
- `loadV5AndPredictOnSilence()` is gated on `MLXAUDIO_ENABLE_NETWORK_TESTS=1` (matches the existing `SmartTurnNetworkTests` pattern).

## Out of scope

- Wiring SileroVAD into `CohereTranscribe` (or any other ASR) as a preprocessor — separate PR. The Python equivalent is [Blaizzy/mlx-audio#697](https://github.com/Blaizzy/mlx-audio/pull/697); the Swift wiring will follow the same shape once this PR lands.
- 256 ms compiled-graph variant of Silero (only available via CoreML today). Investigated; produces a quality regression in pure MLX (different conv-padding semantics) — out of scope here.
