### PR TITLE
Add MOSS-TTS model family

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 | Soprano | [Soprano README](Sources/MLXAudioTTS/Models/Soprano/README.md) | [mlx-community/Soprano-80M-bf16](https://huggingface.co/mlx-community/Soprano-80M-bf16) |
 | VyvoTTS | [VyvoTTS README](Sources/MLXAudioTTS/Models/Qwen3/README.md) | [mlx-community/VyvoTTS-EN-Beta-4bit](https://huggingface.co/mlx-community/VyvoTTS-EN-Beta-4bit) |
 | Orpheus | [Orpheus README](Sources/MLXAudioTTS/Models/Llama/README.md) | [mlx-community/orpheus-3b-0.1-ft-bf16](https://huggingface.co/mlx-community/orpheus-3b-0.1-ft-bf16) |
+| MOSS-TTS | [MOSS-TTS README](Sources/MLXAudioTTS/Models/MossTTS/README.md) | [OpenMOSS-Team/MOSS-TTS](https://huggingface.co/OpenMOSS-Team/MOSS-TTS), [OpenMOSS-Team/MOSS-TTSD-v1.0](https://huggingface.co/OpenMOSS-Team/MOSS-TTSD-v1.0), [OpenMOSS-Team/MOSS-TTS-Local-Transformer](https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Local-Transformer) |
 | Marvis TTS | [Marvis TTS README](Sources/MLXAudioTTS/Models/Marvis/README.md) | [Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit](https://huggingface.co/Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit) |
 | Pocket TTS | [Pocket TTS README](Sources/MLXAudioTTS/Models/PocketTTS/README.md) | [mlx-community/pocket-tts](https://huggingface.co/mlx-community/pocket-tts) |
 

--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSConfig.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSConfig.swift
@@ -1,0 +1,317 @@
+import Foundation
+import MLXAudioCore
+
+public struct MossQwen3Config: Decodable, Sendable {
+    public var modelType: String
+    public var vocabSize: Int
+    public var hiddenSize: Int
+    public var numHiddenLayers: Int
+    public var intermediateSize: Int
+    public var numAttentionHeads: Int
+    public var numKeyValueHeads: Int
+    public var headDim: Int
+    public var rmsNormEps: Float
+    public var maxPositionEmbeddings: Int
+    public var ropeTheta: Float
+    public var tieWordEmbeddings: Bool
+    public var padTokenID: Int?
+    public var bosTokenID: Int?
+    public var eosTokenID: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case ropeTheta = "rope_theta"
+        case ropeParameters = "rope_parameters"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case padTokenID = "pad_token_id"
+        case bosTokenID = "bos_token_id"
+        case eosTokenID = "eos_token_id"
+    }
+
+    public init(
+        modelType: String = "qwen3",
+        vocabSize: Int = 155_648,
+        hiddenSize: Int = 4_096,
+        numHiddenLayers: Int = 36,
+        intermediateSize: Int = 12_288,
+        numAttentionHeads: Int = 32,
+        numKeyValueHeads: Int = 8,
+        headDim: Int = 128,
+        rmsNormEps: Float = 1e-6,
+        maxPositionEmbeddings: Int = 40_960,
+        ropeTheta: Float = 1_000_000,
+        tieWordEmbeddings: Bool = false,
+        padTokenID: Int? = nil,
+        bosTokenID: Int? = nil,
+        eosTokenID: Int? = nil
+    ) {
+        self.modelType = modelType
+        self.vocabSize = vocabSize
+        self.hiddenSize = hiddenSize
+        self.numHiddenLayers = numHiddenLayers
+        self.intermediateSize = intermediateSize
+        self.numAttentionHeads = numAttentionHeads
+        self.numKeyValueHeads = numKeyValueHeads
+        self.headDim = headDim
+        self.rmsNormEps = rmsNormEps
+        self.maxPositionEmbeddings = maxPositionEmbeddings
+        self.ropeTheta = ropeTheta
+        self.tieWordEmbeddings = tieWordEmbeddings
+        self.padTokenID = padTokenID
+        self.bosTokenID = bosTokenID
+        self.eosTokenID = eosTokenID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "qwen3"
+        self.vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 155_648
+        self.hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 4_096
+        self.numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 36
+        self.intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 12_288
+        self.numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 32
+        self.numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 8
+        self.headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? (hiddenSize / numAttentionHeads)
+        self.rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        self.maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 40_960
+        var ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta)
+        if ropeTheta == nil,
+           let ropeParams = try c.decodeIfPresent([String: FlexibleJSONValue].self, forKey: .ropeParameters),
+           let value = ropeParams["rope_theta"]?.floatValue {
+            ropeTheta = value
+        }
+        self.ropeTheta = ropeTheta ?? 1_000_000
+        self.tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+        self.padTokenID = try c.decodeIfPresent(Int.self, forKey: .padTokenID)
+        self.bosTokenID = try c.decodeIfPresent(Int.self, forKey: .bosTokenID)
+        self.eosTokenID = try c.decodeIfPresent(Int.self, forKey: .eosTokenID)
+    }
+}
+
+public struct MossTTSConfig: Decodable, Sendable {
+    public var modelType: String
+    public var modelPath: String?
+    public var languageConfig: MossQwen3Config
+    public var initializerRange: Float
+    public var nVQ: Int
+    public var audioVocabSize: Int
+    public var audioUserSlotTokenID: Int
+    public var audioAssistantGenSlotTokenID: Int
+    public var audioAssistantDelaySlotTokenID: Int
+    public var audioStartTokenID: Int
+    public var audioEndTokenID: Int
+    public var audioPadCode: Int
+    public var padTokenID: Int
+    public var imStartTokenID: Int
+    public var imEndTokenID: Int
+    public var samplingRate: Int
+    public var audioTokenizerPretrainedNameOrPath: String?
+    public var additionalMLPFFNHiddenSize: Int?
+    public var localFFNHiddenSize: Int?
+    public var localHiddenSize: Int?
+    public var localNumLayers: Int?
+
+    public var hiddenSize: Int { languageConfig.hiddenSize }
+    public var vocabSize: Int { languageConfig.vocabSize }
+    public var isLocalTransformer: Bool {
+        additionalMLPFFNHiddenSize != nil
+            && localFFNHiddenSize != nil
+            && localHiddenSize != nil
+            && localNumLayers != nil
+    }
+    public var usesDialogueScenePrompt: Bool {
+        nVQ == 16
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case modelPath = "model_path"
+        case languageConfig = "language_config"
+        case initializerRange = "initializer_range"
+        case nVQ = "n_vq"
+        case audioVocabSize = "audio_vocab_size"
+        case audioUserSlotTokenID = "audio_user_slot_token_id"
+        case audioAssistantGenSlotTokenID = "audio_assistant_gen_slot_token_id"
+        case audioAssistantDelaySlotTokenID = "audio_assistant_delay_slot_token_id"
+        case audioStartTokenID = "audio_start_token_id"
+        case audioEndTokenID = "audio_end_token_id"
+        case audioPadCode = "audio_pad_code"
+        case padTokenID = "pad_token_id"
+        case imStartTokenID = "im_start_token_id"
+        case imEndTokenID = "im_end_token_id"
+        case samplingRate = "sampling_rate"
+        case sampleRate = "sample_rate"
+        case audioTokenizerPretrainedNameOrPath = "audio_tokenizer_pretrained_name_or_path"
+        case additionalMLPFFNHiddenSize = "additional_mlp_ffn_hidden_size"
+        case localFFNHiddenSize = "local_ffn_hidden_size"
+        case localHiddenSize = "local_hidden_size"
+        case localNumLayers = "local_num_layers"
+    }
+
+    public init(
+        modelType: String = "moss_tts_delay",
+        modelPath: String? = nil,
+        languageConfig: MossQwen3Config = MossQwen3Config(),
+        initializerRange: Float = 0.02,
+        nVQ: Int = 32,
+        audioVocabSize: Int = 1_024,
+        audioUserSlotTokenID: Int = 151_654,
+        audioAssistantGenSlotTokenID: Int = 151_656,
+        audioAssistantDelaySlotTokenID: Int = 151_662,
+        audioStartTokenID: Int = 151_652,
+        audioEndTokenID: Int = 151_653,
+        audioPadCode: Int = 1_024,
+        padTokenID: Int = 151_643,
+        imStartTokenID: Int = 151_644,
+        imEndTokenID: Int = 151_645,
+        samplingRate: Int = 24_000,
+        audioTokenizerPretrainedNameOrPath: String? = nil,
+        additionalMLPFFNHiddenSize: Int? = nil,
+        localFFNHiddenSize: Int? = nil,
+        localHiddenSize: Int? = nil,
+        localNumLayers: Int? = nil
+    ) {
+        self.modelType = modelType
+        self.modelPath = modelPath
+        self.languageConfig = languageConfig
+        self.initializerRange = initializerRange
+        self.nVQ = nVQ
+        self.audioVocabSize = audioVocabSize
+        self.audioUserSlotTokenID = audioUserSlotTokenID
+        self.audioAssistantGenSlotTokenID = audioAssistantGenSlotTokenID
+        self.audioAssistantDelaySlotTokenID = audioAssistantDelaySlotTokenID
+        self.audioStartTokenID = audioStartTokenID
+        self.audioEndTokenID = audioEndTokenID
+        self.audioPadCode = audioPadCode
+        self.padTokenID = padTokenID
+        self.imStartTokenID = imStartTokenID
+        self.imEndTokenID = imEndTokenID
+        self.samplingRate = samplingRate
+        self.audioTokenizerPretrainedNameOrPath = audioTokenizerPretrainedNameOrPath
+        self.additionalMLPFFNHiddenSize = additionalMLPFFNHiddenSize
+        self.localFFNHiddenSize = localFFNHiddenSize
+        self.localHiddenSize = localHiddenSize
+        self.localNumLayers = localNumLayers
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "moss_tts_delay"
+        self.modelPath = try c.decodeIfPresent(String.self, forKey: .modelPath)
+        self.languageConfig = try c.decodeIfPresent(MossQwen3Config.self, forKey: .languageConfig) ?? MossQwen3Config()
+        self.initializerRange = try c.decodeIfPresent(Float.self, forKey: .initializerRange) ?? 0.02
+        self.nVQ = try c.decodeIfPresent(Int.self, forKey: .nVQ) ?? 32
+        self.audioVocabSize = try c.decodeIfPresent(Int.self, forKey: .audioVocabSize) ?? 1_024
+        self.audioUserSlotTokenID = try c.decodeIfPresent(Int.self, forKey: .audioUserSlotTokenID) ?? 151_654
+        self.audioAssistantGenSlotTokenID = try c.decodeIfPresent(Int.self, forKey: .audioAssistantGenSlotTokenID) ?? 151_656
+        self.audioAssistantDelaySlotTokenID = try c.decodeIfPresent(Int.self, forKey: .audioAssistantDelaySlotTokenID) ?? 151_662
+        self.audioStartTokenID = try c.decodeIfPresent(Int.self, forKey: .audioStartTokenID) ?? 151_652
+        self.audioEndTokenID = try c.decodeIfPresent(Int.self, forKey: .audioEndTokenID) ?? 151_653
+        self.audioPadCode = try c.decodeIfPresent(Int.self, forKey: .audioPadCode) ?? 1_024
+        self.padTokenID = try c.decodeIfPresent(Int.self, forKey: .padTokenID) ?? 151_643
+        self.imStartTokenID = try c.decodeIfPresent(Int.self, forKey: .imStartTokenID) ?? 151_644
+        self.imEndTokenID = try c.decodeIfPresent(Int.self, forKey: .imEndTokenID) ?? 151_645
+        self.samplingRate = try c.decodeIfPresent(Int.self, forKey: .samplingRate)
+            ?? c.decodeIfPresent(Int.self, forKey: .sampleRate)
+            ?? 24_000
+        self.audioTokenizerPretrainedNameOrPath = try c.decodeIfPresent(String.self, forKey: .audioTokenizerPretrainedNameOrPath)
+        self.additionalMLPFFNHiddenSize = try c.decodeIfPresent(Int.self, forKey: .additionalMLPFFNHiddenSize)
+        self.localFFNHiddenSize = try c.decodeIfPresent(Int.self, forKey: .localFFNHiddenSize)
+        self.localHiddenSize = try c.decodeIfPresent(Int.self, forKey: .localHiddenSize)
+        self.localNumLayers = try c.decodeIfPresent(Int.self, forKey: .localNumLayers)
+    }
+
+    public func localTransformerConfig() throws -> MossQwen3Config {
+        guard let localHiddenSize,
+              let localFFNHiddenSize,
+              let localNumLayers
+        else {
+            throw AudioGenerationError.invalidInput("local transformer configuration is not initialized")
+        }
+        var config = languageConfig
+        config.hiddenSize = localHiddenSize
+        config.intermediateSize = localFFNHiddenSize
+        config.numHiddenLayers = localNumLayers
+        return config
+    }
+}
+
+public struct MossTTSGenerationConfig: Decodable, Sendable {
+    public var maxNewTokens: Int?
+    public var temperature: Float?
+    public var topP: Float?
+    public var topK: Int?
+    public var repetitionPenalty: Float?
+
+    enum CodingKeys: String, CodingKey {
+        case maxNewTokens = "max_new_tokens"
+        case temperature
+        case topP = "top_p"
+        case topK = "top_k"
+        case repetitionPenalty = "repetition_penalty"
+    }
+
+    public static func fromFileIfPresent(_ url: URL) -> MossTTSGenerationConfig {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(MossTTSGenerationConfig.self, from: data)
+        else {
+            return MossTTSGenerationConfig()
+        }
+        return decoded
+    }
+
+    public init(
+        maxNewTokens: Int? = nil,
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        topK: Int? = nil,
+        repetitionPenalty: Float? = nil
+    ) {
+        self.maxNewTokens = maxNewTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.repetitionPenalty = repetitionPenalty
+    }
+}
+
+private enum FlexibleJSONValue: Decodable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() {
+            self = .null
+        } else if let value = try? c.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? c.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? c.decode(Bool.self) {
+            self = .bool(value)
+        } else {
+            self = .string(try c.decode(String.self))
+        }
+    }
+
+    var floatValue: Float? {
+        switch self {
+        case .int(let value): Float(value)
+        case .double(let value): Float(value)
+        case .string(let value): Float(value)
+        case .bool, .null: nil
+        }
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSFullSampling.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSFullSampling.swift
@@ -1,0 +1,77 @@
+@preconcurrency import MLX
+import MLXNN
+
+public func mossTTSApplyRepetitionPenaltyDelayPattern(
+    logits: MLXArray,
+    previousTokens: MLXArray?,
+    penalty: Float
+) -> MLXArray {
+    guard let previousTokens, penalty != 1.0, previousTokens.size > 0 else {
+        return logits
+    }
+
+    let vocabSize = logits.dim(logits.ndim - 1)
+    let previous = previousTokens.asType(.int32)
+    let sanitized = MLX.where(
+        previous .< MLXArray(Int32(0)),
+        MLXArray(Int32(0)),
+        MLX.where(previous .>= MLXArray(Int32(vocabSize)), MLXArray(Int32(0)), previous)
+    )
+    let penalized = MLX.where(logits .> MLXArray(0), logits / MLXArray(penalty), logits * MLXArray(penalty))
+
+    if logits.ndim == 2 {
+        let ids = Array(Set(sanitized.asArray(Int32.self).map(Int.init))).filter { $0 >= 0 && $0 < vocabSize }
+        guard !ids.isEmpty else { return logits }
+        let tokenIDs = MLXArray(ids.map(Int32.init)).reshaped([1, -1])
+        let selected = takeAlong(penalized, tokenIDs, axis: -1)
+        return putAlong(logits, tokenIDs, values: selected, axis: -1)
+    }
+
+    if logits.ndim == 3 {
+        var heads: [MLXArray] = []
+        let headCount = logits.dim(1)
+        for head in 0 ..< headCount {
+            let headLogits = logits[0..., head, 0...]
+            let headPenalized = penalized[0..., head, 0...]
+            let headPrevious = sanitized[0..., 0..., head]
+            let ids = Array(Set(headPrevious.asArray(Int32.self).map(Int.init))).filter { $0 >= 0 && $0 < vocabSize }
+            if ids.isEmpty {
+                heads.append(headLogits)
+            } else {
+                let tokenIDs = MLXArray(ids.map(Int32.init)).reshaped([1, -1])
+                let selected = takeAlong(headPenalized, tokenIDs, axis: -1)
+                heads.append(putAlong(headLogits, tokenIDs, values: selected, axis: -1))
+            }
+        }
+        return MLX.stacked(heads, axis: 1)
+    }
+
+    return logits
+}
+
+public func mossTTSSampleToken(
+    logits: MLXArray,
+    previousTokens: MLXArray? = nil,
+    repetitionPenalty: Float = 1.0,
+    topP: Float? = nil,
+    topK: Int? = nil,
+    doSample: Bool = true
+) -> MLXArray {
+    var scores = mossTTSApplyRepetitionPenaltyDelayPattern(
+        logits: logits,
+        previousTokens: previousTokens,
+        penalty: repetitionPenalty
+    )
+    if !doSample {
+        return argMax(scores, axis: -1).asType(.int32)
+    }
+
+    let originalShape = scores.shape
+    let vocabSize = scores.dim(scores.ndim - 1)
+    scores = scores.reshaped([-1, vocabSize])
+    scores = mossApplyTopK(scores, topK: topK)
+    scores = mossApplyTopP(scores, topP: topP)
+    return MLXRandom.categorical(scores)
+        .reshaped(Array(originalShape.dropLast()))
+        .asType(.int32)
+}

--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift
@@ -1,0 +1,856 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+public let mossTTSDefaultAudioTokenizerRepo = "OpenMOSS-Team/MOSS-Audio-Tokenizer"
+
+final class MosiTTSModel: Module {
+    let config: MossTTSConfig
+
+    @ModuleInfo(key: "embedding_list") var embeddingList: [Embedding]
+    @ModuleInfo(key: "language_model") var languageModel: MossQwen3Model
+
+    init(config: MossTTSConfig) {
+        self.config = config
+        var embeddings = [Embedding(embeddingCount: config.vocabSize, dimensions: config.hiddenSize)]
+        embeddings.append(
+            contentsOf: (0 ..< config.nVQ).map { _ in
+                Embedding(embeddingCount: config.audioVocabSize + 1, dimensions: config.hiddenSize)
+            }
+        )
+        _embeddingList.wrappedValue = embeddings
+        _languageModel.wrappedValue = MossQwen3Model(config.languageConfig)
+    }
+
+    func prepareMultiModalInputs(
+        _ inputIDs: MLXArray,
+        nVQForInference: Int? = nil
+    ) throws -> MLXArray {
+        guard inputIDs.ndim == 3, inputIDs.dim(2) == config.nVQ + 1 else {
+            throw AudioGenerationError.invalidInput(
+                "Expected input_ids shape [batch, seq, \(config.nVQ + 1)], got \(inputIDs.shape)"
+            )
+        }
+        let channels = min(inputIDs.dim(2), 1 + (nVQForInference ?? config.nVQ))
+        var inputsEmbeds = MLXArray.zeros(
+            [inputIDs.dim(0), inputIDs.dim(1), config.hiddenSize],
+            dtype: embeddingList[0].weight.dtype
+        )
+        for channel in 0 ..< channels {
+            inputsEmbeds = inputsEmbeds + embeddingList[channel](inputIDs[0..., 0..., channel])
+        }
+        return inputsEmbeds
+    }
+
+    func callAsFunction(
+        inputIDs: MLXArray? = nil,
+        inputEmbeddings: MLXArray? = nil,
+        cache: [KVCache]? = nil,
+        nVQForInference: Int? = nil
+    ) throws -> MLXArray {
+        let embeddings: MLXArray
+        if let inputEmbeddings {
+            embeddings = inputEmbeddings
+        } else if let inputIDs {
+            embeddings = try prepareMultiModalInputs(inputIDs, nVQForInference: nVQForInference)
+        } else {
+            throw AudioGenerationError.invalidInput("inputIDs or inputEmbeddings are required")
+        }
+        return try languageModel(inputEmbeddings: embeddings, cache: cache)
+    }
+}
+
+public final class MossTTSModel: Module, SpeechGenerationModel, @unchecked Sendable {
+    public let config: MossTTSConfig
+    public private(set) var generationConfig: MossTTSGenerationConfig = .init()
+
+    @ModuleInfo(key: "language_model") var languageModel: MossQwen3Model?
+    @ModuleInfo(key: "emb_ext") var embExt: [Embedding]
+    @ModuleInfo(key: "model") var localModel: MosiTTSModel?
+    @ModuleInfo(key: "local_transformer") var localTransformer: MossTTSLocalTransformer?
+    @ModuleInfo(key: "speech_embedding_to_local_mlp") var speechEmbeddingToLocalMLP: MossTTSMLP?
+    @ModuleInfo(key: "local_to_speech_embedding_mlps") var localToSpeechEmbeddingMLPs: [MossTTSMLP]
+    @ModuleInfo(key: "layer_norm_before_lm_heads") var layerNormBeforeLMHeads: [RMSNorm]
+    @ModuleInfo(key: "lm_heads") var lmHeads: [Linear]
+
+    public var tokenizer: MossTTSTextTokenizing?
+    public var audioTokenizer: MossAudioTokenizing?
+
+    public var sampleRate: Int { config.samplingRate }
+
+    public var defaultGenerationParameters: GenerateParameters {
+        if config.isLocalTransformer {
+            return GenerateParameters(
+                maxTokens: 4_096,
+                temperature: 1.0,
+                topP: 0.95,
+                topK: 50,
+                repetitionPenalty: 1.1
+            )
+        }
+        return GenerateParameters(
+            maxTokens: generationConfig.maxNewTokens ?? 4_096,
+            temperature: generationConfig.temperature ?? 1.7,
+            topP: generationConfig.topP ?? 0.8,
+            topK: generationConfig.topK ?? 25,
+            repetitionPenalty: generationConfig.repetitionPenalty ?? 1.0
+        )
+    }
+
+    public init(config: MossTTSConfig) throws {
+        self.config = config
+        let channels = config.nVQ + 1
+        if config.isLocalTransformer {
+            _languageModel.wrappedValue = nil
+            _embExt.wrappedValue = []
+            _localModel.wrappedValue = MosiTTSModel(config: config)
+            let localConfig = try config.localTransformerConfig()
+            _localTransformer.wrappedValue = MossTTSLocalTransformer(localConfig)
+            _speechEmbeddingToLocalMLP.wrappedValue = MossTTSMLP(
+                inputSize: config.hiddenSize,
+                ffnHiddenSize: config.additionalMLPFFNHiddenSize!,
+                outputSize: config.localHiddenSize!
+            )
+            _localToSpeechEmbeddingMLPs.wrappedValue = (0 ..< channels).map { _ in
+                MossTTSMLP(
+                    inputSize: config.localHiddenSize!,
+                    ffnHiddenSize: config.additionalMLPFFNHiddenSize!,
+                    outputSize: config.hiddenSize
+                )
+            }
+            _layerNormBeforeLMHeads.wrappedValue = (0 ..< channels).map { _ in
+                RMSNorm(dimensions: config.hiddenSize)
+            }
+        } else {
+            _languageModel.wrappedValue = MossQwen3Model(config.languageConfig)
+            _embExt.wrappedValue = (0 ..< config.nVQ).map { _ in
+                Embedding(embeddingCount: config.audioVocabSize + 1, dimensions: config.hiddenSize)
+            }
+            _localModel.wrappedValue = nil
+            _localTransformer.wrappedValue = nil
+            _speechEmbeddingToLocalMLP.wrappedValue = nil
+            _localToSpeechEmbeddingMLPs.wrappedValue = []
+            _layerNormBeforeLMHeads.wrappedValue = []
+        }
+
+        var heads = [Linear(config.hiddenSize, config.vocabSize, bias: false)]
+        heads.append(
+            contentsOf: (0 ..< config.nVQ).map { _ in
+                Linear(config.hiddenSize, config.audioVocabSize + 1, bias: false)
+            }
+        )
+        _lmHeads.wrappedValue = heads
+    }
+
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        guard !config.isLocalTransformer else { return weights }
+        var sanitized: [String: MLXArray] = [:]
+        sanitized.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            if key.hasPrefix("model.") {
+                sanitized[String(key.dropFirst("model.".count))] = value
+            } else {
+                sanitized[key] = value
+            }
+        }
+        return sanitized
+    }
+
+    public func buildInputsEmbeds(_ inputIDs: MLXArray) throws -> MLXArray {
+        guard inputIDs.ndim == 3, inputIDs.dim(2) == config.nVQ + 1 else {
+            throw AudioGenerationError.invalidInput(
+                "Expected input_ids shape [batch, seq, \(config.nVQ + 1)], got \(inputIDs.shape)"
+            )
+        }
+        if let localModel {
+            return try localModel.prepareMultiModalInputs(inputIDs)
+        }
+        guard let languageModel else {
+            throw AudioGenerationError.modelNotInitialized("MOSS language model is not initialized")
+        }
+        var inputsEmbeds = languageModel.embedTokens(inputIDs[0..., 0..., 0])
+        for (index, embedding) in embExt.enumerated() {
+            inputsEmbeds = inputsEmbeds + embedding(inputIDs[0..., 0..., index + 1])
+        }
+        return inputsEmbeds
+    }
+
+    func headLogits(_ hiddenStates: MLXArray, headIndex: Int) -> MLXArray {
+        let logits = lmHeads[headIndex](hiddenStates)
+        guard headIndex != 0 else { return logits }
+        let last = logits.dim(logits.ndim - 1)
+        let invalidPad = MLXArray.full(
+            Array(logits.shape.dropLast()) + [1],
+            values: MLXArray(-Float.infinity),
+            dtype: logits.dtype
+        )
+        if logits.ndim == 3 {
+            return MLX.concatenated([logits[0..., 0..., 0..<(last - 1)], invalidPad], axis: -1)
+        }
+        return MLX.concatenated([logits[0..., 0..<(last - 1)], invalidPad], axis: -1)
+    }
+
+    func callAsFunction(
+        inputIDs: MLXArray? = nil,
+        inputEmbeddings: MLXArray? = nil,
+        cache: [KVCache]? = nil,
+        headIndices: [Int]? = nil,
+        labels: MLXArray? = nil,
+        nVQForInference: Int? = nil
+    ) throws -> [MLXArray] {
+        if config.isLocalTransformer {
+            return try localForward(
+                inputIDs: inputIDs,
+                inputEmbeddings: inputEmbeddings,
+                cache: cache,
+                labels: labels,
+                headIndices: headIndices,
+                nVQForInference: nVQForInference
+            )
+        }
+
+        let embeddings: MLXArray
+        if let inputEmbeddings {
+            embeddings = inputEmbeddings
+        } else if let inputIDs {
+            embeddings = try buildInputsEmbeds(inputIDs)
+        } else {
+            throw AudioGenerationError.invalidInput("inputIDs or inputEmbeddings are required")
+        }
+        guard let languageModel else {
+            throw AudioGenerationError.modelNotInitialized("MOSS language model is not initialized")
+        }
+        let hiddenStates = try languageModel(inputEmbeddings: embeddings, cache: cache)
+        return (headIndices ?? Array(0 ..< (config.nVQ + 1))).map {
+            headLogits(hiddenStates, headIndex: $0)
+        }
+    }
+
+    func makeCache() -> [KVCache] {
+        if let localModel {
+            return localModel.languageModel.makeCache()
+        }
+        return languageModel?.makeCache() ?? []
+    }
+
+    private func maskedEmbedding(_ embedding: Embedding, inputIDs: MLXArray) -> MLXArray {
+        let mask = inputIDs .!= MLXArray(Int32(-100))
+        let safeIDs = MLX.where(mask, inputIDs, MLXArray(Int32(0))).asType(.int32)
+        return MLX.where(
+            mask.expandedDimensions(axis: -1),
+            embedding(safeIDs),
+            MLXArray(0.0)
+        )
+    }
+
+    private func localForward(
+        inputIDs: MLXArray?,
+        inputEmbeddings: MLXArray?,
+        cache: [KVCache]?,
+        labels: MLXArray?,
+        headIndices: [Int]?,
+        nVQForInference: Int?
+    ) throws -> [MLXArray] {
+        guard let localModel,
+              let localTransformer,
+              let speechEmbeddingToLocalMLP
+        else {
+            throw AudioGenerationError.modelNotInitialized("MOSS local-transformer modules are not initialized")
+        }
+        let globalHiddenStates = try localModel(
+            inputIDs: inputIDs,
+            inputEmbeddings: inputEmbeddings,
+            cache: cache,
+            nVQForInference: nVQForInference
+        )
+        let effectiveLabels: MLXArray
+        if let labels {
+            effectiveLabels = labels
+        } else if let inputIDs {
+            effectiveLabels = inputIDs
+        } else {
+            throw AudioGenerationError.invalidInput("labels are required when inputEmbeddings are provided")
+        }
+        let channels = config.nVQ + 1
+        guard effectiveLabels.ndim == 3, effectiveLabels.dim(2) == channels else {
+            throw AudioGenerationError.invalidInput(
+                "Expected labels shape [batch, seq, \(channels)], got \(effectiveLabels.shape)"
+            )
+        }
+
+        var localInputs = [globalHiddenStates]
+        for channel in 0 ..< (channels - 1) {
+            localInputs.append(maskedEmbedding(localModel.embeddingList[channel], inputIDs: effectiveLabels[0..., 0..., channel]))
+        }
+        var stackedInputs = MLX.stacked(localInputs, axis: 0)
+        stackedInputs = speechEmbeddingToLocalMLP(stackedInputs)
+        let channelCount = stackedInputs.dim(0)
+        let batch = stackedInputs.dim(1)
+        let seqLen = stackedInputs.dim(2)
+        let localDim = stackedInputs.dim(3)
+        stackedInputs = stackedInputs.transposed(1, 2, 0, 3).reshaped(batch * seqLen, channelCount, localDim)
+        let localOutputs = localTransformer(stackedInputs)
+
+        return (headIndices ?? Array(0 ..< channels)).map { headIndex in
+            var headHidden = localOutputs[0..., headIndex, 0...]
+            headHidden = localToSpeechEmbeddingMLPs[headIndex](headHidden)
+            headHidden = layerNormBeforeLMHeads[headIndex](headHidden)
+            headHidden = headHidden.reshaped(batch, seqLen, config.hiddenSize)
+            return lmHeads[headIndex](headHidden)
+        }
+    }
+
+    public func encodeReferenceAudio(
+        _ refAudio: MLXArray,
+        numQuantizers: Int? = nil
+    ) throws -> MLXArray {
+        guard let audioTokenizer else {
+            throw AudioGenerationError.modelNotInitialized("MOSS audio tokenizer is not initialized")
+        }
+        return try audioTokenizer.encodeAudio(refAudio, numQuantizers: numQuantizers ?? config.nVQ)
+    }
+
+    public func decodeAudioTokenIDs(
+        _ audioTokenIDs: MLXArray,
+        numQuantizers: Int? = nil
+    ) throws -> MLXArray {
+        guard let audioTokenizer else {
+            throw AudioGenerationError.modelNotInitialized("MOSS audio tokenizer is not initialized")
+        }
+        return try audioTokenizer.decodeAudioCodes(audioTokenIDs, numQuantizers: numQuantizers ?? config.nVQ)
+    }
+
+    private func ensureAudioTokenizer() async throws {
+        if audioTokenizer != nil { return }
+        if let modelPath = config.modelPath {
+            let local = URL(fileURLWithPath: modelPath).appendingPathComponent("audio_tokenizer", isDirectory: true)
+            if FileManager.default.fileExists(atPath: local.appendingPathComponent("config.json").path) {
+                audioTokenizer = try MLXMossAudioTokenizer.fromModelDirectory(local)
+                return
+            }
+        }
+        let source = config.audioTokenizerPretrainedNameOrPath?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let source, !source.isEmpty {
+            let localSource = URL(fileURLWithPath: (source as NSString).expandingTildeInPath)
+            if FileManager.default.fileExists(atPath: localSource.appendingPathComponent("config.json").path) {
+                audioTokenizer = try MLXMossAudioTokenizer.fromModelDirectory(localSource)
+                return
+            }
+        }
+        if let cached = Self.findCachedHubSnapshot(
+            repo: source?.isEmpty == false ? source! : mossTTSDefaultAudioTokenizerRepo
+        ) {
+            audioTokenizer = try MLXMossAudioTokenizer.fromModelDirectory(cached)
+            return
+        }
+        audioTokenizer = try await MLXMossAudioTokenizer.fromPretrained(
+            (source?.isEmpty == false ? source! : mossTTSDefaultAudioTokenizerRepo)
+        )
+    }
+
+    private static func findCachedHubSnapshot(repo: String) -> URL? {
+        let components = repo.split(separator: "/", maxSplits: 1).map(String.init)
+        guard components.count == 2 else { return nil }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let snapshotsDir = home
+            .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+            .appendingPathComponent("models--\(components[0])--\(components[1])", isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+        guard let snapshots = try? FileManager.default.contentsOfDirectory(
+            at: snapshotsDir,
+            includingPropertiesForKeys: nil
+        ) else {
+            return nil
+        }
+        return snapshots.sorted { $0.lastPathComponent > $1.lastPathComponent }.first {
+            FileManager.default.fileExists(atPath: $0.appendingPathComponent("config.json").path)
+        }
+    }
+
+    private static func findLastEqual(_ values: MLXArray, target: Int) -> Int {
+        let items = values.asType(.int32).asArray(Int32.self)
+        for index in stride(from: items.count - 1, through: 0, by: -1) {
+            if Int(items[index]) == target { return index }
+        }
+        return -1
+    }
+
+    private static func setLogitsToNegInf(_ logits: MLXArray, tokenIDs: [Int]) -> MLXArray {
+        guard !tokenIDs.isEmpty else { return logits }
+        let ids = MLXArray(tokenIDs.map(Int32.init)).reshaped([1, -1])
+        let values = MLXArray.full(ids.shape, values: MLXArray(-Float.infinity), dtype: logits.dtype)
+        return putAlong(logits, ids, values: values, axis: -1)
+    }
+
+    private static func keepOnlyLogits(_ logits: MLXArray, tokenIDs: [Int]) -> MLXArray {
+        guard !tokenIDs.isEmpty else { return logits }
+        let ids = MLXArray(tokenIDs.map(Int32.init)).reshaped([1, -1])
+        let selected = takeAlong(logits, ids, axis: -1)
+        let base = MLXArray.full(logits.shape, values: MLXArray(-Float.infinity), dtype: logits.dtype)
+        return putAlong(base, ids, values: selected, axis: -1)
+    }
+
+    public func generateDelayPatternIDs(
+        inputIDs: MLXArray,
+        maxNewTokens: Int = 4_096,
+        textTemperature: Float = 1.5,
+        textTopP: Float = 1.0,
+        textTopK: Int = 50,
+        audioTemperature: Float = 1.7,
+        audioTopP: Float = 0.8,
+        audioTopK: Int = 25,
+        audioRepetitionPenalty: Float = 1.0
+    ) throws -> [(startLength: Int, generationIDs: MLXArray)] {
+        guard inputIDs.ndim == 3 else {
+            throw AudioGenerationError.invalidInput("Expected input_ids rank 3, got \(inputIDs.shape)")
+        }
+        guard inputIDs.dim(0) == 1 else {
+            throw AudioGenerationError.generationFailed("MOSS-TTS batch generation is not implemented.")
+        }
+
+        var textTemperature = textTemperature
+        let textDoSample = textTemperature > 0
+        if !textDoSample { textTemperature = 1 }
+        var audioTemperature = audioTemperature
+        let audioDoSample = audioTemperature > 0
+        if !audioDoSample { audioTemperature = 1 }
+
+        let batchSize = inputIDs.dim(0)
+        let seqLen = inputIDs.dim(1)
+        let width = inputIDs.dim(2)
+        let nVQ = width - 1
+        guard nVQ == config.nVQ else {
+            throw AudioGenerationError.invalidInput("Expected \(config.nVQ) VQ channels, got \(nVQ)")
+        }
+
+        let cache = makeCache()
+        var currentInputIDs = inputIDs
+        var generationIDs = inputIDs
+        var isStopping = false
+        var audioLengths = 0
+        var delayedLengths = Int.max
+
+        let lastTextToken = inputIDs[0, -1, 0].item(Int.self)
+        let isContinuation = lastTextToken == config.audioStartTokenID
+            || lastTextToken == config.audioAssistantGenSlotTokenID
+        let audioStartIndex = Self.findLastEqual(inputIDs[0, 0..., 0], target: config.audioStartTokenID)
+        var isAudio = isContinuation && audioStartIndex != -1
+        if isAudio {
+            audioLengths = seqLen - audioStartIndex
+        }
+
+        let textExcludeOutsideAudio = [
+            config.padTokenID,
+            config.audioAssistantGenSlotTokenID,
+            config.audioAssistantDelaySlotTokenID,
+            config.audioEndTokenID,
+        ]
+        let textKeepInsideAudio = [
+            config.audioAssistantGenSlotTokenID,
+            config.audioAssistantDelaySlotTokenID,
+        ]
+
+        for timeStep in 0 ..< maxNewTokens {
+            let outputs = try self(inputIDs: currentInputIDs, cache: cache)
+            let nextTokenLogits = outputs.enumerated().map { index, logits in
+                logits[0..., -1, 0...] / MLXArray(index == 0 ? textTemperature : audioTemperature)
+            }
+
+            var nextTextTokenValue = config.padTokenID
+            if !isStopping && delayedLengths < nVQ {
+                nextTextTokenValue = config.audioAssistantDelaySlotTokenID
+            } else if !isStopping && delayedLengths == nVQ {
+                nextTextTokenValue = config.audioEndTokenID
+                isAudio = false
+            } else if !isStopping && delayedLengths > nVQ {
+                var textLogits = nextTokenLogits[0]
+                if isAudio {
+                    textLogits = Self.keepOnlyLogits(textLogits, tokenIDs: textKeepInsideAudio)
+                } else {
+                    textLogits = Self.setLogitsToNegInf(textLogits, tokenIDs: textExcludeOutsideAudio)
+                }
+                if timeStep == 0 {
+                    textLogits = Self.setLogitsToNegInf(textLogits, tokenIDs: [config.audioAssistantDelaySlotTokenID])
+                }
+                if timeStep <= nVQ {
+                    textLogits = Self.setLogitsToNegInf(textLogits, tokenIDs: [config.imEndTokenID])
+                }
+                let token = mossTTSSampleToken(
+                    logits: textLogits,
+                    topP: textTopP,
+                    topK: textTopK,
+                    doSample: textDoSample
+                )
+                eval(token)
+                nextTextTokenValue = token.item(Int.self)
+            }
+
+            if nextTextTokenValue == config.audioStartTokenID {
+                isAudio = true
+            }
+            if nextTextTokenValue == config.imEndTokenID {
+                isStopping = true
+            }
+
+            var nextAudioValues = Array(repeating: Int32(config.audioPadCode), count: batchSize * nVQ)
+            for codebookIndex in 0 ..< nVQ {
+                let preAudio = audioLengths > codebookIndex
+                let postAudio = delayedLengths == Int.max ? true : codebookIndex > delayedLengths - 1
+                guard preAudio && postAudio else { continue }
+
+                var channelLogits = nextTokenLogits[codebookIndex + 1]
+                channelLogits = Self.setLogitsToNegInf(channelLogits, tokenIDs: [config.audioPadCode])
+                let channelToken = mossTTSSampleToken(
+                    logits: channelLogits,
+                    previousTokens: generationIDs[0..., 0..., codebookIndex + 1],
+                    repetitionPenalty: audioRepetitionPenalty,
+                    topP: audioTopP,
+                    topK: audioTopK,
+                    doSample: audioDoSample
+                )
+                eval(channelToken)
+                nextAudioValues[codebookIndex] = Int32(channelToken.item(Int.self))
+            }
+
+            if [
+                config.audioStartTokenID,
+                config.audioAssistantGenSlotTokenID,
+                config.audioAssistantDelaySlotTokenID,
+            ].contains(nextTextTokenValue) {
+                audioLengths += 1
+            }
+            if nextTextTokenValue == config.audioEndTokenID {
+                audioLengths = 0
+            }
+            if delayedLengths == Int.max && nextTextTokenValue == config.audioAssistantDelaySlotTokenID {
+                delayedLengths = 0
+            }
+            if delayedLengths != Int.max {
+                delayedLengths += 1
+            }
+            if delayedLengths > nVQ {
+                delayedLengths = Int.max
+            }
+
+            let nextTextToken = MLXArray([Int32(nextTextTokenValue)], [batchSize, 1, 1]).asType(.int32)
+            let nextAudioTokens = MLXArray(nextAudioValues, [batchSize, 1, nVQ]).asType(.int32)
+            currentInputIDs = MLX.concatenated([nextTextToken, nextAudioTokens], axis: 2)
+            generationIDs = MLX.concatenated([generationIDs, currentInputIDs], axis: 1)
+            eval(currentInputIDs)
+
+            if isStopping { break }
+        }
+
+        var startIndex = Self.findLastEqual(inputIDs[0, 0..., 0], target: config.imStartTokenID)
+        startIndex = startIndex != -1 ? startIndex + 3 : seqLen
+        let startLength = seqLen - startIndex
+        return [(startLength, generationIDs[0, startIndex..., 0...])]
+    }
+
+    public func generateLocalIDs(
+        inputIDs: MLXArray,
+        maxNewTokens: Int = 4_096,
+        textTemperature: Float = 1.5,
+        textTopP: Float = 1.0,
+        textTopK: Int = 50,
+        textRepetitionPenalty: Float = 1.0,
+        audioTemperature: Float = 1.0,
+        audioTopP: Float = 0.95,
+        audioTopK: Int = 50,
+        audioRepetitionPenalty: Float = 1.1,
+        nVQForInference: Int? = nil
+    ) throws -> [(startLength: Int, generationIDs: MLXArray)] {
+        guard inputIDs.ndim == 3 else {
+            throw AudioGenerationError.invalidInput("Expected input_ids rank 3, got \(inputIDs.shape)")
+        }
+        guard inputIDs.dim(0) == 1 else {
+            throw AudioGenerationError.generationFailed("MOSS-TTS batch generation is not implemented.")
+        }
+        guard let localModel,
+              let localTransformer,
+              let speechEmbeddingToLocalMLP
+        else {
+            throw AudioGenerationError.modelNotInitialized("MOSS local-transformer modules are not initialized")
+        }
+
+        var textTemperature = textTemperature
+        let textDoSample = textTemperature > 0
+        if !textDoSample { textTemperature = 1 }
+        var audioTemperature = audioTemperature
+        let audioDoSample = audioTemperature > 0
+        if !audioDoSample { audioTemperature = 1 }
+
+        let batchSize = inputIDs.dim(0)
+        let seqLen = inputIDs.dim(1)
+        let channels = inputIDs.dim(2)
+        guard channels == config.nVQ + 1 else {
+            throw AudioGenerationError.invalidInput("Expected \(config.nVQ + 1) channels, got \(channels)")
+        }
+        let nVQ = max(1, min(channels - 1, nVQForInference ?? (channels - 1)))
+        let activeChannels = 1 + nVQ
+
+        let cache = makeCache()
+        var currentInputIDs = inputIDs
+        var generationIDs = inputIDs
+
+        for _ in 0 ..< maxNewTokens {
+            let globalHiddenStates = try localModel(
+                inputIDs: currentInputIDs,
+                cache: cache,
+                nVQForInference: nVQ
+            )
+            var currentLocalInput = speechEmbeddingToLocalMLP(globalHiddenStates[0..., -1, 0...])
+            var localInputs = MLXArray.zeros(
+                [batchSize, 0, config.localHiddenSize!],
+                dtype: currentLocalInput.dtype
+            )
+            var nextValues: [Int32] = []
+            nextValues.reserveCapacity(channels)
+
+            for channelIndex in 0 ..< activeChannels {
+                localInputs = MLX.concatenated([localInputs, currentLocalInput.expandedDimensions(axis: 1)], axis: 1)
+                let localOutputs = localTransformer(localInputs)
+                var headHidden = localOutputs[0..., -1, 0...]
+                headHidden = localToSpeechEmbeddingMLPs[channelIndex](headHidden)
+                headHidden = layerNormBeforeLMHeads[channelIndex](headHidden)
+                var logits = lmHeads[channelIndex](headHidden)
+                if channelIndex != 0 {
+                    logits = Self.setLogitsToNegInf(logits, tokenIDs: [config.audioPadCode])
+                }
+
+                let isText = channelIndex == 0
+                let doSample = isText ? textDoSample : audioDoSample
+                let repetitionPenalty = doSample
+                    ? (isText ? textRepetitionPenalty : audioRepetitionPenalty)
+                    : 1.0
+                let token = mossTTSSampleToken(
+                    logits: logits / MLXArray(isText ? textTemperature : audioTemperature),
+                    previousTokens: generationIDs[0..., 0..., channelIndex],
+                    repetitionPenalty: repetitionPenalty,
+                    topP: isText ? textTopP : audioTopP,
+                    topK: isText ? textTopK : audioTopK,
+                    doSample: doSample
+                )
+                eval(token)
+                nextValues.append(Int32(token.item(Int.self)))
+
+                currentLocalInput = localModel.embeddingList[channelIndex](token)
+                currentLocalInput = speechEmbeddingToLocalMLP(currentLocalInput)
+            }
+
+            while nextValues.count < channels {
+                nextValues.append(0)
+            }
+            let nextTokens = MLXArray(nextValues, [batchSize, channels]).asType(.int32)
+            currentInputIDs = nextTokens.expandedDimensions(axis: 1)
+            generationIDs = MLX.concatenated([generationIDs, currentInputIDs], axis: 1)
+            eval(currentInputIDs)
+
+            if Int(nextValues[0]) == config.audioEndTokenID {
+                break
+            }
+        }
+
+        let audioStartIndex = Self.findLastEqual(inputIDs[0, 0..., 0], target: config.audioStartTokenID)
+        let startIndex = audioStartIndex != -1 ? audioStartIndex : seqLen
+        let startLength = audioStartIndex != -1 ? seqLen - startIndex - 1 : 0
+        return [(startLength, generationIDs[0, startIndex..., 0...])]
+    }
+
+    private func decodeGeneratedAudio(
+        _ outputs: [(startLength: Int, generationIDs: MLXArray)]
+    ) throws -> (audio: MLXArray, tokenCount: Int) {
+        var segments: [MLXArray] = []
+        var tokenCount = 0
+        for output in outputs {
+            var audioCodes = output.generationIDs[0..., 1...].asType(.int32)
+            if !config.isLocalTransformer {
+                audioCodes = try mossTTSApplyDeDelayPattern(audioCodes)
+            }
+            let rows = audioCodes.dim(0)
+            let cols = audioCodes.dim(1)
+            let values = audioCodes.asArray(Int32.self)
+            var nonPad: [Int] = []
+            for row in 0 ..< rows {
+                var allPad = true
+                for col in 0 ..< cols where values[row * cols + col] != Int32(config.audioPadCode) {
+                    allPad = false
+                    break
+                }
+                if !allPad { nonPad.append(row) }
+            }
+            guard !nonPad.isEmpty else { continue }
+
+            var breakStart = 0
+            while breakStart < nonPad.count {
+                var breakEnd = breakStart + 1
+                while breakEnd < nonPad.count && nonPad[breakEnd] == nonPad[breakEnd - 1] + 1 {
+                    breakEnd += 1
+                }
+                let segmentRows = nonPad[breakStart ..< breakEnd]
+                let codes = audioCodes[segmentRows.first! ... segmentRows.last!, 0...]
+                tokenCount += codes.dim(0)
+                var audio = try decodeAudioTokenIDs(codes, numQuantizers: config.nVQ)
+                if output.startLength > 0 && segments.isEmpty {
+                    let firstCodesLength = codes.dim(0)
+                    if firstCodesLength > 0 {
+                        let trimRatio = max(0, min(Float(output.startLength) / Float(firstCodesLength), 1))
+                        let trimSamples = Int(Float(audio.dim(0)) * trimRatio)
+                        if trimSamples < audio.dim(0) {
+                            audio = audio[trimSamples..., 0...]
+                        } else {
+                            audio = MLXArray.zeros([0, audio.dim(1)], dtype: .float32)
+                        }
+                    }
+                }
+                segments.append(audio)
+                breakStart = breakEnd
+            }
+        }
+
+        guard !segments.isEmpty else {
+            return (MLXArray.zeros([0, 1], dtype: .float32), 0)
+        }
+        return (MLX.concatenated(segments, axis: 0), tokenCount)
+    }
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        _ = voice
+        guard let tokenizer else {
+            throw AudioGenerationError.modelNotInitialized("MOSS tokenizer is not initialized")
+        }
+        try await ensureAudioTokenizer()
+
+        let promptAudioCodes = try refAudio.map {
+            try encodeReferenceAudio($0, numQuantizers: config.nVQ)
+        }
+        let mode = (refText != nil && promptAudioCodes != nil) ? "continuation" : "generation"
+        let processor: MossTTSDelayProcessor = config.isLocalTransformer
+            ? try MossTTSLocalProcessor(tokenizer: tokenizer, config: config)
+            : try MossTTSDelayProcessor(tokenizer: tokenizer, config: config)
+
+        let userMessage = processor.buildUserMessage(
+            text: mode == "generation" ? text : (refText ?? "") + text,
+            reference: mode == "generation" ? promptAudioCodes.map { [$0] } : nil,
+            language: language
+        )
+        let conversations: [[MossTTSConversationMessage]]
+        if mode == "generation" {
+            conversations = [[userMessage]]
+        } else {
+            guard let promptAudioCodes else {
+                throw AudioGenerationError.invalidInput("continuation mode requires refAudio")
+            }
+            conversations = [[
+                userMessage,
+                processor.buildAssistantMessage(audioCodesList: [promptAudioCodes]),
+            ]]
+        }
+
+        let batch = try processor(conversations, mode: mode)
+        let outputs: [(startLength: Int, generationIDs: MLXArray)]
+        if config.isLocalTransformer {
+            outputs = try generateLocalIDs(
+                inputIDs: batch.inputIDs,
+                maxNewTokens: generationParameters.maxTokens ?? 4_096,
+                audioTemperature: generationParameters.temperature,
+                audioTopP: generationParameters.topP,
+                audioTopK: generationParameters.topK,
+                audioRepetitionPenalty: generationParameters.repetitionPenalty ?? 1.1
+            )
+        } else {
+            outputs = try generateDelayPatternIDs(
+                inputIDs: batch.inputIDs,
+                maxNewTokens: generationParameters.maxTokens ?? generationConfig.maxNewTokens ?? 4_096,
+                textTemperature: generationConfig.temperature ?? 1.5,
+                textTopP: generationConfig.topP ?? 1.0,
+                textTopK: 50,
+                audioTemperature: generationParameters.temperature,
+                audioTopP: generationParameters.topP,
+                audioTopK: generationParameters.topK,
+                audioRepetitionPenalty: generationParameters.repetitionPenalty ?? generationConfig.repetitionPenalty ?? 1.0
+            )
+        }
+        return try decodeGeneratedAudio(outputs).audio
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { @Sendable in
+                do {
+                    let audio = try await self.generate(
+                        text: text,
+                        voice: voice,
+                        refAudio: refAudio,
+                        refText: refText,
+                        language: language,
+                        generationParameters: generationParameters
+                    )
+                    continuation.yield(.audio(audio))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    public static func fromPretrained(
+        _ modelRepo: String,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> MossTTSModel {
+        guard let repoID = Repo.ID(rawValue: modelRepo) else {
+            throw TTSModelError.invalidRepositoryID(modelRepo)
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["*.json", "*.txt", "*.jinja", "*.py", "*.md", "*.index.json"],
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try await fromModelDirectory(modelDir)
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) async throws -> MossTTSModel {
+        let configData = try Data(contentsOf: modelDir.appendingPathComponent("config.json"))
+        var config = try JSONDecoder().decode(MossTTSConfig.self, from: configData)
+        config.modelPath = modelDir.path
+        let model = try MossTTSModel(config: config)
+        model.generationConfig = MossTTSGenerationConfig.fromFileIfPresent(
+            modelDir.appendingPathComponent("generation_config.json")
+        )
+
+        let weights = try loadWeights(from: modelDir)
+        try model.update(parameters: ModuleParameters.unflattened(model.sanitize(weights: weights)), verify: .all)
+        eval(model)
+
+        model.tokenizer = try await MossTTSTokenizerAdapter.fromModelDirectory(modelDir)
+
+        let audioTokenizerDir = modelDir.appendingPathComponent("audio_tokenizer", isDirectory: true)
+        if FileManager.default.fileExists(atPath: audioTokenizerDir.appendingPathComponent("config.json").path) {
+            model.audioTokenizer = try MLXMossAudioTokenizer.fromModelDirectory(audioTokenizerDir)
+        }
+        return model
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSProcessor.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSProcessor.swift
@@ -1,0 +1,512 @@
+import Foundation
+@preconcurrency import MLX
+import MLXAudioCore
+import Tokenizers
+
+public let mossTTSAudioPlaceholder = "<|audio|>"
+
+public protocol MossTTSTextTokenizing {
+    func encode(_ text: String) -> [Int]
+    func decode(_ tokenIDs: [Int]) -> String
+    func tokenString(for tokenID: Int) -> String?
+}
+
+public final class MossTTSTokenizerAdapter: MossTTSTextTokenizing {
+    private let tokenizer: any Tokenizer
+    private let tokenStringsByID: [Int: String]
+
+    public init(tokenizer: any Tokenizer, tokenStringsByID: [Int: String]) {
+        self.tokenizer = tokenizer
+        self.tokenStringsByID = tokenStringsByID
+    }
+
+    public func encode(_ text: String) -> [Int] {
+        tokenizer.encode(text: text, addSpecialTokens: false)
+    }
+
+    public func decode(_ tokenIDs: [Int]) -> String {
+        tokenizer.decode(tokens: tokenIDs, skipSpecialTokens: false)
+    }
+
+    public func tokenString(for tokenID: Int) -> String? {
+        tokenStringsByID[tokenID]
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) async throws -> MossTTSTokenizerAdapter {
+        let tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
+        return MossTTSTokenizerAdapter(
+            tokenizer: tokenizer,
+            tokenStringsByID: try loadAddedTokenStrings(modelDir: modelDir)
+        )
+    }
+
+    public static func loadAddedTokenStrings(modelDir: URL) throws -> [Int: String] {
+        let tokenizerConfig = modelDir.appendingPathComponent("tokenizer_config.json")
+        if let data = try? Data(contentsOf: tokenizerConfig),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let decoder = object["added_tokens_decoder"] as? [String: [String: Any]] {
+            var result: [Int: String] = [:]
+            for (key, value) in decoder {
+                guard let id = Int(key), let content = value["content"] as? String else { continue }
+                result[id] = content
+            }
+            if !result.isEmpty { return result }
+        }
+
+        let addedTokens = modelDir.appendingPathComponent("added_tokens.json")
+        if let data = try? Data(contentsOf: addedTokens),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Int] {
+            return Dictionary(uniqueKeysWithValues: object.map { ($0.value, $0.key) })
+        }
+        return [:]
+    }
+}
+
+public struct MossTTSConversationMessage {
+    public var role: String
+    public var content: String
+    public var audioCodesList: [MLXArray]
+}
+
+public struct MossTTSProcessorBatch {
+    public var inputIDs: MLXArray
+    public var attentionMask: MLXArray
+}
+
+public func mossTTSApplyDelayPattern(_ codes: MLXArray, padCode: Int) throws -> MLXArray {
+    guard codes.ndim == 2 else {
+        throw AudioGenerationError.invalidInput("Expected codes shape [frames, n_vq], got \(codes.shape)")
+    }
+    let frames = codes.dim(0)
+    let nVQ = codes.dim(1)
+    var values = Array(repeating: Int32(padCode), count: (frames + nVQ - 1) * nVQ)
+    let source = codes.asType(.int32).asArray(Int32.self)
+    for codebook in 0 ..< nVQ {
+        for frame in 0 ..< frames {
+            values[(codebook + frame) * nVQ + codebook] = source[frame * nVQ + codebook]
+        }
+    }
+    return MLXArray(values, [frames + nVQ - 1, nVQ]).asType(.int32)
+}
+
+public func mossTTSApplyDeDelayPattern(_ delayedCodes: MLXArray) throws -> MLXArray {
+    guard delayedCodes.ndim == 2 else {
+        throw AudioGenerationError.invalidInput("Expected delay_codes shape [frames, n_vq], got \(delayedCodes.shape)")
+    }
+    let delayedFrames = delayedCodes.dim(0)
+    let nVQ = delayedCodes.dim(1)
+    let outputLength = delayedFrames - nVQ + 1
+    guard outputLength > 0 else {
+        return MLXArray.zeros([0, nVQ], type: Int32.self)
+    }
+    let source = delayedCodes.asType(.int32).asArray(Int32.self)
+    var values = Array(repeating: Int32(0), count: outputLength * nVQ)
+    for codebook in 0 ..< nVQ {
+        for frame in 0 ..< outputLength {
+            values[frame * nVQ + codebook] = source[(codebook + frame) * nVQ + codebook]
+        }
+    }
+    return MLXArray(values, [outputLength, nVQ]).asType(.int32)
+}
+
+public class MossTTSDelayProcessor {
+    public let tokenizer: MossTTSTextTokenizing
+    public let config: MossTTSConfig
+    public let useDelayPattern: Bool
+    public let appendAudioStartForGeneration: Bool
+
+    private let audioUserSlotToken: String
+    private let audioAssistantGenSlotToken: String
+    private let audioAssistantDelaySlotToken: String
+    private let audioStartToken: String
+    private let audioEndToken: String
+
+    public init(
+        tokenizer: MossTTSTextTokenizing,
+        config: MossTTSConfig,
+        useDelayPattern: Bool = true,
+        appendAudioStartForGeneration: Bool = false
+    ) throws {
+        self.tokenizer = tokenizer
+        self.config = config
+        self.useDelayPattern = useDelayPattern
+        self.appendAudioStartForGeneration = appendAudioStartForGeneration
+        self.audioUserSlotToken = try Self.tokenString(tokenizer, id: config.audioUserSlotTokenID)
+        self.audioAssistantGenSlotToken = try Self.tokenString(tokenizer, id: config.audioAssistantGenSlotTokenID)
+        self.audioAssistantDelaySlotToken = try Self.tokenString(tokenizer, id: config.audioAssistantDelaySlotTokenID)
+        self.audioStartToken = try Self.tokenString(tokenizer, id: config.audioStartTokenID)
+        self.audioEndToken = try Self.tokenString(tokenizer, id: config.audioEndTokenID)
+    }
+
+    private static func tokenString(_ tokenizer: MossTTSTextTokenizing, id: Int) throws -> String {
+        if let value = tokenizer.tokenString(for: id), !value.isEmpty {
+            return value
+        }
+        let decoded = tokenizer.decode([id])
+        guard !decoded.isEmpty else {
+            throw AudioGenerationError.invalidInput("Tokenizer cannot resolve MOSS special token id \(id)")
+        }
+        return decoded
+    }
+
+    public func buildUserMessage(
+        text: String? = nil,
+        reference: [MLXArray?]? = nil,
+        instruction: String? = nil,
+        tokens: Int? = nil,
+        quality: String? = nil,
+        soundEvent: String? = nil,
+        ambientSound: String? = nil,
+        language: String? = nil,
+        scene: String? = nil
+    ) -> MossTTSConversationMessage {
+        var audioCodes: [MLXArray] = []
+        let referenceText: String
+        if let reference {
+            var parts: [String] = []
+            for (index, item) in reference.enumerated() {
+                if let item {
+                    parts.append("[S\(index + 1)]:\n\(mossTTSAudioPlaceholder)")
+                    audioCodes.append(item)
+                } else {
+                    parts.append("[S\(index + 1)]: None")
+                }
+            }
+            referenceText = parts.joined(separator: "\n")
+        } else {
+            referenceText = "None"
+        }
+
+        var fields: [(name: String, value: String)] = [
+            ("Reference(s)", referenceText),
+            ("Instruction", instruction ?? "None"),
+            ("Tokens", tokens.map(String.init) ?? "None"),
+            ("Quality", quality ?? "None"),
+            ("Sound Event", soundEvent ?? "None"),
+            ("Ambient Sound", ambientSound ?? "None"),
+            ("Language", language ?? "None"),
+        ]
+        if config.usesDialogueScenePrompt {
+            fields.append(("Scene", scene ?? "None"))
+        }
+        fields.append(("Text", text ?? "None"))
+
+        let content = """
+        <user_inst>
+        \(fields.map { "- \($0.name):\n\($0.value)" }.joined(separator: "\n"))
+        </user_inst>
+        """
+
+        return MossTTSConversationMessage(role: "user", content: content, audioCodesList: audioCodes)
+    }
+
+    public func buildAssistantMessage(
+        audioCodesList: [MLXArray],
+        content: String = mossTTSAudioPlaceholder
+    ) -> MossTTSConversationMessage {
+        MossTTSConversationMessage(role: "assistant", content: content, audioCodesList: audioCodesList)
+    }
+
+    public static func applyChatTemplate(
+        role: String,
+        content: String,
+        addGenerationPrompt: Bool
+    ) -> String {
+        var rendered = "<|im_start|>\(role)\n\(content)<|im_end|>\n"
+        if addGenerationPrompt {
+            rendered += "<|im_start|>assistant\n"
+        }
+        return rendered
+    }
+
+    private func replaceAudioPlaceholders(
+        content: String,
+        lengths: [Int],
+        genSlotToken: String,
+        delaySlotToken: String,
+        audioStartToken: String,
+        audioEndToken: String
+    ) throws -> String {
+        guard config.nVQ >= 1 else {
+            throw AudioGenerationError.invalidInput("n_vq must be >= 1, got \(config.nVQ)")
+        }
+        guard content.mossTTSCount(of: mossTTSAudioPlaceholder) == lengths.count else {
+            throw AudioGenerationError.invalidInput("Audio placeholders do not match audio code lengths")
+        }
+        var output = content
+        for length in lengths {
+            guard length >= 0 else {
+                throw AudioGenerationError.invalidInput("length must be >= 0, got \(length)")
+            }
+            let block: String
+            if length == 0 {
+                block = "\(audioStartToken)\(audioEndToken)"
+            } else if !delaySlotToken.isEmpty {
+                block = audioStartToken
+                    + String(repeating: genSlotToken, count: length)
+                    + String(repeating: delaySlotToken, count: config.nVQ - 1)
+                    + audioEndToken
+            } else {
+                block = audioStartToken + String(repeating: genSlotToken, count: length) + audioEndToken
+            }
+            if let range = output.range(of: mossTTSAudioPlaceholder) {
+                output.replaceSubrange(range, with: block)
+            }
+        }
+        return output
+    }
+
+    private func getUnifiedCodes(
+        role: String,
+        content: String,
+        audioCodesList: [MLXArray],
+        truncation: Bool
+    ) throws -> MLXArray {
+        let audioGenSlotToken: String
+        let audioDelaySlotToken: String
+        let effectiveTruncation: Bool
+        if role == "user" {
+            audioGenSlotToken = audioUserSlotToken
+            audioDelaySlotToken = audioUserSlotToken
+            effectiveTruncation = false
+        } else {
+            audioGenSlotToken = audioAssistantGenSlotToken
+            audioDelaySlotToken = audioAssistantDelaySlotToken
+            effectiveTruncation = truncation
+        }
+
+        var normalizedCodes = try normalizeAudioCodesList(audioCodesList, nVQ: config.nVQ)
+        var renderedContent = content
+        if normalizedCodes.count > 1 && renderedContent.contains(mossTTSAudioPlaceholder) {
+            let merged = mergeConsecutiveAudioPlaceholders(renderedContent, audioCodesList: normalizedCodes)
+            renderedContent = merged.content
+            normalizedCodes = merged.audioCodesList
+        }
+        renderedContent = try replaceAudioPlaceholders(
+            content: renderedContent,
+            lengths: normalizedCodes.map { $0.dim(0) },
+            genSlotToken: audioGenSlotToken,
+            delaySlotToken: useDelayPattern ? audioDelaySlotToken : "",
+            audioStartToken: audioStartToken,
+            audioEndToken: audioEndToken
+        )
+
+        let textCodes = tokenizer.encode(renderedContent)
+        let audioStartIndices = textCodes.enumerated()
+            .compactMap { $0.element == config.audioStartTokenID ? $0.offset : nil }
+        let audioEndIndices = textCodes.enumerated()
+            .compactMap { $0.element == config.audioEndTokenID ? $0.offset : nil }
+        guard audioStartIndices.count == normalizedCodes.count,
+              audioEndIndices.count == normalizedCodes.count
+        else {
+            throw AudioGenerationError.invalidInput("Audio placeholders do not match the provided audio codes list")
+        }
+
+        let nVQ = config.nVQ
+        let delayAudioCodes: MLXArray
+        if normalizedCodes.isEmpty {
+            delayAudioCodes = MLX.full([textCodes.count, nVQ], values: Int32(config.audioPadCode), type: Int32.self)
+        } else {
+            var sections: [MLXArray] = []
+            var prefixIndex = 0
+            for index in normalizedCodes.indices {
+                let audioStartIndex = audioStartIndices[index]
+                let audioEndIndex = audioEndIndices[index]
+                let codes = normalizedCodes[index]
+                let effectiveCodes = useDelayPattern
+                    ? try mossTTSApplyDelayPattern(codes, padCode: config.audioPadCode)
+                    : codes.asType(.int32)
+                let padRows = max(audioStartIndex - prefixIndex + 1, 0)
+                sections.append(MLX.full([padRows, nVQ], values: Int32(config.audioPadCode), type: Int32.self))
+                sections.append(effectiveCodes)
+                prefixIndex = audioEndIndex
+            }
+
+            if effectiveTruncation && useDelayPattern && nVQ > 1, let last = sections.popLast() {
+                let keep = max(last.dim(0) - (nVQ - 1), 0)
+                sections.append(last[0..<keep, 0...])
+            } else if !effectiveTruncation, let lastEnd = audioEndIndices.last {
+                sections.append(
+                    MLX.full(
+                        [max(textCodes.count - lastEnd, 0), nVQ],
+                        values: Int32(config.audioPadCode),
+                        type: Int32.self
+                    )
+                )
+            }
+            delayAudioCodes = MLX.concatenated(sections, axis: 0)
+        }
+
+        let outputLength = min(textCodes.count, delayAudioCodes.dim(0))
+        let text = MLXArray(textCodes.prefix(outputLength).map(Int32.init), [outputLength, 1]).asType(.int32)
+        return MLX.concatenated([text, delayAudioCodes[0..<outputLength, 0...]], axis: 1)
+    }
+
+    private func normalizeAudioCodesList(_ audioCodesList: [MLXArray], nVQ: Int) throws -> [MLXArray] {
+        try audioCodesList.map { codes in
+            guard codes.ndim == 2 else {
+                throw AudioGenerationError.invalidInput("Expected audio codes shape [frames, n_vq], got \(codes.shape)")
+            }
+            var normalized = codes
+            if normalized.dim(1) < nVQ && normalized.dim(0) >= nVQ {
+                normalized = normalized.transposed(1, 0)
+            }
+            guard normalized.dim(1) >= nVQ else {
+                throw AudioGenerationError.invalidInput(
+                    "audio_codes channels (\(normalized.dim(1))) < model n_vq (\(nVQ))"
+                )
+            }
+            return normalized[0..., 0..<nVQ].asType(.int32)
+        }
+    }
+
+    private func mergeConsecutiveAudioPlaceholders(
+        _ content: String,
+        audioCodesList: [MLXArray]
+    ) -> (content: String, audioCodesList: [MLXArray]) {
+        let placeholder = mossTTSAudioPlaceholder
+        guard content.mossTTSCount(of: placeholder) == audioCodesList.count,
+              audioCodesList.count > 1
+        else {
+            return (content, audioCodesList)
+        }
+
+        var resultContent = ""
+        var resultCodes: [MLXArray] = []
+        var remaining = content[...]
+        var codeIndex = 0
+
+        while let range = remaining.range(of: placeholder) {
+            resultContent += String(remaining[..<range.lowerBound])
+            var merged = audioCodesList[codeIndex]
+            codeIndex += 1
+            var suffix = remaining[range.upperBound...]
+
+            while codeIndex < audioCodesList.count,
+                  let nextRange = suffix.range(of: placeholder),
+                  suffix[..<nextRange.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                merged = MLX.concatenated([merged, audioCodesList[codeIndex]], axis: 0)
+                codeIndex += 1
+                suffix = suffix[nextRange.upperBound...]
+            }
+
+            resultContent += placeholder
+            resultCodes.append(merged)
+            remaining = suffix
+        }
+        resultContent += String(remaining)
+        return (resultContent, resultCodes)
+    }
+
+    public func callAsFunction(
+        _ conversations: [[MossTTSConversationMessage]],
+        mode: String = "generation",
+        applyChatTemplate: Bool = true
+    ) throws -> MossTTSProcessorBatch {
+        guard mode == "generation" || mode == "continuation" else {
+            throw AudioGenerationError.invalidInput("mode must be generation or continuation")
+        }
+
+        let truncation = mode == "continuation"
+        var inputIDsList: [MLXArray] = []
+        for conversation in conversations {
+            guard !conversation.isEmpty else {
+                throw AudioGenerationError.invalidInput("Conversation must not be empty")
+            }
+            if (mode == "generation") == (conversation.count % 2 == 0) {
+                throw AudioGenerationError.invalidInput("Invalid conversation length for mode")
+            }
+            if (mode == "generation") != (conversation.last?.role == "user") {
+                throw AudioGenerationError.invalidInput("Invalid final role for mode")
+            }
+
+            var unified: [MLXArray] = []
+            for (messageIndex, message) in conversation.enumerated() {
+                let addGenerationPrompt = mode == "generation" && messageIndex == conversation.count - 1
+                let content = applyChatTemplate
+                    ? Self.applyChatTemplate(
+                        role: message.role,
+                        content: message.content,
+                        addGenerationPrompt: addGenerationPrompt
+                    )
+                    : message.content
+                unified.append(
+                    try getUnifiedCodes(
+                        role: message.role,
+                        content: content,
+                        audioCodesList: message.audioCodesList,
+                        truncation: truncation
+                    )
+                )
+            }
+            var inputIDs = MLX.concatenated(unified, axis: 0)
+            if appendAudioStartForGeneration && mode == "generation" {
+                var row = Array(repeating: Int32(config.audioPadCode), count: config.nVQ + 1)
+                row[0] = Int32(config.audioStartTokenID)
+                inputIDs = MLX.concatenated(
+                    [inputIDs, MLXArray(row, [1, config.nVQ + 1]).asType(.int32)],
+                    axis: 0
+                )
+            }
+            inputIDsList.append(inputIDs)
+        }
+        return pad(inputIDsList)
+    }
+
+    private func pad(_ inputIDsList: [MLXArray]) -> MossTTSProcessorBatch {
+        let maxLength = inputIDsList.map { $0.dim(0) }.max() ?? 0
+        var padded: [MLXArray] = []
+        var masks: [MLXArray] = []
+        for var inputIDs in inputIDsList {
+            let padLength = maxLength - inputIDs.dim(0)
+            if padLength > 0 {
+                var flat = Array(repeating: Int32(config.audioPadCode), count: padLength * (config.nVQ + 1))
+                for row in 0 ..< padLength {
+                    flat[row * (config.nVQ + 1)] = Int32(config.padTokenID)
+                }
+                inputIDs = MLX.concatenated(
+                    [MLXArray(flat, [padLength, config.nVQ + 1]).asType(.int32), inputIDs],
+                    axis: 0
+                )
+            }
+            padded.append(inputIDs)
+            masks.append(
+                MLX.concatenated(
+                    [
+                        MLXArray.zeros([padLength], dtype: .bool),
+                        MLXArray.ones([maxLength - padLength], dtype: .bool),
+                    ],
+                    axis: 0
+                )
+            )
+        }
+        return MossTTSProcessorBatch(
+            inputIDs: MLX.stacked(padded, axis: 0).asType(.int32),
+            attentionMask: MLX.stacked(masks, axis: 0).asType(.bool)
+        )
+    }
+}
+
+public final class MossTTSLocalProcessor: MossTTSDelayProcessor {
+    public init(tokenizer: MossTTSTextTokenizing, config: MossTTSConfig) throws {
+        try super.init(
+            tokenizer: tokenizer,
+            config: config,
+            useDelayPattern: false,
+            appendAudioStartForGeneration: true
+        )
+    }
+}
+
+private extension String {
+    func mossTTSCount(of needle: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchRange = startIndex..<endIndex
+        while let range = range(of: needle, range: searchRange) {
+            count += 1
+            searchRange = range.upperBound..<endIndex
+        }
+        return count
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSQwen3.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSQwen3.swift
@@ -1,0 +1,269 @@
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXFast
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+final class MossQwen3Attention: Module {
+    let numHeads: Int
+    let numKVHeads: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+
+    let rope: RoPE
+
+    init(_ config: MossQwen3Config) {
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.headDim
+        self.scale = Float(1.0 / Double(config.headDim).squareRoot())
+
+        _qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: false)
+        _kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        _vProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        _oProj.wrappedValue = Linear(numHeads * headDim, config.hiddenSize, bias: false)
+        _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+        _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+        self.rope = RoPE(dimensions: headDim, traditional: false, base: config.ropeTheta)
+    }
+
+    func callAsFunction(
+        _ hiddenStates: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let batch = hiddenStates.dim(0)
+        let length = hiddenStates.dim(1)
+
+        var queries = qProj(hiddenStates)
+        var keys = kProj(hiddenStates)
+        var values = vProj(hiddenStates)
+
+        queries = qNorm(queries.reshaped(batch, length, numHeads, headDim))
+            .transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(batch, length, numKVHeads, headDim))
+            .transposed(0, 2, 1, 3)
+        values = values.reshaped(batch, length, numKVHeads, headDim)
+            .transposed(0, 2, 1, 3)
+
+        if let cache {
+            queries = rope(queries, offset: cache.offset)
+            keys = rope(keys, offset: cache.offset)
+            (keys, values) = cache.update(keys: keys, values: values)
+        } else {
+            queries = rope(queries)
+            keys = rope(keys)
+        }
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: mask
+        )
+        return oProj(output.transposed(0, 2, 1, 3).reshaped(batch, length, -1))
+    }
+}
+
+final class MossQwen3MLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(_ config: MossQwen3Config) {
+        _gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+final class MossQwen3DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: MossQwen3Attention
+    @ModuleInfo(key: "mlp") var mlp: MossQwen3MLP
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(_ config: MossQwen3Config) {
+        _selfAttention.wrappedValue = MossQwen3Attention(config)
+        _mlp.wrappedValue = MossQwen3MLP(config)
+        _inputLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ hiddenStates: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        var residual = hiddenStates
+        var h = selfAttention(inputLayerNorm(hiddenStates), mask: mask, cache: cache)
+        h = residual + h
+        residual = h
+        h = mlp(postAttentionLayerNorm(h))
+        return residual + h
+    }
+}
+
+final class MossQwen3Model: Module {
+    let config: MossQwen3Config
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "layers") var layers: [MossQwen3DecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(_ config: MossQwen3Config) {
+        self.config = config
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.hiddenSize
+        )
+        _layers.wrappedValue = (0 ..< config.numHiddenLayers).map { _ in
+            MossQwen3DecoderLayer(config)
+        }
+        _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func makeCache() -> [KVCache] {
+        layers.map { _ in KVCacheSimple() }
+    }
+
+    func callAsFunction(
+        inputIDs: MLXArray? = nil,
+        inputEmbeddings: MLXArray? = nil,
+        cache: [KVCache]? = nil
+    ) throws -> MLXArray {
+        var hiddenStates: MLXArray
+        if let inputEmbeddings {
+            hiddenStates = inputEmbeddings
+        } else if let inputIDs {
+            hiddenStates = embedTokens(inputIDs)
+        } else {
+            throw AudioGenerationError.invalidInput("inputIDs or inputEmbeddings are required")
+        }
+
+        let mask = createAttentionMask(h: hiddenStates, cache: cache?.first)
+        let caches = cache ?? [KVCache?](repeating: nil, count: layers.count)
+        for (index, layer) in layers.enumerated() {
+            hiddenStates = layer(hiddenStates, mask: mask, cache: caches[index])
+        }
+        return norm(hiddenStates)
+    }
+}
+
+final class MossTTSMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(inputSize: Int, ffnHiddenSize: Int, outputSize: Int) {
+        _gateProj.wrappedValue = Linear(inputSize, ffnHiddenSize, bias: false)
+        _upProj.wrappedValue = Linear(inputSize, ffnHiddenSize, bias: false)
+        _downProj.wrappedValue = Linear(ffnHiddenSize, outputSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+final class MossTTSLocalAttention: Module {
+    let numHeads: Int
+    let numKVHeads: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+
+    init(_ config: MossQwen3Config) {
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.headDim
+        self.scale = Float(1.0 / Double(config.headDim).squareRoot())
+        _qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: false)
+        _kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        _vProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        _oProj.wrappedValue = Linear(numHeads * headDim, config.hiddenSize, bias: false)
+        _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+        _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode) -> MLXArray {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        var queries = qProj(x)
+        var keys = kProj(x)
+        var values = vProj(x)
+        queries = qNorm(queries.reshaped(batch, length, numHeads, headDim)).transposed(0, 2, 1, 3)
+        keys = kNorm(keys.reshaped(batch, length, numKVHeads, headDim)).transposed(0, 2, 1, 3)
+        values = values.reshaped(batch, length, numKVHeads, headDim).transposed(0, 2, 1, 3)
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: mask
+        )
+        return oProj(output.transposed(0, 2, 1, 3).reshaped(batch, length, -1))
+    }
+}
+
+final class MossTTSLocalTransformerBlock: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: MossTTSLocalAttention
+    @ModuleInfo(key: "mlp") var mlp: MossTTSMLP
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(_ config: MossQwen3Config) {
+        _selfAttention.wrappedValue = MossTTSLocalAttention(config)
+        _mlp.wrappedValue = MossTTSMLP(
+            inputSize: config.hiddenSize,
+            ffnHiddenSize: config.intermediateSize,
+            outputSize: config.hiddenSize
+        )
+        _inputLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode) -> MLXArray {
+        let h = x + selfAttention(inputLayerNorm(x), mask: mask)
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+final class MossTTSLocalTransformer: Module {
+    @ModuleInfo(key: "layers") var layers: [MossTTSLocalTransformerBlock]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(_ config: MossQwen3Config) {
+        _layers.wrappedValue = (0 ..< config.numHiddenLayers).map { _ in
+            MossTTSLocalTransformerBlock(config)
+        }
+        _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ inputEmbeddings: MLXArray) -> MLXArray {
+        var hiddenStates = inputEmbeddings
+        let mask = createAttentionMask(h: hiddenStates, cache: nil as KVCache?)
+        for layer in layers {
+            hiddenStates = layer(hiddenStates, mask: mask)
+        }
+        return norm(hiddenStates)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/MossTTS/README.md
+++ b/Sources/MLXAudioTTS/Models/MossTTS/README.md
@@ -1,0 +1,75 @@
+# MOSS-TTS
+
+MOSS-TTS covers the non-quantized full OpenMOSS text-to-speech checkpoints: the standard delay-pattern model, the dialogue model, and the local-transformer variant. It uses a Qwen3 backbone, multi-codebook audio generation, and the full MOSS Audio Tokenizer.
+
+## Supported Models
+
+- `OpenMOSS-Team/MOSS-TTS`
+- `OpenMOSS-Team/MOSS-TTSD-v1.0`
+- `OpenMOSS-Team/MOSS-TTS-Local-Transformer`
+
+The full audio tokenizer is loaded automatically from:
+
+- `OpenMOSS-Team/MOSS-Audio-Tokenizer`
+
+## CLI Examples
+
+Standard MOSS-TTS:
+
+```bash
+swift run mlx-audio-swift-tts \
+  --model OpenMOSS-Team/MOSS-TTS \
+  --text "Hello, this is MOSS-TTS running from Swift." \
+  --output moss-tts.wav
+```
+
+Dialogue model:
+
+```bash
+swift run mlx-audio-swift-tts \
+  --model OpenMOSS-Team/MOSS-TTSD-v1.0 \
+  --text "[S1] Hello. [S2] Hi, this is MOSS-TTSD running from Swift." \
+  --output moss-ttsd.wav
+```
+
+Local-transformer model:
+
+```bash
+swift run mlx-audio-swift-tts \
+  --model OpenMOSS-Team/MOSS-TTS-Local-Transformer \
+  --text "Hello, this is the MOSS local-transformer model running from Swift." \
+  --output moss-local-transformer.wav
+```
+
+Voice cloning with a single reference clip:
+
+```bash
+swift run mlx-audio-swift-tts \
+  --model OpenMOSS-Team/MOSS-TTS \
+  --text "This is a short cloned voice sample." \
+  --ref_audio speaker.wav \
+  --ref_text "Reference transcript for the speaker." \
+  --output moss-clone.wav
+```
+
+## Swift Example
+
+```swift
+import Foundation
+import MLXAudioCore
+import MLXAudioTTS
+
+let model = try await TTS.loadModel(modelRepo: "OpenMOSS-Team/MOSS-TTS")
+let audio = try await model.generate(
+    text: "Hello, this is MOSS-TTS running from Swift.",
+    voice: nil,
+    refAudio: nil,
+    refText: nil,
+    language: "English",
+    generationParameters: GenerateParameters(
+        maxTokens: 120,
+        temperature: 1.1,
+        topP: 0.9
+    )
+)
+```

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossAudioTokenizer.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossAudioTokenizer.swift
@@ -64,7 +64,7 @@ public struct MossAudioTokenizerConfig: Sendable {
             samplingRate: json.mossInt("sampling_rate", fallback: json.mossInt("sample_rate", fallback: 48_000)),
             downsampleRate: json.mossInt("downsample_rate", fallback: 3_840),
             causalTransformerContextDuration: json.mossFloat("causal_transformer_context_duration", fallback: 10),
-            numberChannels: json.mossInt("number_channels", fallback: 2),
+            numberChannels: json.mossInt("number_channels", fallback: 1),
             enableChannelInterleave: json.mossBool("enable_channel_interleave", fallback: true),
             encoderKwargs: encoderKwargs,
             decoderKwargs: decoderKwargs,
@@ -230,7 +230,14 @@ private final class MossLayerScale: Module {
     }
 }
 
-private final class MossAudioIdentity: Module {}
+private final class MossAudioIdentity: Module, UnaryLayer {
+    func callAsFunction(_ x: MLXArray) -> MLXArray { x }
+}
+
+@inline(__always)
+private func mossAudioCallUnary(_ module: Module, _ x: MLXArray) -> MLXArray {
+    (module as! UnaryLayer).callAsFunction(x)
+}
 
 private func mossApplyLayerScale(_ module: Module, to x: MLXArray) -> MLXArray {
     if let scale = module as? MossLayerScale {
@@ -470,15 +477,17 @@ private final class MossAudioTransformer: Module {
 private final class MossProjectedTransformer: Module, MossAudioTokenizerStage {
     let downsampleRatio = 1
 
-    @ModuleInfo(key: "input_proj") var inputProj: Linear
+    @ModuleInfo(key: "input_proj") var inputProj: Module
     @ModuleInfo var transformer: MossAudioTransformer
-    @ModuleInfo(key: "output_proj") var outputProj: Linear
+    @ModuleInfo(key: "output_proj") var outputProj: Module
 
     init(kwargs: [String: SendableValue], context: Int) throws {
         let inputDimension = kwargs.int("input_dimension", fallback: 0)
         let outputDimension = kwargs.int("output_dimension", fallback: 0)
         let dModel = kwargs.int("d_model", fallback: 0)
-        _inputProj.wrappedValue = Linear(inputDimension, dModel, bias: false)
+        _inputProj.wrappedValue = inputDimension == dModel
+            ? MossAudioIdentity()
+            : Linear(inputDimension, dModel, bias: false)
         _transformer.wrappedValue = try MossAudioTransformer(
             dModel: dModel,
             numHeads: kwargs.int("num_heads", fallback: 1),
@@ -493,13 +502,15 @@ private final class MossProjectedTransformer: Module, MossAudioTokenizerStage {
             norm: kwargs.string("norm", fallback: "layer_norm"),
             gating: kwargs.string("gating", fallback: "none")
         )
-        _outputProj.wrappedValue = Linear(dModel, outputDimension, bias: false)
+        _outputProj.wrappedValue = outputDimension == dModel
+            ? MossAudioIdentity()
+            : Linear(dModel, outputDimension, bias: false)
     }
 
     func callAsFunction(_ x: MLXArray, inputLengths: MLXArray) throws -> (MLXArray, MLXArray) {
-        var hidden = inputProj(x.transposed(0, 2, 1))
+        var hidden = mossAudioCallUnary(inputProj, x.transposed(0, 2, 1))
         hidden = transformer(hidden, inputLengths: inputLengths)
-        let output = outputProj(hidden)
+        let output = mossAudioCallUnary(outputProj, hidden)
         return (output.transposed(0, 2, 1), inputLengths)
     }
 }
@@ -744,9 +755,31 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
         let config = try MossAudioTokenizerConfig.fromFile(modelDir.appendingPathComponent("config.json"))
         let model = try MLXMossAudioTokenizer(config: config)
         let weights = try loadWeights(from: modelDir)
-        try model.update(parameters: ModuleParameters.unflattened(weights), verify: .all)
+        try model.update(parameters: ModuleParameters.unflattened(sanitize(weights: weights)), verify: .all)
         eval(model)
         return model
+    }
+
+    private static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result = weights
+        for (key, value) in weights {
+            var mappedKey: String?
+            if key.contains(".self_attn.in_projs.0.") {
+                mappedKey = key.replacingOccurrences(of: ".self_attn.in_projs.0.", with: ".self_attn.in_proj.")
+            } else if key.contains(".self_attn.out_projs.0.") {
+                mappedKey = key.replacingOccurrences(of: ".self_attn.out_projs.0.", with: ".self_attn.out_proj.")
+            } else if key.contains(".transformer.layers.") && key.contains(".linear1.") {
+                mappedKey = key.replacingOccurrences(of: ".linear1.", with: ".ffn.0.")
+            } else if key.contains(".transformer.layers.") && key.contains(".linear2.") {
+                mappedKey = key.replacingOccurrences(of: ".linear2.", with: ".ffn.2.")
+            }
+
+            if let mappedKey {
+                result[mappedKey] = value
+                result.removeValue(forKey: key)
+            }
+        }
+        return result
     }
 
     public static func fromPretrained(

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -21,12 +21,35 @@ public enum TTSModelError: Error, LocalizedError, CustomStringConvertible {
 }
 
 public enum TTS {
+    private enum ModelSource {
+        case repository(String, cache: HubCache)
+        case localDirectory(URL, repoHint: String)
+
+        var fallbackName: String {
+            switch self {
+            case .repository(let modelRepo, _):
+                modelRepo
+            case .localDirectory(let modelDir, let repoHint):
+                repoHint.isEmpty ? modelDir.path : repoHint
+            }
+        }
+    }
+
     public static func loadModel(
         modelRepo: String,
         textProcessor: TextProcessor? = nil,
         hfToken: String? = nil,
         cache: HubCache = .default
     ) async throws -> SpeechGenerationModel {
+        if let modelDir = localModelDirectory(modelRepo) {
+            let modelType = try localModelType(modelDir) ?? inferModelType(from: modelRepo)
+            return try await loadResolvedModel(
+                modelType: modelType,
+                source: .localDirectory(modelDir, repoHint: modelRepo),
+                textProcessor: textProcessor
+            )
+        }
+
         guard let repoID = Repo.ID(rawValue: modelRepo) else {
             throw TTSModelError.invalidRepositoryID(modelRepo)
         }
@@ -36,7 +59,11 @@ public enum TTS {
             hfToken: hfToken,
             cache: cache
         )
-        return try await loadModel(modelRepo: modelRepo, modelType: modelType, textProcessor: textProcessor, cache: cache)
+        return try await loadResolvedModel(
+            modelType: modelType,
+            source: .repository(modelRepo, cache: cache),
+            textProcessor: textProcessor
+        )
     }
 
     public static func loadModel(
@@ -45,39 +72,147 @@ public enum TTS {
         textProcessor: TextProcessor? = nil,
         cache: HubCache = .default
     ) async throws -> SpeechGenerationModel {
-        let resolvedType = normalizedModelType(modelType) ?? inferModelType(from: modelRepo)
+        if let modelDir = localModelDirectory(modelRepo) {
+            let localType = try localModelType(modelDir)
+            let resolvedModelType = normalizedModelType(modelType)
+                ?? localType
+                ?? inferModelType(from: modelRepo)
+            return try await loadResolvedModel(
+                modelType: resolvedModelType,
+                source: .localDirectory(modelDir, repoHint: modelRepo),
+                textProcessor: textProcessor
+            )
+        }
+
+        return try await loadResolvedModel(
+            modelType: modelType,
+            source: .repository(modelRepo, cache: cache),
+            textProcessor: textProcessor
+        )
+    }
+
+    private static func loadResolvedModel(
+        modelType: String?,
+        source: ModelSource,
+        textProcessor: TextProcessor?
+    ) async throws -> SpeechGenerationModel {
+        let resolvedType = normalizedModelType(modelType) ?? inferModelType(from: source.fallbackName)
         guard let resolvedType else {
             throw TTSModelError.unsupportedModelType(modelType)
         }
 
         switch resolvedType {
         case "moss_tts_nano":
-            return try await MossTTSNanoModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await MossTTSNanoModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await MossTTSNanoModel.fromModelDirectory(modelDir) }
+            )
+        case "moss_tts", "moss_tts_delay", "moss_tts_local":
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await MossTTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await MossTTSModel.fromModelDirectory(modelDir) }
+            )
         case "echo_tts", "echo":
-            return try await EchoTTSModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await EchoTTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await EchoTTSModel.fromModelDirectory(modelDir) }
+            )
         case "qwen3_tts":
-            return try await Qwen3TTSModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await Qwen3TTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await Qwen3TTSModel.fromModelDirectory(modelDir) }
+            )
         case "qwen3", "qwen":
-            return try await Qwen3Model.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await Qwen3Model.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await Qwen3Model.fromModelDirectory(modelDir) }
+            )
         case "fish_speech", "fish_qwen3_omni":
-            return try await FishSpeechModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await FishSpeechModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await FishSpeechModel.fromModelDirectory(modelDir) }
+            )
         case "llama_tts", "llama3_tts", "llama3", "llama", "orpheus", "orpheus_tts":
-            return try await LlamaTTSModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await LlamaTTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await LlamaTTSModel.fromModelDirectory(modelDir) }
+            )
         case "csm", "sesame":
-            return try await MarvisTTSModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await MarvisTTSModel.fromPretrained($0, cache: $1) }
+            )
         case "soprano_tts", "soprano":
-            return try await SopranoModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await SopranoModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, repoHint in try await SopranoModel.fromModelDirectory(modelDir, repo: repoHint) }
+            )
         case "pocket_tts":
-            return try await PocketTTSModel.fromPretrained(modelRepo, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await PocketTTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await PocketTTSModel.fromModelDirectory(modelDir) }
+            )
         case "chatterbox", "chatterbox_tts", "chatterbox_turbo":
-            return try await ChatterboxModel.fromPretrained(modelRepo)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { modelRepo, _ in try await ChatterboxModel.fromPretrained(modelRepo) },
+                local: { modelDir, _ in try await ChatterboxModel.fromModelDirectory(modelDir, hfToken: nil) }
+            )
         case "kitten_tts", "kitten":
-            return try await KittenTTSModel.fromPretrained(modelRepo, textProcessor: textProcessor ?? MisakiTextProcessor(), cache: cache)
+            let processor = textProcessor ?? MisakiTextProcessor()
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await KittenTTSModel.fromPretrained($0, textProcessor: processor, cache: $1) },
+                local: { modelDir, _ in try await KittenTTSModel.fromModelDirectory(modelDir, textProcessor: processor) }
+            )
         case "kokoro", "kokoro_tts":
             let processor = textProcessor ?? KokoroMultilingualProcessor()
-            return try await KokoroModel.fromPretrained(modelRepo, textProcessor: processor, cache: cache)
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await KokoroModel.fromPretrained($0, textProcessor: processor, cache: $1) },
+                local: { modelDir, _ in try await KokoroModel.fromModelDirectory(modelDir, textProcessor: processor) }
+            )
         default:
-            throw TTSModelError.unsupportedModelType(modelType ?? resolvedType)
+            throw TTSModelError.unsupportedModelType(resolvedType)
+        }
+    }
+
+    private static func load<Model: SpeechGenerationModel>(
+        _ source: ModelSource,
+        modelType: String,
+        pretrained: (String, HubCache) async throws -> Model,
+        local: ((URL, String) async throws -> Model)? = nil
+    ) async throws -> SpeechGenerationModel {
+        switch source {
+        case .repository(let modelRepo, let cache):
+            return try await pretrained(modelRepo, cache)
+        case .localDirectory(let modelDir, let repoHint):
+            guard let local else {
+                throw TTSModelError.unsupportedModelType("\(modelType) from local directory")
+            }
+            return try await local(modelDir, repoHint)
         }
     }
 
@@ -90,6 +225,29 @@ public enum TTS {
 
     static func resolveModelType(modelRepo: String, modelType: String? = nil) -> String? {
         normalizedModelType(modelType) ?? inferModelType(from: modelRepo)
+    }
+
+    private static func localModelDirectory(_ path: String) -> URL? {
+        let expanded = (path as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              FileManager.default.fileExists(atPath: url.appendingPathComponent("config.json").path)
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func localModelType(_ modelDir: URL) throws -> String? {
+        let data = try Data(contentsOf: modelDir.appendingPathComponent("config.json"))
+        guard let config = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return (config["model_type"] as? String)
+            ?? (config["architecture"] as? String)
+            ?? (config["model_version"] as? String)
     }
 
     private static func inferModelType(from modelRepo: String) -> String? {
@@ -109,7 +267,13 @@ public enum TTS {
             return "echo_tts"
         }
         if lower.contains("moss") && lower.contains("tts") {
-            return "moss_tts_nano"
+            if lower.contains("nano") {
+                return "moss_tts_nano"
+            }
+            if lower.contains("local-transformer") || lower.contains("local_transformer") {
+                return "moss_tts_local"
+            }
+            return "moss_tts_delay"
         }
         if lower.contains("qwen3") || lower.contains("qwen") {
             return "qwen3"

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -71,6 +71,57 @@ private struct MossFakeTokenizer: MossTextTokenizing {
     }
 }
 
+private struct MossTTSFullFakeTokenizer: MossTTSTextTokenizing {
+    private let tokenIDsByString: [String: Int] = [
+        "<|im_start|>": 151_644,
+        "<|im_end|>": 151_645,
+        "<|audio_start|>": 151_652,
+        "<|audio_end|>": 151_653,
+        "<|audio_user_slot|>": 151_654,
+        "<|audio_assistant_gen_slot|>": 151_656,
+        "<|audio_assistant_delay_slot|>": 151_662,
+    ]
+
+    private var tokenStringsByID: [Int: String] {
+        Dictionary(uniqueKeysWithValues: tokenIDsByString.map { ($0.value, $0.key) })
+    }
+
+    private var orderedSpecialTokens: [(String, Int)] {
+        tokenIDsByString.sorted { lhs, rhs in
+            lhs.key.count == rhs.key.count ? lhs.key < rhs.key : lhs.key.count > rhs.key.count
+        }
+    }
+
+    func encode(_ text: String) -> [Int] {
+        var result: [Int] = []
+        var index = text.startIndex
+        while index < text.endIndex {
+            var matched = false
+            let suffix = text[index...]
+            for (token, id) in orderedSpecialTokens where suffix.hasPrefix(token) {
+                result.append(id)
+                index = text.index(index, offsetBy: token.count)
+                matched = true
+                break
+            }
+            if !matched {
+                let scalar = text[index].unicodeScalars.first?.value ?? 0
+                result.append(1_000 + Int(scalar % 500))
+                index = text.index(after: index)
+            }
+        }
+        return result
+    }
+
+    func decode(_ tokenIDs: [Int]) -> String {
+        tokenIDs.map { tokenStringsByID[$0] ?? "<\($0)>" }.joined()
+    }
+
+    func tokenString(for tokenID: Int) -> String? {
+        tokenStringsByID[tokenID]
+    }
+}
+
 private func makeTinyMossConfig(nVQ: Int = 2) throws -> MossTTSNanoConfig {
     try MossTTSNanoConfig(
         gpt2Config: MossGPT2Config(
@@ -319,6 +370,174 @@ struct MossTTSNanoTests {
     @Test func ttsModelResolutionIncludesMossNano() {
         #expect(TTS.resolveModelType(modelRepo: "mlx-community/MOSS-TTS-Nano") == "moss_tts_nano")
         #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "moss_tts_nano") == "moss_tts_nano")
+    }
+}
+
+@Suite("MOSS TTS Full Tests")
+struct MossTTSFullTests {
+    @Test func configDecodesDelayAndLocalVariants() throws {
+        let delayJSON = """
+        {
+          "model_type": "moss_tts_delay",
+          "n_vq": 16,
+          "audio_vocab_size": 1024,
+          "sampling_rate": 24000,
+          "language_config": {
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "num_hidden_layers": 2,
+            "intermediate_size": 6144,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "rope_parameters": { "rope_theta": 1000000.0 }
+          }
+        }
+        """
+        let delay = try JSONDecoder().decode(MossTTSConfig.self, from: Data(delayJSON.utf8))
+        #expect(delay.nVQ == 16)
+        #expect(delay.samplingRate == 24_000)
+        #expect(delay.languageConfig.ropeTheta == 1_000_000)
+        #expect(delay.isLocalTransformer == false)
+
+        let localJSON = """
+        {
+          "model_type": "moss_tts_delay",
+          "n_vq": 32,
+          "audio_vocab_size": 1024,
+          "sample_rate": 24000,
+          "additional_mlp_ffn_hidden_size": 4096,
+          "local_ffn_hidden_size": 4096,
+          "local_hidden_size": 1536,
+          "local_num_layers": 4,
+          "language_config": {
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "num_hidden_layers": 2,
+            "intermediate_size": 6144,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 128
+          }
+        }
+        """
+        let local = try JSONDecoder().decode(MossTTSConfig.self, from: Data(localJSON.utf8))
+        #expect(local.isLocalTransformer)
+        #expect(local.samplingRate == 24_000)
+        let localTransformer = try local.localTransformerConfig()
+        #expect(localTransformer.hiddenSize == 1536)
+        #expect(localTransformer.intermediateSize == 4096)
+        #expect(localTransformer.numHiddenLayers == 4)
+    }
+
+    @Test func audioTokenizerMissingChannelCountDefaultsToMono() throws {
+        let directory = try makeTemporaryArtifactDirectory(prefix: "full-moss-audio-tokenizer")
+        defer { cleanupTemporaryArtifactDirectory(directory) }
+        let configJSON = """
+        {
+          "sample_rate": 24000,
+          "sampling_rate": 24000,
+          "downsample_rate": 1920,
+          "enable_channel_interleave": true,
+          "quantizer_type": "rlfq",
+          "quantizer_kwargs": {
+            "num_quantizers": 32,
+            "codebook_size": 1024,
+            "codebook_dim": 8
+          }
+        }
+        """
+        try writeTestFile(directory.appendingPathComponent("config.json"), contents: configJSON)
+        let parsed = try MossAudioTokenizerConfig.fromFile(directory.appendingPathComponent("config.json"))
+        #expect(parsed.numberChannels == 1)
+        #expect(parsed.downsampleRate == 1_920)
+    }
+
+    @Test func delayPatternRoundTripsAudioCodes() throws {
+        let codes = MLXArray([Int32(1), 2, 3, 4, 5, 6], [2, 3]).asType(.int32)
+        let delayed = try mossTTSApplyDelayPattern(codes, padCode: 99)
+        #expect(delayed.asArray(Int32.self) == [
+            1, 99, 99,
+            4, 2, 99,
+            99, 5, 3,
+            99, 99, 6,
+        ])
+        let restored = try mossTTSApplyDeDelayPattern(delayed)
+        #expect(restored.asArray(Int32.self) == codes.asArray(Int32.self))
+    }
+
+    @Test func delayProcessorBuildsReferencePromptRows() throws {
+        let config = MossTTSConfig(nVQ: 3, audioPadCode: 99)
+        let tokenizer = MossTTSFullFakeTokenizer()
+        let processor = try MossTTSDelayProcessor(tokenizer: tokenizer, config: config)
+        let reference = MLXArray([Int32(1), 2, 3, 4, 5, 6], [2, 3]).asType(.int32)
+        let user = processor.buildUserMessage(text: "target", reference: [reference], language: "English")
+
+        let batch = try processor([[user]], mode: "generation")
+        #expect(batch.inputIDs.dim(0) == 1)
+        #expect(batch.inputIDs.dim(2) == 4)
+
+        let textColumn = batch.inputIDs[0, 0..., 0].asArray(Int32.self).map(Int.init)
+        #expect(textColumn.contains(config.audioStartTokenID))
+        #expect(textColumn.contains(config.audioEndTokenID))
+        #expect(textColumn.contains(config.audioUserSlotTokenID))
+
+        let audioColumns = batch.inputIDs[0, 0..., 1...].asArray(Int32.self)
+        #expect(audioColumns.contains(1))
+        #expect(audioColumns.contains(6))
+    }
+
+    @Test func standardPromptOmitsSceneField() throws {
+        let config = MossTTSConfig(nVQ: 32)
+        let processor = try MossTTSDelayProcessor(tokenizer: MossTTSFullFakeTokenizer(), config: config)
+        let user = processor.buildUserMessage(text: "target", language: "English", scene: "studio")
+
+        #expect(!user.content.contains("- Scene:"))
+        #expect(user.content.contains("- Text:\ntarget"))
+    }
+
+    @Test func dialoguePromptKeepsSceneField() throws {
+        let config = MossTTSConfig(nVQ: 16)
+        let processor = try MossTTSDelayProcessor(tokenizer: MossTTSFullFakeTokenizer(), config: config)
+        let user = processor.buildUserMessage(text: "target", language: "English", scene: "studio")
+
+        #expect(user.content.contains("- Scene:\nstudio"))
+        #expect(user.content.contains("- Text:\ntarget"))
+    }
+
+    @Test func localProcessorAppendsAudioStartWithoutDelayPattern() throws {
+        let language = MossQwen3Config(
+            vocabSize: 151_936,
+            hiddenSize: 64,
+            numHiddenLayers: 1,
+            intermediateSize: 128,
+            numAttentionHeads: 4,
+            numKeyValueHeads: 4,
+            headDim: 16
+        )
+        let config = MossTTSConfig(
+            languageConfig: language,
+            nVQ: 3,
+            audioPadCode: 99,
+            additionalMLPFFNHiddenSize: 128,
+            localFFNHiddenSize: 128,
+            localHiddenSize: 64,
+            localNumLayers: 1
+        )
+        let processor = try MossTTSLocalProcessor(tokenizer: MossTTSFullFakeTokenizer(), config: config)
+        let user = processor.buildUserMessage(text: "target", language: "English")
+
+        let batch = try processor([[user]], mode: "generation")
+        let textColumn = batch.inputIDs[0, 0..., 0].asArray(Int32.self).map(Int.init)
+        #expect(textColumn.last == config.audioStartTokenID)
+        #expect(batch.inputIDs[0, -1, 1...].asArray(Int32.self).allSatisfy { $0 == Int32(config.audioPadCode) })
+    }
+
+    @Test func ttsModelResolutionIncludesFullMossVariants() {
+        #expect(TTS.resolveModelType(modelRepo: "OpenMOSS-Team/MOSS-TTS") == "moss_tts_delay")
+        #expect(TTS.resolveModelType(modelRepo: "OpenMOSS-Team/MOSS-TTSD-v1.0") == "moss_tts_delay")
+        #expect(TTS.resolveModelType(modelRepo: "OpenMOSS-Team/MOSS-TTS-Local-Transformer") == "moss_tts_local")
+        #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "moss_tts_delay") == "moss_tts_delay")
     }
 }
 


### PR DESCRIPTION
This adds the MOSS-TTS/TTSD models, ported from the python implementation.

I also did some mild refactoring of the TTS model loading to make it easier to use path-based models, e.g. embedded in the app bundle on iOS, which was previously not really possible with the generic model loading entrypoints.

Resolves https://github.com/Blaizzy/mlx-audio-swift/issues/171