### PR TITLE
Add MiMo-V2.5-ASR STT support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ let package = Package(
                 "Models/FireRedASR2/README.md",
                 "Models/GLMASR/README.md",
                 "Models/GraniteSpeech/README.md",
+                "Models/MiMoV2ASR/README.md",
                 "Models/Parakeet/README.md",
                 "Models/Qwen3ASR/README.md",
                 "Models/SenseVoice/README.md",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MLXAudio follows a modular design allowing you to import only what you need:
 - **MLXAudioCore**: Base types, protocols, and utilities
 - **MLXAudioCodecs**: Audio codec implementations (SNAC, Encodec, Vocos, Mimi, DACVAE)
 - **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, Fish Audio S2 Pro, Soprano, VyvoTTS, Orpheus, Marvis TTS, Pocket TTS)
-- **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Voxtral Realtime, Cohere Transcribe, Parakeet, GLMASR)
+- **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, MiMo-V2.5-ASR, Voxtral Realtime, Cohere Transcribe, Parakeet, GLMASR)
 - **MLXAudioVAD**: Voice Activity Detection & Speaker Diarization (Sortformer, SmartTurn)
 - **MLXAudioSTS**: Speech-to-Speech models (LFM2.5-Audio, SAM-Audio, MossFormer2-SE, DeepFilterNet)
 - **MLXAudioUI**: SwiftUI components for audio interfaces
@@ -133,6 +133,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 |-------|--------------|------------------|
 | Qwen3-ASR | [Qwen3-ASR README](Sources/MLXAudioSTT/Models/Qwen3ASR/README.md) | [mlx-community/Qwen3-ASR-1.7B-bf16](https://huggingface.co/mlx-community/Qwen3-ASR-1.7B-bf16) |
 | Qwen3-ForcedAligner | [Qwen3-ASR README](Sources/MLXAudioSTT/Models/Qwen3ASR/README.md) | [mlx-community/Qwen3-ForcedAligner-0.6B-bf16](https://huggingface.co/mlx-community/Qwen3-ForcedAligner-0.6B-bf16) |
+| MiMo-V2.5-ASR | [MiMo-V2.5-ASR README](Sources/MLXAudioSTT/Models/MiMoV2ASR/README.md) | [mlx-community/MiMo-V2.5-ASR-MLX](https://huggingface.co/mlx-community/MiMo-V2.5-ASR-MLX) |
 | Voxtral Realtime | [Voxtral README](Sources/MLXAudioSTT/Models/VoxtralRealtime/README.md) | [mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16) |
 | Cohere Transcribe | [Cohere Transcribe README](Sources/MLXAudioSTT/Models/CohereTranscribe/README.md) | [beshkenadze/cohere-transcribe-03-2026-mlx-fp16](https://huggingface.co/beshkenadze/cohere-transcribe-03-2026-mlx-fp16) |
 | Parakeet | [Parakeet README](Sources/MLXAudioSTT/Models/Parakeet/README.md) | [mlx-community/parakeet-tdt-0.6b-v3](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3) |

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoAudioPreprocessing.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoAudioPreprocessing.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+enum MiMoAudioPreprocessing {
+    static let targetSampleRate = 24_000
+    static let nFFT = 960
+    static let hopLength = 240
+    static let nMels = 128
+    static let chunkDurationSeconds = 30
+
+    static func normalizeWaveform(_ waveform: MLXArray) -> MLXArray {
+        if waveform.ndim == 1 {
+            return waveform.asType(.float32)
+        }
+        return waveform.mean(axis: -1).reshaped([-1]).asType(.float32)
+    }
+
+    static func splitIntoChunks(_ waveform: MLXArray, sampleRate: Int = targetSampleRate) -> [MLXArray] {
+        let wav = normalizeWaveform(waveform)
+        let totalSamples = wav.shape[0]
+        guard totalSamples > 0 else { return [] }
+
+        let chunkSamples = chunkDurationSeconds * sampleRate
+        var chunks: [MLXArray] = []
+        chunks.reserveCapacity(max(1, totalSamples / max(chunkSamples, 1)))
+
+        var start = 0
+        while start < totalSamples {
+            var end = min(start + chunkSamples, totalSamples)
+            if 0 < totalSamples - end, totalSamples - end < nFFT {
+                end = totalSamples
+            }
+
+            var chunk = wav[start..<end]
+            if chunk.shape[0] < nFFT {
+                chunk = MLX.padded(chunk, widths: [IntOrPair((0, nFFT - chunk.shape[0]))])
+            }
+
+            chunks.append(chunk)
+            start = end
+        }
+
+        return chunks
+    }
+
+    static func computeLogMel(_ waveform: MLXArray) -> MLXArray {
+        let audio = normalizeWaveform(waveform)
+        guard audio.shape[0] > 0 else {
+            return MLXArray.zeros([0, nMels], type: Float.self)
+        }
+
+        let window = hanningWindow(size: nFFT)
+        let freqs = stft(audio: audio, window: window, nFft: nFFT, hopLength: hopLength)
+        let magnitudes = MLX.abs(freqs)
+        let filters = melFilters(
+            sampleRate: targetSampleRate,
+            nFft: nFFT,
+            nMels: nMels,
+            fMin: 0,
+            fMax: nil,
+            norm: nil,
+            melScale: .htk
+        )
+
+        let mel = MLX.matmul(magnitudes, filters)
+        let clipped = MLX.maximum(mel, MLXArray(Float(1e-7)))
+        return MLX.log(clipped)
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoAudioTokenizer.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoAudioTokenizer.swift
@@ -1,0 +1,383 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXAudioCodecs
+
+final class MiMoAudioTokenizerAttention: Module {
+    let embedDim: Int
+    let numHeads: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    let rope: RoPE
+
+    init(embedDim: Int, numHeads: Int, ropeTheta: Int) {
+        self.embedDim = embedDim
+        self.numHeads = numHeads
+        self.headDim = embedDim / numHeads
+        self.scale = pow(Float(headDim), -0.5)
+        _qProj.wrappedValue = Linear(embedDim, embedDim, bias: true)
+        _kProj.wrappedValue = Linear(embedDim, embedDim, bias: false)
+        _vProj.wrappedValue = Linear(embedDim, embedDim, bias: true)
+        _outProj.wrappedValue = Linear(embedDim, embedDim, bias: true)
+        self.rope = RoPE(dimensions: headDim, traditional: false, base: Float(ropeTheta))
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        let batch = hiddenStates.shape[0]
+        let time = hiddenStates.shape[1]
+
+        var queries = qProj(hiddenStates)
+        var keys = kProj(hiddenStates)
+        var values = vProj(hiddenStates)
+
+        queries = queries.reshaped([batch, time, numHeads, headDim]).transposed(0, 2, 1, 3)
+        keys = keys.reshaped([batch, time, numHeads, headDim]).transposed(0, 2, 1, 3)
+        values = values.reshaped([batch, time, numHeads, headDim]).transposed(0, 2, 1, 3)
+
+        queries = rope(queries)
+        keys = rope(keys)
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: nil
+        )
+
+        return outProj(output.transposed(0, 2, 1, 3).reshaped([batch, time, embedDim]))
+    }
+}
+
+final class MiMoAudioTokenizerEncoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: MiMoAudioTokenizerAttention
+    @ModuleInfo(key: "self_attn_layer_norm") var selfAttentionLayerNorm: LayerNorm
+    @ModuleInfo(key: "fc1") var fc1: Linear
+    @ModuleInfo(key: "fc2") var fc2: Linear
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    init(config: MiMoAudioTokenizerConfig) {
+        _selfAttention.wrappedValue = MiMoAudioTokenizerAttention(
+            embedDim: config.dModel,
+            numHeads: config.encoderAttentionHeads,
+            ropeTheta: config.ropeTheta
+        )
+        _selfAttentionLayerNorm.wrappedValue = LayerNorm(dimensions: config.dModel, eps: 1e-5)
+        _fc1.wrappedValue = Linear(config.dModel, config.encoderFFNDim, bias: true)
+        _fc2.wrappedValue = Linear(config.encoderFFNDim, config.dModel, bias: true)
+        _finalLayerNorm.wrappedValue = LayerNorm(dimensions: config.dModel, eps: 1e-5)
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        var residual = hiddenStates
+        var output = selfAttentionLayerNorm(hiddenStates)
+        output = selfAttention(output)
+        output = residual + output
+
+        residual = output
+        output = finalLayerNorm(output)
+        output = gelu(fc1(output))
+        output = fc2(output)
+        return residual + output
+    }
+}
+
+final class MiMoAudioTokenizerCodebook: Module {
+    var embed: MLXArray
+
+    init(codebookSize: Int, dim: Int) {
+        self.embed = MLXArray.zeros([codebookSize, dim], type: Float.self)
+    }
+}
+
+final class MiMoAudioTokenizerVectorQuantization: Module {
+    @ModuleInfo(key: "_codebook") var codebook: MiMoAudioTokenizerCodebook
+
+    init(codebookSize: Int, dim: Int) {
+        _codebook.wrappedValue = MiMoAudioTokenizerCodebook(codebookSize: codebookSize, dim: dim)
+    }
+
+    func encode(_ hiddenStates: MLXArray) -> MLXArray {
+        let x = hiddenStates.asType(.float32)
+        let embedding = codebook.embed.asType(.float32)
+        let distances =
+            -(MLX.sum(x * x, axis: -1, keepDims: true)
+              - 2 * MLX.matmul(x, embedding.transposed())
+              + MLX.sum(embedding * embedding, axis: -1).expandedDimensions(axis: 0))
+        return distances.argMax(axis: -1).asType(.int32)
+    }
+
+    func decode(_ indices: MLXArray) -> MLXArray {
+        take(codebook.embed, indices, axis: 0)
+    }
+}
+
+final class MiMoAudioTokenizerResidualVectorQuantization: Module {
+    @ModuleInfo(key: "layers") var layers: [MiMoAudioTokenizerVectorQuantization]
+
+    init(config: MiMoAudioTokenizerConfig, activeQuantizers: Int) {
+        let codebookSizes = Array(config.codebookSize.prefix(max(1, activeQuantizers)))
+        _layers.wrappedValue = codebookSizes.map {
+            MiMoAudioTokenizerVectorQuantization(codebookSize: $0, dim: config.dModel)
+        }
+    }
+
+    func encode(_ hiddenStates: MLXArray, nQuantizers: Int? = nil) -> MLXArray {
+        let activeQuantizers = min(nQuantizers ?? layers.count, layers.count)
+        var residual = hiddenStates.asType(.float32)
+        var outputs: [MLXArray] = []
+        outputs.reserveCapacity(activeQuantizers)
+
+        for layerIndex in 0..<activeQuantizers {
+            let indices = layers[layerIndex].encode(residual)
+            let quantized = layers[layerIndex].decode(indices)
+            residual = residual - quantized
+            outputs.append(indices.expandedDimensions(axis: 1))
+        }
+
+        return MLX.concatenated(outputs, axis: 1)
+    }
+}
+
+final class MiMoAudioTokenizerQuantizer: Module {
+    @ModuleInfo(key: "vq") var vq: MiMoAudioTokenizerResidualVectorQuantization
+
+    init(config: MiMoAudioTokenizerConfig, activeQuantizers: Int) {
+        _vq.wrappedValue = MiMoAudioTokenizerResidualVectorQuantization(
+            config: config,
+            activeQuantizers: activeQuantizers
+        )
+    }
+
+    func encode(_ hiddenStates: MLXArray, nQuantizers: Int? = nil) -> MLXArray {
+        vq.encode(hiddenStates, nQuantizers: nQuantizers)
+    }
+}
+
+final class MiMoAudioTokenizerEncoder: Module {
+    let config: MiMoAudioTokenizerConfig
+    let activeQuantizers: Int
+
+    @ModuleInfo(key: "conv1") var conv1: MLXAudioCodecs.Conv1d
+    @ModuleInfo(key: "conv2") var conv2: MLXAudioCodecs.Conv1d
+    @ModuleInfo(key: "layers") var layers: [MiMoAudioTokenizerEncoderLayer]
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo(key: "down_sample_layer") var downSampleLayer: [MLXAudioCodecs.Conv1d]
+    @ModuleInfo(key: "down_sample_norm") var downSampleNorm: LayerNorm
+    @ModuleInfo(key: "quantizer") var quantizer: MiMoAudioTokenizerQuantizer
+
+    init(config: MiMoAudioTokenizerConfig, activeQuantizers: Int) {
+        self.config = config
+        self.activeQuantizers = activeQuantizers
+
+        _conv1.wrappedValue = MLXAudioCodecs.Conv1d(
+            inChannels: config.nMels,
+            outChannels: config.dModel,
+            ksize: config.kernelSize,
+            stride: 1,
+            padding: 1,
+            bias: true
+        )
+        _conv2.wrappedValue = MLXAudioCodecs.Conv1d(
+            inChannels: config.dModel,
+            outChannels: config.dModel,
+            ksize: config.kernelSize,
+            stride: config.strideSize,
+            padding: 1,
+            bias: true
+        )
+        _layers.wrappedValue = (0..<config.encoderLayers).map { _ in
+            MiMoAudioTokenizerEncoderLayer(config: config)
+        }
+        _layerNorm.wrappedValue = LayerNorm(dimensions: config.dModel, eps: 1e-5)
+        _downSampleLayer.wrappedValue = [
+            MLXAudioCodecs.Conv1d(
+                inChannels: config.dModel,
+                outChannels: config.dModel,
+                ksize: config.avgPooler,
+                stride: config.avgPooler,
+                padding: 0,
+                bias: false
+            )
+        ]
+        _downSampleNorm.wrappedValue = LayerNorm(dimensions: config.dModel, eps: 1e-5)
+        _quantizer.wrappedValue = MiMoAudioTokenizerQuantizer(
+            config: config,
+            activeQuantizers: activeQuantizers
+        )
+    }
+
+    func encodeMel(_ mel: MLXArray, nQuantizers: Int? = nil) -> MLXArray {
+        var hiddenStates = mel
+        if hiddenStates.ndim == 2 {
+            hiddenStates = hiddenStates.expandedDimensions(axis: 0)
+        }
+        if hiddenStates.shape[1] != config.nMels {
+            hiddenStates = hiddenStates.transposed(0, 2, 1)
+        }
+
+        hiddenStates = gelu(conv1(hiddenStates))
+        hiddenStates = gelu(conv2(hiddenStates))
+        hiddenStates = hiddenStates.transposed(0, 2, 1)
+
+        var skipConnection = MLXArray.zeros(hiddenStates.shape, dtype: hiddenStates.dtype)
+        for (index, layer) in layers.enumerated() {
+            hiddenStates = layer(hiddenStates)
+            if let skipLayerID = config.encoderSkipLayerID, index == skipLayerID - 1 {
+                skipConnection = hiddenStates
+            }
+        }
+
+        hiddenStates = layerNorm(hiddenStates + skipConnection)
+
+        let remainder = hiddenStates.shape[1] % config.avgPooler
+        if remainder != 0 {
+            let padLength = config.avgPooler - remainder
+            hiddenStates = MLX.padded(
+                hiddenStates,
+                widths: [.init((0, 0)), .init((0, padLength)), .init((0, 0))]
+            )
+        }
+
+        hiddenStates = downSampleLayer[0](hiddenStates.transposed(0, 2, 1))
+        hiddenStates = gelu(hiddenStates)
+        hiddenStates = hiddenStates.transposed(0, 2, 1)
+        hiddenStates = downSampleNorm(hiddenStates)
+
+        let packed = hiddenStates.reshaped([-1, config.dModel])
+        return quantizer.encode(packed, nQuantizers: nQuantizers)
+    }
+}
+
+final class MiMoAudioTokenizerModel: Module {
+    let config: MiMoAudioTokenizerConfig
+    let activeQuantizers: Int
+
+    @ModuleInfo(key: "encoder") var encoder: MiMoAudioTokenizerEncoder
+
+    init(config: MiMoAudioTokenizerConfig, activeQuantizers: Int) {
+        self.config = config
+        self.activeQuantizers = activeQuantizers
+        _encoder.wrappedValue = MiMoAudioTokenizerEncoder(
+            config: config,
+            activeQuantizers: activeQuantizers
+        )
+    }
+
+    func encodeMel(_ mel: MLXArray, nQuantizers: Int? = nil) -> MLXArray {
+        encoder.encodeMel(mel, nQuantizers: nQuantizers ?? activeQuantizers)
+    }
+
+    static func load(
+        modelDirectory: URL,
+        config: MiMoAudioTokenizerConfig,
+        activeQuantizers: Int
+    ) throws -> MiMoAudioTokenizerModel {
+        let model = MiMoAudioTokenizerModel(config: config, activeQuantizers: activeQuantizers)
+        let weights = try loadWeights(from: modelDirectory)
+        let sanitized = sanitize(weights: weights, activeQuantizers: activeQuantizers)
+        if let quantization = config.quantization {
+            quantize(model: model) { path, _ in
+                guard sanitized["\(path).scales"] != nil else {
+                    return nil
+                }
+                return quantization.asTuple
+            }
+        }
+        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: [])
+        eval(model)
+        return model
+    }
+
+    private static func loadWeights(from modelDirectory: URL) throws -> [String: MLXArray] {
+        let files = try FileManager.default.contentsOfDirectory(
+            at: modelDirectory,
+            includingPropertiesForKeys: nil
+        )
+        let safetensors = files.filter { $0.pathExtension == "safetensors" }
+        guard !safetensors.isEmpty else {
+            throw NSError(
+                domain: "MiMoAudioTokenizerModel",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "No safetensors files found in \(modelDirectory.path)"]
+            )
+        }
+
+        var merged: [String: MLXArray] = [:]
+        for file in safetensors {
+            let shard = try MLX.loadArrays(url: file)
+            merged.merge(shard) { _, new in new }
+        }
+        return merged
+    }
+
+    private static func sanitize(
+        weights: [String: MLXArray],
+        activeQuantizers: Int
+    ) -> [String: MLXArray] {
+        let quantizerPrefix = "encoder.quantizer.vq.layers."
+        let hasHFStyleKeys = weights.keys.contains { $0.hasPrefix("encoder.") || $0.hasPrefix("decoder.") }
+
+        return weights.filter { key, _ in
+            if hasHFStyleKeys {
+                guard key.hasPrefix("encoder.") else {
+                    return false
+                }
+                guard !key.contains(".cluster_size"),
+                      !key.contains(".embed_avg"),
+                      !key.contains(".inited") else {
+                    return false
+                }
+                guard key.starts(with: "decoder.") == false else {
+                    return false
+                }
+            } else {
+                guard key != "position_embedding.inv_freq" else {
+                    return false
+                }
+                guard !key.contains(".cluster_size"),
+                      !key.contains(".embed_avg"),
+                      !key.contains(".inited") else {
+                    return false
+                }
+            }
+
+            let normalizedKey = hasHFStyleKeys ? key : mlxExportKeyToSwiftKey(key)
+            if normalizedKey.hasPrefix(quantizerPrefix) {
+                let suffix = normalizedKey.dropFirst(quantizerPrefix.count)
+                let indexText = suffix.prefix { $0.isNumber }
+                guard let index = Int(indexText), index < activeQuantizers else {
+                    return false
+                }
+            }
+            return true
+        }.reduce(into: [String: MLXArray]()) { partialResult, item in
+            let rawKey = item.key
+            let value = item.value
+            let key = hasHFStyleKeys ? rawKey : mlxExportKeyToSwiftKey(rawKey)
+            let normalizedValue: MLXArray
+            if value.ndim == 3, value.shape[1] > value.shape[2] {
+                normalizedValue = value.transposed(0, 2, 1)
+            } else {
+                normalizedValue = value
+            }
+            partialResult[key] = normalizedValue
+        }
+    }
+
+    private static func mlxExportKeyToSwiftKey(_ key: String) -> String {
+        var mapped = "encoder." + key
+        if mapped.hasPrefix("encoder.down_sample.") {
+            mapped = mapped.replacingOccurrences(of: "encoder.down_sample.", with: "encoder.down_sample_layer.0.")
+        }
+        mapped = mapped.replacingOccurrences(of: ".codebook.", with: "._codebook.")
+        return mapped
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoAudioTokenizerConfig.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoAudioTokenizerConfig.swift
@@ -1,0 +1,145 @@
+import Foundation
+import MLXLMCommon
+
+public struct MiMoAudioTokenizerConfig: Decodable, Sendable {
+    public let maxAudioSeconds: Int
+    public let strideSize: Int
+    public let avgPooler: Int
+    public let dModel: Int
+    public let scaleEmbedding: Bool
+    public let kernelSize: Int
+    public let activationFunction: String
+    public let encoderLayers: Int
+    public let encoderSkipLayerID: Int?
+    public let encoderAttentionHeads: Int
+    public let encoderFFNDim: Int
+    public let encoderCausal: Bool
+    public let encoderAttentionWindowSize: [Int]
+    public let decoderLayers: Int
+    public let decoderAttentionHeads: Int
+    public let decoderFFNDim: Int
+    public let decoderKernelSize: Int
+    public let decoderStrideSize: Int
+    public let decoderCausal: Bool
+    public let decoderAttentionWindowSize: [Int]
+    public let nfft: Int
+    public let vocoderDim: Int
+    public let vocoderIntermediateDim: Int
+    public let vocoderNumLayers: Int
+    public let nMels: Int
+    public let samplingRate: Int
+    public let hopLength: Int
+    public let windowSize: Int
+    public let vocoderPadding: String
+    public let fmin: Int
+    public let fmax: Int?
+    public let numQuantizers: Int
+    public let codebookSize: [Int]
+    public let thresholdEMADeadCode: Int
+    public let positionEmbeddingType: String
+    public let ropeTheta: Int
+    public let ropeType: String
+    public let layerNormType: String
+    public let vocoderAttentionHeads: Int
+    public let vocoderAttentionWindowSize: [Int]
+    public let quantization: BaseConfiguration.Quantization?
+
+    enum CodingKeys: String, CodingKey {
+        case maxAudioSeconds = "max_audio_seconds"
+        case strideSize = "stride_size"
+        case avgPooler = "avg_pooler"
+        case dModel = "d_model"
+        case scaleEmbedding = "scale_embedding"
+        case kernelSize = "kernel_size"
+        case activationFunction = "activation_function"
+        case encoderLayers = "encoder_layers"
+        case encoderSkipLayerID = "encoder_skip_layer_id"
+        case encoderAttentionHeads = "encoder_attention_heads"
+        case encoderFFNDim = "encoder_ffn_dim"
+        case encoderCausal = "encoder_causal"
+        case encoderAttentionWindowSize = "encoder_attn_window_size"
+        case decoderLayers = "decoder_layers"
+        case decoderAttentionHeads = "decoder_attention_heads"
+        case decoderFFNDim = "decoder_ffn_dim"
+        case decoderKernelSize = "decoder_kernel_size"
+        case decoderStrideSize = "decoder_stride_size"
+        case decoderCausal = "decoder_causal"
+        case decoderAttentionWindowSize = "decoder_attn_window_size"
+        case nfft
+        case vocoderDim = "vocoder_dim"
+        case vocoderIntermediateDim = "vocoder_intermediate_dim"
+        case vocoderNumLayers = "vocoder_num_layers"
+        case nMels = "n_mels"
+        case samplingRate = "sampling_rate"
+        case hopLength = "hop_length"
+        case windowSize = "window_size"
+        case vocoderPadding = "vocoder_padding"
+        case fmin
+        case fmax
+        case numQuantizers = "num_quantizers"
+        case codebookSize = "codebook_size"
+        case thresholdEMADeadCode = "threshold_ema_dead_code"
+        case positionEmbeddingType = "position_embedding_type"
+        case ropeTheta = "rope_theta"
+        case ropeType = "rope_type"
+        case layerNormType = "ln_type"
+        case vocoderAttentionHeads = "vocoder_attention_heads"
+        case vocoderAttentionWindowSize = "vocoder_attn_window_size"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        maxAudioSeconds = try container.decode(Int.self, forKey: .maxAudioSeconds)
+        strideSize = try container.decode(Int.self, forKey: .strideSize)
+        avgPooler = try container.decode(Int.self, forKey: .avgPooler)
+        dModel = try container.decode(Int.self, forKey: .dModel)
+        scaleEmbedding = try container.decode(Bool.self, forKey: .scaleEmbedding)
+        kernelSize = try container.decode(Int.self, forKey: .kernelSize)
+        activationFunction = try container.decode(String.self, forKey: .activationFunction)
+        encoderLayers = try container.decode(Int.self, forKey: .encoderLayers)
+        encoderSkipLayerID = try container.decodeIfPresent(Int.self, forKey: .encoderSkipLayerID)
+        encoderAttentionHeads = try container.decode(Int.self, forKey: .encoderAttentionHeads)
+        encoderFFNDim = try container.decode(Int.self, forKey: .encoderFFNDim)
+        encoderCausal = try container.decode(Bool.self, forKey: .encoderCausal)
+        encoderAttentionWindowSize = try container.decode([Int].self, forKey: .encoderAttentionWindowSize)
+        decoderLayers = try container.decode(Int.self, forKey: .decoderLayers)
+        decoderAttentionHeads = try container.decode(Int.self, forKey: .decoderAttentionHeads)
+        decoderFFNDim = try container.decode(Int.self, forKey: .decoderFFNDim)
+        decoderKernelSize = try container.decode(Int.self, forKey: .decoderKernelSize)
+        decoderStrideSize = try container.decode(Int.self, forKey: .decoderStrideSize)
+        decoderCausal = try container.decode(Bool.self, forKey: .decoderCausal)
+        decoderAttentionWindowSize = try container.decode([Int].self, forKey: .decoderAttentionWindowSize)
+        nfft = try container.decode(Int.self, forKey: .nfft)
+        vocoderDim = try container.decode(Int.self, forKey: .vocoderDim)
+        vocoderIntermediateDim = try container.decode(Int.self, forKey: .vocoderIntermediateDim)
+        vocoderNumLayers = try container.decode(Int.self, forKey: .vocoderNumLayers)
+        nMels = try container.decode(Int.self, forKey: .nMels)
+        samplingRate = try container.decode(Int.self, forKey: .samplingRate)
+        hopLength = try container.decode(Int.self, forKey: .hopLength)
+        windowSize = try container.decode(Int.self, forKey: .windowSize)
+        vocoderPadding = try container.decode(String.self, forKey: .vocoderPadding)
+        fmin = try container.decode(Int.self, forKey: .fmin)
+        fmax = try container.decodeIfPresent(Int.self, forKey: .fmax)
+        numQuantizers = try container.decode(Int.self, forKey: .numQuantizers)
+        codebookSize = try container.decode([Int].self, forKey: .codebookSize)
+        thresholdEMADeadCode = try container.decode(Int.self, forKey: .thresholdEMADeadCode)
+        positionEmbeddingType = try container.decode(String.self, forKey: .positionEmbeddingType)
+        ropeTheta = try container.decode(Int.self, forKey: .ropeTheta)
+        ropeType = try container.decode(String.self, forKey: .ropeType)
+        layerNormType = try container.decode(String.self, forKey: .layerNormType)
+        vocoderAttentionHeads = try container.decode(Int.self, forKey: .vocoderAttentionHeads)
+        vocoderAttentionWindowSize = try container.decode([Int].self, forKey: .vocoderAttentionWindowSize)
+
+        let globalQuant = try container.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantization)
+        let altGlobalQuant = try container.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantizationConfig)
+        quantization = globalQuant ?? altGlobalQuant
+    }
+
+    public func activeCodebookSizes(prefixCount: Int? = nil) -> [Int] {
+        guard let prefixCount else { return codebookSize }
+        return Array(codebookSize.prefix(max(0, prefixCount)))
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoMLXManifest.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoMLXManifest.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct MiMoMLXManifest: Decodable, Sendable {
+    public let format: String?
+    public let model: String?
+    public let precision: String?
+    public let weightFile: String?
+    public let indexFile: String?
+    public let configFile: String?
+    public let audioTokenizerDir: String?
+    public let audioTokenizerRepo: String?
+    public let bf16FallbackDir: String?
+    public let pythonLoader: String?
+
+    enum CodingKeys: String, CodingKey {
+        case format
+        case model
+        case precision
+        case weightFile = "weight_file"
+        case indexFile = "index_file"
+        case configFile = "config_file"
+        case audioTokenizerDir = "audio_tokenizer_dir"
+        case audioTokenizerRepo = "audio_tokenizer_repo"
+        case bf16FallbackDir = "bf16_fallback_dir"
+        case pythonLoader = "python_loader"
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoPromptBuilder.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoPromptBuilder.swift
@@ -1,0 +1,263 @@
+import Foundation
+import MLX
+import Tokenizers
+
+enum MiMoPromptLanguage {
+    case auto
+    case chinese
+    case english
+}
+
+struct MiMoSpecialTokens: Sendable {
+    let sosp: Int32
+    let eosp: Int32
+    let empty: Int32
+    let human: Int32?
+    let speechLM: Int32?
+    let sostm: Int32
+    let eostm: Int32
+    let eot: Int32
+    let imStart: Int32
+    let imEnd: Int32
+}
+
+struct MiMoInputSegment: Sendable {
+    var text: String?
+    var tokenIDs: [Int32]?
+    var audioTokens: [Int32]?
+    var addSospEosp = true
+
+    init(text: String) {
+        self.text = text
+        self.tokenIDs = nil
+        self.audioTokens = nil
+    }
+
+    init(tokenIDs: [Int32]) {
+        self.text = nil
+        self.tokenIDs = tokenIDs
+        self.audioTokens = nil
+    }
+
+    init(audioTokens: [Int32], addSospEosp: Bool = true) {
+        self.text = nil
+        self.tokenIDs = nil
+        self.audioTokens = audioTokens
+        self.addSospEosp = addSospEosp
+    }
+}
+
+enum MiMoPromptBuilder {
+    static let fixedChineseTemplateTokenIDs: [Int32] = [44063, 111268, 43815, 105359, 12857, 87335, 68805]
+    static let fixedChineseAssistantPrefixTokenIDs: [Int32] = [13708, 766, 1339, 522, 26865, 397, 27, 331, 7346, 29]
+    static let fixedEnglishAssistantPrefixTokenIDs: [Int32] = [13708, 766, 1339, 522, 26865, 397, 27, 974, 975, 678, 29]
+
+    static let chineseTemplates: [String] = [
+        "请将这段语音转换为文字",
+        "帮我识别这个音频文件中的内容",
+        "把这段录音转成文本",
+    ]
+
+    static let englishTemplates: [String] = [
+        "Please transcribe this audio file",
+        "Convert this speech recording to text",
+        "Transcribe the following voice message",
+    ]
+
+    static func resolveSpecialTokens(using tokenizer: any Tokenizer) throws -> MiMoSpecialTokens {
+        try .init(
+            sosp: singleTokenID("<|sosp|>", using: tokenizer),
+            eosp: singleTokenID("<|eosp|>", using: tokenizer),
+            empty: singleTokenID("<|empty|>", using: tokenizer),
+            human: try? singleTokenID("<|Human|>", using: tokenizer),
+            speechLM: try? singleTokenID("<|SpeechLM|>", using: tokenizer),
+            sostm: singleTokenID("<|sostm|>", using: tokenizer),
+            eostm: singleTokenID("<|eostm|>", using: tokenizer),
+            eot: singleTokenID("<|eot|>", using: tokenizer),
+            imStart: singleTokenID("<|im_start|>", using: tokenizer),
+            imEnd: singleTokenID("<|im_end|>", using: tokenizer)
+        )
+    }
+
+    static func buildASRPrompt(
+        tokenizer: any Tokenizer,
+        specialTokens: MiMoSpecialTokens,
+        audioTokens: [Int32],
+        groupSize: Int,
+        audioChannels: Int,
+        speechEmptyIDs: [Int32],
+        language: MiMoPromptLanguage = .auto
+    ) -> MLXArray {
+        let templateSegment: MiMoInputSegment
+        let assistantPrefixSegment: MiMoInputSegment
+        switch language {
+        case .chinese:
+            templateSegment = .init(tokenIDs: fixedChineseTemplateTokenIDs)
+            assistantPrefixSegment = .init(tokenIDs: fixedChineseAssistantPrefixTokenIDs)
+        case .english:
+            templateSegment = .init(text: englishTemplates[0])
+            assistantPrefixSegment = .init(tokenIDs: fixedEnglishAssistantPrefixTokenIDs)
+        case .auto:
+            templateSegment = .init(tokenIDs: fixedChineseTemplateTokenIDs)
+            assistantPrefixSegment = .init(
+                tokenIDs: tokenizer.encode(
+                    text: " thinking\n\n response\n<chinese>",
+                    addSpecialTokens: false
+                ).map(Int32.init)
+            )
+        }
+
+        let segments: [MiMoInputSegment] = [
+            .init(text: "<|im_start|>user\n"),
+            .init(audioTokens: audioTokens),
+            templateSegment,
+            .init(text: "<|im_end|>\n"),
+            .init(text: "<|im_start|>assistant\n"),
+            assistantPrefixSegment,
+        ]
+
+        return buildInputIDs(
+            segments: segments,
+            tokenizer: tokenizer,
+            specialTokens: specialTokens,
+            groupSize: groupSize,
+            audioChannels: audioChannels,
+            speechEmptyIDs: speechEmptyIDs
+        )
+    }
+
+    static func buildInputIDs(
+        segments: [MiMoInputSegment],
+        tokenizer: any Tokenizer,
+        specialTokens: MiMoSpecialTokens,
+        groupSize: Int,
+        audioChannels: Int,
+        speechEmptyIDs: [Int32]
+    ) -> MLXArray {
+        precondition(groupSize > 0)
+        precondition(audioChannels > 0)
+        precondition(speechEmptyIDs.count == audioChannels)
+
+        var rows = Array(repeating: [Int32](), count: audioChannels + 1)
+
+        for segment in segments {
+            let chunk = segmentRows(
+                for: segment,
+                tokenizer: tokenizer,
+                specialTokens: specialTokens,
+                groupSize: groupSize,
+                audioChannels: audioChannels,
+                speechEmptyIDs: speechEmptyIDs
+            )
+            for index in chunk.indices {
+                rows[index].append(contentsOf: chunk[index])
+            }
+        }
+
+        let time = rows[0].count
+        let flattened = rows.flatMap { $0 }
+        return MLXArray(flattened).reshaped([audioChannels + 1, time])
+    }
+
+    static func flattenPrompt(_ inputIDs: MLXArray) -> MLXArray {
+        precondition(inputIDs.ndim == 2)
+        return inputIDs.transposed(1, 0).reshaped([1, -1])
+    }
+
+    private static func segmentRows(
+        for segment: MiMoInputSegment,
+        tokenizer: any Tokenizer,
+        specialTokens: MiMoSpecialTokens,
+        groupSize: Int,
+        audioChannels: Int,
+        speechEmptyIDs: [Int32]
+    ) -> [[Int32]] {
+        if let audioTokens = segment.audioTokens {
+            return audioSegmentRows(
+                audioTokens: audioTokens,
+                specialTokens: specialTokens,
+                groupSize: groupSize,
+                audioChannels: audioChannels,
+                speechEmptyIDs: speechEmptyIDs,
+                addSospEosp: segment.addSospEosp
+            )
+        }
+
+        let tokenizedText = segment.tokenIDs
+            ?? tokenizer.encode(text: segment.text ?? "", addSpecialTokens: false).map(Int32.init)
+        let textRow = insertBetween(tokenizedText, fillCount: groupSize - 1, fillValue: -100)
+
+        var result = Array(repeating: [Int32](), count: audioChannels + 1)
+        result[0] = textRow
+        for channel in 0..<audioChannels {
+            result[channel + 1] = Array(repeating: speechEmptyIDs[channel], count: textRow.count)
+        }
+        return result
+    }
+
+    private static func audioSegmentRows(
+        audioTokens: [Int32],
+        specialTokens: MiMoSpecialTokens,
+        groupSize: Int,
+        audioChannels: Int,
+        speechEmptyIDs: [Int32],
+        addSospEosp: Bool
+    ) -> [[Int32]] {
+        precondition(audioTokens.count.isMultiple(of: audioChannels), "Audio tokens must align with audio channels.")
+
+        let sequenceLength = audioTokens.count / audioChannels
+        precondition(sequenceLength.isMultiple(of: groupSize), "Audio token length must be divisible by group size.")
+
+        let textLength = sequenceLength / groupSize
+        var textTokens = Array(repeating: specialTokens.empty, count: textLength)
+        if addSospEosp {
+            textTokens.insert(specialTokens.sosp, at: 0)
+            textTokens.append(specialTokens.eosp)
+        }
+        let textRow = insertBetween(textTokens, fillCount: groupSize - 1, fillValue: -100)
+
+        var audioRows = Array(repeating: [Int32](), count: audioChannels)
+        for timestep in 0..<sequenceLength {
+            for channel in 0..<audioChannels {
+                audioRows[channel].append(audioTokens[timestep * audioChannels + channel])
+            }
+        }
+
+        if addSospEosp {
+            for channel in 0..<audioChannels {
+                let boundary = Array(repeating: speechEmptyIDs[channel], count: groupSize)
+                audioRows[channel] = boundary + audioRows[channel] + boundary
+            }
+        }
+
+        var result = Array(repeating: [Int32](), count: audioChannels + 1)
+        result[0] = textRow
+        for channel in 0..<audioChannels {
+            result[channel + 1] = audioRows[channel]
+        }
+        return result
+    }
+
+    private static func singleTokenID(_ text: String, using tokenizer: any Tokenizer) throws -> Int32 {
+        let ids = tokenizer.encode(text: text, addSpecialTokens: false)
+        guard ids.count == 1 else {
+            throw NSError(
+                domain: "MiMoPromptBuilder",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Expected a single token for \(text), got \(ids.count)."]
+            )
+        }
+        return Int32(ids[0])
+    }
+
+    private static func insertBetween(_ tokens: [Int32], fillCount: Int, fillValue: Int32) -> [Int32] {
+        guard fillCount > 0, !tokens.isEmpty else { return tokens }
+
+        let expandedCount = tokens.count + tokens.count * fillCount
+        var result = Array(repeating: fillValue, count: expandedCount)
+        for (index, token) in tokens.enumerated() {
+            result[index * (fillCount + 1)] = token
+        }
+        return result
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoV2ASR.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoV2ASR.swift
@@ -1,0 +1,645 @@
+import Foundation
+import HuggingFace
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXAudioCore
+import Tokenizers
+
+private struct MiMoUncheckedSendableBox<T>: @unchecked Sendable {
+    let value: T
+}
+
+private struct MiMoTranscriptionResult {
+    let text: String
+    let promptTokens: Int
+    let generationTokens: Int
+    let promptTime: TimeInterval
+    let generationTime: TimeInterval
+    let totalTime: TimeInterval
+    let peakMemoryUsage: Double
+}
+
+public struct MiMoV2ASRAssets: Sendable {
+    public let modelDirectory: URL
+    public let tokenizerDirectory: URL
+    public let config: MiMoV2ASRConfig
+    public let tokenizerConfig: MiMoAudioTokenizerConfig
+    public let manifest: MiMoMLXManifest?
+}
+
+public final class MiMoV2ASRModel: STTGenerationModel {
+    public let assets: MiMoV2ASRAssets
+    let coreModel: MiMoV2ASRCore
+    let audioTokenizerModel: MiMoAudioTokenizerModel
+    public var tokenizer: Tokenizers.Tokenizer?
+    var specialTokens: MiMoSpecialTokens?
+
+    init(
+        assets: MiMoV2ASRAssets,
+        coreModel: MiMoV2ASRCore,
+        audioTokenizerModel: MiMoAudioTokenizerModel
+    ) {
+        self.assets = assets
+        self.coreModel = coreModel
+        self.audioTokenizerModel = audioTokenizerModel
+    }
+
+    public var config: MiMoV2ASRConfig { assets.config }
+    public var tokenizerConfig: MiMoAudioTokenizerConfig { assets.tokenizerConfig }
+
+    public var defaultGenerationParameters: STTGenerateParameters {
+        STTGenerateParameters(
+            maxTokens: 4096,
+            temperature: 0.0,
+            topP: 0.95,
+            topK: 0,
+            verbose: false,
+            language: nil,
+            chunkDuration: 30.0,
+            minChunkDuration: 1.0
+        )
+    }
+
+    public func generate(audio: MLXArray, generationParameters: STTGenerateParameters) -> STTOutput {
+        do {
+            let result = try transcribe(audio: audio, generationParameters: generationParameters)
+            return STTOutput(
+                text: result.text,
+                language: generationParameters.language,
+                promptTokens: result.promptTokens,
+                generationTokens: result.generationTokens,
+                totalTokens: result.promptTokens + result.generationTokens,
+                promptTps: Double(result.promptTokens) / max(result.promptTime, 0.001),
+                generationTps: Double(result.generationTokens) / max(result.generationTime, 0.001),
+                totalTime: result.totalTime,
+                peakMemoryUsage: result.peakMemoryUsage
+            )
+        } catch {
+            if generationParameters.verbose {
+                fputs("MiMo generation failed: \(error)\n", stderr)
+            }
+            return STTOutput(
+                text: "",
+                language: generationParameters.language,
+                totalTime: 0,
+                peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+            )
+        }
+    }
+
+    public func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> AsyncThrowingStream<STTGeneration, Error> {
+        let sendableModel = MiMoUncheckedSendableBox(value: self)
+        let sendableAudio = MiMoUncheckedSendableBox(value: audio)
+        return AsyncThrowingStream { continuation in
+            let task = Task.detached {
+                do {
+                    let result = try sendableModel.value.transcribe(
+                        audio: sendableAudio.value,
+                        generationParameters: generationParameters
+                    ) { tokenText in
+                        guard !tokenText.isEmpty else { return }
+                        continuation.yield(STTGeneration.token(tokenText))
+                    }
+
+                    let info = STTGenerationInfo(
+                        promptTokenCount: result.promptTokens,
+                        generationTokenCount: result.generationTokens,
+                        prefillTime: result.promptTime,
+                        generateTime: result.generationTime,
+                        tokensPerSecond: Double(result.generationTokens) / max(result.generationTime, 0.001),
+                        peakMemoryUsage: result.peakMemoryUsage
+                    )
+                    continuation.yield(.info(info))
+                    continuation.yield(
+                        .result(
+                            STTOutput(
+                                text: result.text,
+                                language: generationParameters.language,
+                                promptTokens: result.promptTokens,
+                                generationTokens: result.generationTokens,
+                                totalTokens: result.promptTokens + result.generationTokens,
+                                promptTps: Double(result.promptTokens) / max(result.promptTime, 0.001),
+                                generationTps: Double(result.generationTokens) / max(result.generationTime, 0.001),
+                                totalTime: result.totalTime,
+                                peakMemoryUsage: result.peakMemoryUsage
+                            )
+                        )
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    public static func loadAssets(
+        modelDirectory: URL,
+        tokenizerDirectory: URL? = nil,
+        cache: HubCache = .default
+    ) async throws -> MiMoV2ASRAssets {
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(MiMoV2ASRConfig.self, from: configData)
+
+        let manifest = try loadManifestIfPresent(in: modelDirectory)
+        let resolvedTokenizerDirectory = try await resolveTokenizerDirectory(
+            modelDirectory: modelDirectory,
+            explicitTokenizerDirectory: tokenizerDirectory,
+            manifest: manifest,
+            cache: cache
+        )
+
+        let tokenizerConfigURL = resolvedTokenizerDirectory.appendingPathComponent("config.json")
+        let tokenizerConfigData = try Data(contentsOf: tokenizerConfigURL)
+        let tokenizerConfig = try JSONDecoder().decode(MiMoAudioTokenizerConfig.self, from: tokenizerConfigData)
+
+        return MiMoV2ASRAssets(
+            modelDirectory: modelDirectory,
+            tokenizerDirectory: resolvedTokenizerDirectory,
+            config: config,
+            tokenizerConfig: tokenizerConfig,
+            manifest: manifest
+        )
+    }
+
+    public static func fromModelDirectory(
+        _ modelDirectory: URL,
+        tokenizerDirectory: URL? = nil,
+        cache: HubCache = .default
+    ) async throws -> MiMoV2ASRModel {
+        let assets = try await loadAssets(
+            modelDirectory: modelDirectory,
+            tokenizerDirectory: tokenizerDirectory,
+            cache: cache
+        )
+        let coreModel = try MiMoV2ASRCore.load(
+            modelDirectory: assets.modelDirectory,
+            config: assets.config
+        )
+        let audioTokenizerModel = try MiMoAudioTokenizerModel.load(
+            modelDirectory: assets.tokenizerDirectory,
+            config: assets.tokenizerConfig,
+            activeQuantizers: assets.config.audioChannels
+        )
+        let model = MiMoV2ASRModel(
+            assets: assets,
+            coreModel: coreModel,
+            audioTokenizerModel: audioTokenizerModel
+        )
+        model.tokenizer = try await AutoTokenizer.from(modelFolder: modelDirectory)
+        if let tokenizer = model.tokenizer {
+            model.specialTokens = try MiMoPromptBuilder.resolveSpecialTokens(using: tokenizer)
+        }
+        return model
+    }
+
+    public static func fromPretrained(
+        _ modelPath: String,
+        tokenizerPath: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> MiMoV2ASRModel {
+        let fileManager = FileManager.default
+        let expandedModelPath = (modelPath as NSString).expandingTildeInPath
+        let modelDirectory: URL
+        if fileManager.fileExists(atPath: expandedModelPath) {
+            modelDirectory = URL(fileURLWithPath: expandedModelPath)
+        } else {
+            guard let repoID = Repo.ID(rawValue: modelPath) else {
+                throw NSError(
+                    domain: "MiMoV2ASRModel",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID or local path: \(modelPath)"]
+                )
+            }
+            modelDirectory = try await ModelUtils.resolveOrDownloadModel(
+                repoID: repoID,
+                requiredExtension: "safetensors",
+                cache: cache
+            )
+        }
+
+        let explicitTokenizerDirectory: URL?
+        if let tokenizerPath {
+            let expandedTokenizerPath = (tokenizerPath as NSString).expandingTildeInPath
+            if fileManager.fileExists(atPath: expandedTokenizerPath) {
+                explicitTokenizerDirectory = URL(fileURLWithPath: expandedTokenizerPath)
+            } else if let tokenizerRepoID = Repo.ID(rawValue: tokenizerPath) {
+                explicitTokenizerDirectory = try await ModelUtils.resolveOrDownloadModel(
+                    repoID: tokenizerRepoID,
+                    requiredExtension: "safetensors",
+                    cache: cache
+                )
+            } else {
+                explicitTokenizerDirectory = URL(fileURLWithPath: expandedTokenizerPath)
+            }
+        } else {
+            explicitTokenizerDirectory = nil
+        }
+
+        return try await fromModelDirectory(
+            modelDirectory,
+            tokenizerDirectory: explicitTokenizerDirectory,
+            cache: cache
+        )
+    }
+
+    static func loadManifestIfPresent(in modelDirectory: URL) throws -> MiMoMLXManifest? {
+        let manifestURL = modelDirectory.appendingPathComponent("mlx_manifest.json")
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            return nil
+        }
+        let data = try Data(contentsOf: manifestURL)
+        return try JSONDecoder().decode(MiMoMLXManifest.self, from: data)
+    }
+
+    static func resolveTokenizerDirectory(
+        modelDirectory: URL,
+        explicitTokenizerDirectory: URL?,
+        manifest: MiMoMLXManifest?,
+        cache: HubCache = .default
+    ) async throws -> URL {
+        if let explicitTokenizerDirectory {
+            return explicitTokenizerDirectory.standardizedFileURL
+        }
+
+        if let manifestTokenizerDir = manifest?.audioTokenizerDir {
+            let candidate = modelDirectory
+                .appendingPathComponent(manifestTokenizerDir)
+                .standardizedFileURL
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        if let tokenizerRepo = manifest?.audioTokenizerRepo,
+           let tokenizerRepoID = Repo.ID(rawValue: tokenizerRepo) {
+            return try await ModelUtils.resolveOrDownloadModel(
+                repoID: tokenizerRepoID,
+                requiredExtension: "safetensors",
+                cache: cache
+            )
+        }
+
+        let sibling = modelDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("MiMo-Audio-Tokenizer")
+            .standardizedFileURL
+        if FileManager.default.fileExists(atPath: sibling.path) {
+            return sibling
+        }
+
+        throw NSError(
+            domain: "MiMoV2ASRModel",
+            code: 2,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Unable to resolve MiMo audio tokenizer directory from explicit path, manifest, tokenizer repo, or sibling directory."
+            ]
+        )
+    }
+
+    private func encodeAudioChunks(_ chunks: [MLXArray]) throws -> [Int32] {
+        var allCodes: [Int32] = []
+
+        for chunk in chunks {
+            let mel = MiMoAudioPreprocessing.computeLogMel(chunk)
+            let codes = audioTokenizerModel.encodeMel(mel, nQuantizers: config.audioChannels)
+            eval(codes)
+            allCodes.append(contentsOf: codes.asArray(Int32.self))
+        }
+
+        guard !allCodes.isEmpty else { return [] }
+
+        let frameCount = allCodes.count / config.audioChannels
+        let remainder = frameCount % config.groupSize
+        guard remainder != 0 else { return allCodes }
+
+        let padFrames = config.groupSize - remainder
+        let lastFrameStart = max(0, allCodes.count - config.audioChannels)
+        let lastFrame = Array(allCodes[lastFrameStart..<allCodes.count])
+        for _ in 0..<padFrames {
+            allCodes.append(contentsOf: lastFrame)
+        }
+        return allCodes
+    }
+
+    private func transcribePrompt(
+        _ prompt: MLXArray,
+        generationParameters: STTGenerateParameters,
+        specialTokens: MiMoSpecialTokens,
+        onPartialText: ((String) throws -> Void)? = nil
+    ) throws -> ([Int32], TimeInterval, TimeInterval) {
+        let prompt3D = prompt.expandedDimensions(axis: 0)
+        let globalCache = coreModel.makeGlobalCache()
+        let promptStart = Date()
+        let prefill = globalForward(prompt3D, cache: globalCache, specialTokens: specialTokens)
+        let promptTime = Date().timeIntervalSince(promptStart)
+
+        let generationStart = Date()
+        var nextTextToken = sampleTextToken(
+            logits: prefill.textLogits,
+            temperature: generationParameters.temperature
+        )
+        var nextLocalHidden = prefill.localHiddenStates
+        var generatedTextTokens: [Int32] = []
+        let stopTokens = Set([Int32(tokenizer?.eosTokenId ?? 0), specialTokens.eot])
+        var lastEmittedText = ""
+
+        for _ in 0..<generationParameters.maxTokens {
+            try Task.checkCancellation()
+
+            if stopTokens.contains(nextTextToken) {
+                break
+            }
+
+            generatedTextTokens.append(nextTextToken)
+            if let onPartialText, let tokenizer {
+                let decoded = cleanDecodedText(tokenizer.decode(tokens: generatedTextTokens.map(Int.init)))
+                let delta = incrementalTextDelta(previous: lastEmittedText, current: decoded)
+                if !delta.isEmpty {
+                    try onPartialText(delta)
+                }
+                lastEmittedText = decoded
+            }
+
+            let speechTokens: MLXArray
+            if nextTextToken == specialTokens.empty {
+                speechTokens = localForward(nextLocalHidden)
+            } else {
+                var perChannel: [Int32] = []
+                perChannel.reserveCapacity(config.groupSize * config.audioChannels)
+                for _ in 0..<config.groupSize {
+                    perChannel.append(contentsOf: config.parsedSpeechEmptyIDs.map(Int32.init))
+                }
+                speechTokens = MLXArray(perChannel).reshaped([config.groupSize, config.audioChannels])
+            }
+
+            let incremental = makeIncrementalInput(textToken: nextTextToken, speechTokens: speechTokens)
+            let step = globalForward(incremental, cache: globalCache, specialTokens: specialTokens)
+            nextTextToken = sampleTextToken(
+                logits: step.textLogits,
+                temperature: generationParameters.temperature
+            )
+            nextLocalHidden = step.localHiddenStates
+        }
+
+        return (generatedTextTokens, promptTime, Date().timeIntervalSince(generationStart))
+    }
+
+    private func globalForward(
+        _ inputIDs: MLXArray,
+        cache: [KVCache],
+        specialTokens: MiMoSpecialTokens
+    ) -> (textLogits: MLXArray, localHiddenStates: MLXArray) {
+        let inputEmbeddings = prepareInputEmbeddings(inputIDs, specialTokens: specialTokens)
+        let hiddenStates = coreModel.model(inputEmbeddings: inputEmbeddings, cache: cache)
+        let lastHiddenState = hiddenStates[0..., (hiddenStates.shape[1] - 1) ..< hiddenStates.shape[1], 0...]
+        let textLogits = coreModel.lmHead(lastHiddenState)
+        let localHiddenStates = coreModel.hiddenStatesDowncast(lastHiddenState)
+        eval(textLogits, localHiddenStates)
+        return (textLogits, localHiddenStates)
+    }
+
+    private func prepareInputEmbeddings(
+        _ inputIDs: MLXArray,
+        specialTokens: MiMoSpecialTokens
+    ) -> MLXArray {
+        let batch = inputIDs.shape[0]
+        let audioChannels = config.audioChannels
+        let groupSize = config.groupSize
+        let time = inputIDs.shape[2]
+        let groups = time / groupSize
+
+        let textInputIDs = inputIDs[0..., 0, .stride(from: 0, by: groupSize)]
+        let speechInputIDs = inputIDs[0..., 1..., 0...]
+            .reshaped([batch, audioChannels, groups, groupSize])
+            .transposed(0, 2, 1, 3)
+
+        let isSpeech = textInputIDs .== specialTokens.empty
+        var speechEmbeddings = MLXArray.zeros([batch, groups, groupSize, config.inputLocalDim], type: Float.self)
+
+        for channel in 0..<audioChannels {
+            let currentSpeechIDs = speechInputIDs[0..., 0..., channel, 0...]
+            var currentEmbeddings = coreModel.speechEmbeddings[channel](currentSpeechIDs)
+            let mask = currentSpeechIDs .== Int32(config.parsedSpeechEmptyIDs[channel])
+            currentEmbeddings = MLX.where(
+                mask.expandedDimensions(axis: -1),
+                MLXArray.zeros(currentEmbeddings.shape, dtype: currentEmbeddings.dtype),
+                currentEmbeddings
+            )
+            speechEmbeddings = speechEmbeddings + currentEmbeddings
+        }
+
+        speechEmbeddings = speechEmbeddings * isSpeech.expandedDimensions(axis: -1).expandedDimensions(axis: -1).asType(.float32)
+
+        let localInput = speechEmbeddings.reshaped([batch * groups, groupSize, config.inputLocalDim])
+        var encodedSpeech = coreModel.inputLocalTransformer(inputEmbeddings: localInput)
+        encodedSpeech = encodedSpeech.reshaped([batch, groups, groupSize, config.inputLocalDim])
+        encodedSpeech = encodedSpeech * isSpeech.expandedDimensions(axis: -1).expandedDimensions(axis: -1).asType(.float32)
+
+        let groupedSpeech = coreModel.speechGroupDowncast(
+            encodedSpeech.reshaped([batch, groups, config.inputLocalDim * groupSize])
+        )
+
+        var textEmbeddings = coreModel.textEmbedding(textInputIDs)
+        let textMask = textInputIDs .== specialTokens.empty
+        textEmbeddings = MLX.where(
+            textMask.expandedDimensions(axis: -1),
+            MLXArray.zeros(textEmbeddings.shape, dtype: textEmbeddings.dtype),
+            textEmbeddings
+        )
+
+        let combined = textEmbeddings + groupedSpeech
+        eval(combined)
+        return combined
+    }
+
+    private func localForward(_ localEmbeddings: MLXArray) -> MLXArray {
+        let delayIterations = config.groupSize + (config.parsedDelayPattern.max() ?? 0)
+        let localCache = coreModel.makeLocalCache()
+        var currentEmbeddings = localEmbeddings
+        var tokens = [Int32](
+            repeating: 0,
+            count: config.groupSize * config.audioChannels
+        )
+
+        for step in 0..<delayIterations {
+            let hiddenStates = coreModel.localTransformer(inputEmbeddings: currentEmbeddings, cache: localCache)
+            let lastHiddenState = hiddenStates[0..., (hiddenStates.shape[1] - 1) ..< hiddenStates.shape[1], 0...]
+            var nextEmbeddings = MLXArray.zeros(currentEmbeddings.shape, dtype: currentEmbeddings.dtype)
+
+            for channel in 0..<config.audioChannels {
+                let start = config.parsedDelayPattern[channel]
+                let end = start + config.groupSize
+                guard start <= step, step < end else { continue }
+
+                let logits = coreModel.localLogits(channel: channel, hiddenStates: lastHiddenState)
+                let token = sampleSpeechToken(
+                    logits: logits[0..., -1, 0...],
+                    emptyTokenID: Int32(config.parsedSpeechEmptyIDs[channel])
+                )
+                let offset = (step - start) * config.audioChannels + channel
+                tokens[offset] = token
+
+                let tokenArray = MLXArray([token]).reshaped([1, 1])
+                nextEmbeddings = nextEmbeddings + coreModel.speechEmbeddings[channel](tokenArray)
+            }
+
+            currentEmbeddings = nextEmbeddings
+        }
+
+        return MLXArray(tokens).reshaped([config.groupSize, config.audioChannels])
+    }
+
+    private func makeIncrementalInput(textToken: Int32, speechTokens: MLXArray) -> MLXArray {
+        let textRow = [Int32](repeating: textToken, count: config.groupSize)
+        let speech = speechTokens.asArray(Int32.self)
+
+        var flattened: [Int32] = []
+        flattened.reserveCapacity((config.audioChannels + 1) * config.groupSize)
+        flattened.append(contentsOf: textRow)
+        for channel in 0..<config.audioChannels {
+            for step in 0..<config.groupSize {
+                flattened.append(speech[step * config.audioChannels + channel])
+            }
+        }
+
+        return MLXArray(flattened).reshaped([1, config.audioChannels + 1, config.groupSize])
+    }
+
+    private func sampleTextToken(logits: MLXArray, temperature: Float) -> Int32 {
+        let lastLogits = logits[0..., -1, 0...]
+        if temperature <= 0 {
+            return lastLogits.argMax(axis: -1).item(Int32.self)
+        }
+        let sampled = categorical((lastLogits / temperature).expandedDimensions(axis: 0))
+        return sampled.item(Int32.self)
+    }
+
+    private func sampleSpeechToken(logits: MLXArray, emptyTokenID: Int32) -> Int32 {
+        let filtered = suppressToken(logits, tokenID: emptyTokenID)
+        let scaled = filtered / MLXArray(0.9)
+        let nucleus = applyTopP(scaled, topP: 0.95)
+        let sampled = categorical(nucleus)
+        return sampled.item(Int32.self)
+    }
+
+    private func suppressToken(_ logits: MLXArray, tokenID: Int32) -> MLXArray {
+        let indices = MLXArray([tokenID]).reshaped([1, 1])
+        let values = MLXArray.full([1, 1], values: MLXArray(-Float.infinity), dtype: logits.dtype)
+        return putAlong(logits, indices, values: values, axis: -1)
+    }
+
+    private func applyTopP(_ logits: MLXArray, topP: Float) -> MLXArray {
+        guard topP > 0, topP < 1 else { return logits }
+
+        let vocabularySize = logits.dim(logits.ndim - 1)
+        guard vocabularySize > 1 else { return logits }
+
+        let logProbabilities = logSoftmax(logits, axis: -1)
+        let sortedIndices = argSort(logProbabilities, axis: -1)
+        let sortedProbabilities = exp(takeAlong(logProbabilities, sortedIndices, axis: -1))
+        let cumulativeProbabilities = MLX.cumsum(sortedProbabilities, axis: -1)
+
+        let positions = MLXArray(0 ..< vocabularySize).reshaped([1, -1]).asType(.int32)
+        let inverseIndices = putAlong(
+            MLXArray.zeros(sortedIndices.shape, type: Int32.self),
+            sortedIndices.asType(Int32.self),
+            values: positions,
+            axis: -1
+        )
+        let cumulativeOriginalOrder = takeAlong(cumulativeProbabilities, inverseIndices, axis: -1)
+        return MLX.where(
+            cumulativeOriginalOrder .> MLXArray(1 - topP),
+            logits,
+            MLXArray(-Float.infinity).asType(logits.dtype)
+        )
+    }
+
+    private func promptLanguage(from language: String?) -> MiMoPromptLanguage {
+        guard let language else { return .auto }
+        switch language.lowercased() {
+        case "zh", "zh-cn", "chinese", "mandarin":
+            return .chinese
+        case "en", "en-us", "english":
+            return .english
+        default:
+            return .auto
+        }
+    }
+
+    private func cleanDecodedText(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "<|empty|>", with: "")
+            .replacingOccurrences(of: "<|eot|>", with: "")
+            .replacingOccurrences(of: "<|eostm|>", with: "")
+            .replacingOccurrences(of: "<chinese>", with: "")
+            .replacingOccurrences(of: "<english>", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func transcribe(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters,
+        onPartialText: ((String) throws -> Void)? = nil
+    ) throws -> MiMoTranscriptionResult {
+        guard let tokenizer, let specialTokens else {
+            throw STTError.modelNotInitialized("Tokenizer or special tokens not loaded")
+        }
+
+        let startTime = Date()
+        let waveform = MiMoAudioPreprocessing.normalizeWaveform(audio)
+        let chunks = MiMoAudioPreprocessing.splitIntoChunks(
+            waveform,
+            sampleRate: MiMoAudioPreprocessing.targetSampleRate
+        )
+        let audioTokens = try encodeAudioChunks(chunks)
+        let promptLanguage = promptLanguage(from: generationParameters.language)
+        let prompt = MiMoPromptBuilder.buildASRPrompt(
+            tokenizer: tokenizer,
+            specialTokens: specialTokens,
+            audioTokens: audioTokens,
+            groupSize: config.groupSize,
+            audioChannels: config.audioChannels,
+            speechEmptyIDs: config.parsedSpeechEmptyIDs.map(Int32.init),
+            language: promptLanguage
+        )
+
+        let (generated, promptTime, generationTime) = try transcribePrompt(
+            prompt,
+            generationParameters: generationParameters,
+            specialTokens: specialTokens,
+            onPartialText: onPartialText
+        )
+        let totalTime = Date().timeIntervalSince(startTime)
+
+        Memory.clearCache()
+
+        return MiMoTranscriptionResult(
+            text: cleanDecodedText(tokenizer.decode(tokens: generated.map(Int.init))),
+            promptTokens: prompt.shape[1],
+            generationTokens: generated.count,
+            promptTime: promptTime,
+            generationTime: generationTime,
+            totalTime: totalTime,
+            peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+        )
+    }
+
+    private func incrementalTextDelta(previous: String, current: String) -> String {
+        guard !current.isEmpty else { return "" }
+        guard current.hasPrefix(previous) else {
+            return current == previous ? "" : current
+        }
+        return String(current.dropFirst(previous.count))
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoV2ASRConfig.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoV2ASRConfig.swift
@@ -1,0 +1,249 @@
+import Foundation
+import MLXLMCommon
+
+private func decodeStringEncodedInts(
+    from container: KeyedDecodingContainer<MiMoV2ASRConfig.CodingKeys>,
+    key: MiMoV2ASRConfig.CodingKeys,
+    defaultValue: String
+) throws -> String {
+    if let stringValue = try container.decodeIfPresent(String.self, forKey: key) {
+        return stringValue
+    }
+    if let intValue = try container.decodeIfPresent(Int.self, forKey: key) {
+        return String(intValue)
+    }
+    return defaultValue
+}
+
+public struct MiMoV2ASRAudioConfig: Codable, Sendable {
+    public let tokenizerVersion: String?
+    public let speechVocabSize: String
+    public let speechZeroembIdx: String
+    public let groupSize: Int
+    public let audioChannels: Int
+    public let inputLocalLayers: Int
+    public let inputLocalDim: Int
+    public let inputFullAttention: Bool
+    public let inputLocalAttentionHeads: Int
+    public let inputLocalHeadDim: Int
+    public let inputLocalIntermediateSize: Int
+    public let inputLocalHiddenDropout: Float
+    public let outputHiddenSize: Int
+    public let ropeTheta: Float
+    public let partialRotaryFactor: Float
+    public let projectionLayers: Int
+    public let addPostNorm: Bool
+    public let audioSegmentSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case tokenizerVersion = "tokenizer_version"
+        case speechVocabSize = "speech_vocab_size"
+        case speechZeroembIdx = "speech_zeroemb_idx"
+        case groupSize = "group_size"
+        case audioChannels = "audio_channels"
+        case inputLocalLayers = "input_local_layers"
+        case inputLocalDim = "input_local_dim"
+        case inputFullAttention = "input_full_attention"
+        case inputLocalAttentionHeads = "input_local_attn_heads"
+        case inputLocalHeadDim = "input_local_head_dim"
+        case inputLocalIntermediateSize = "input_local_intermediate_size"
+        case inputLocalHiddenDropout = "input_local_hidden_dropout"
+        case outputHiddenSize = "out_hidden_size"
+        case ropeTheta = "rope_theta"
+        case partialRotaryFactor = "partial_rotary_factor"
+        case projectionLayers = "projection_layers"
+        case addPostNorm = "add_post_norm"
+        case audioSegmentSize = "audio_segment_size"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tokenizerVersion = try container.decodeIfPresent(String.self, forKey: .tokenizerVersion)
+        speechVocabSize = try container.decodeIfPresent(String.self, forKey: .speechVocabSize) ?? "1025-1025-129-129-129-129-129-129"
+        speechZeroembIdx = try container.decodeIfPresent(String.self, forKey: .speechZeroembIdx) ?? "1024-1024-128-128-128-128-128-128"
+        groupSize = try container.decodeIfPresent(Int.self, forKey: .groupSize) ?? 4
+        audioChannels = try container.decodeIfPresent(Int.self, forKey: .audioChannels) ?? 8
+        inputLocalLayers = try container.decodeIfPresent(Int.self, forKey: .inputLocalLayers) ?? 6
+        inputLocalDim = try container.decodeIfPresent(Int.self, forKey: .inputLocalDim) ?? 1024
+        inputFullAttention = try container.decodeIfPresent(Bool.self, forKey: .inputFullAttention) ?? true
+        inputLocalAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .inputLocalAttentionHeads) ?? 64
+        inputLocalHeadDim = try container.decodeIfPresent(Int.self, forKey: .inputLocalHeadDim) ?? 16
+        inputLocalIntermediateSize = try container.decodeIfPresent(Int.self, forKey: .inputLocalIntermediateSize) ?? 4096
+        inputLocalHiddenDropout = try container.decodeIfPresent(Float.self, forKey: .inputLocalHiddenDropout) ?? 0.1
+        outputHiddenSize = try container.decodeIfPresent(Int.self, forKey: .outputHiddenSize) ?? 4096
+        ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 640_000
+        partialRotaryFactor = try container.decodeIfPresent(Float.self, forKey: .partialRotaryFactor) ?? 1.0
+        projectionLayers = try container.decodeIfPresent(Int.self, forKey: .projectionLayers) ?? 1
+        addPostNorm = try container.decodeIfPresent(Bool.self, forKey: .addPostNorm) ?? true
+        audioSegmentSize = try container.decodeIfPresent(Int.self, forKey: .audioSegmentSize) ?? 6000
+    }
+
+    public var parsedSpeechVocabSizes: [Int] {
+        speechVocabSize.split(separator: "-").compactMap { Int($0) }
+    }
+
+    public var parsedSpeechEmptyIDs: [Int] {
+        speechZeroembIdx.split(separator: "-").compactMap { Int($0) }
+    }
+}
+
+public struct MiMoV2ASRConfig: Decodable, Sendable {
+    public let architectures: [String]
+    public let modelType: String
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let hiddenAct: String
+    public let maxPositionEmbeddings: Int
+    public let vocabSize: Int
+    public let ropeTheta: Float
+    public let rmsNormEps: Float
+    public let attentionBias: Bool
+    public let attentionDropout: Float
+    public let useCache: Bool
+    public let tieWordEmbeddings: Bool
+
+    public let groupSize: Int
+    public let audioChannels: Int
+    public let delayPattern: String
+    public let speechVocabSize: String
+    public let speechZeroembIdx: String
+    public let localDim: Int
+    public let localLayers: Int
+    public let localAttentionHeads: Int
+    public let localFFNDim: Int
+    public let localAttentionDropout: Float
+    public let inputLocalLayers: Int
+    public let inputLocalDim: Int
+    public let inputFullAttention: Bool
+    public let nRVQ: Int
+    public let addInputLocalTransformer: Bool
+    public let addSpeechSOSPEOSP: Bool
+    public let audioConfig: MiMoV2ASRAudioConfig?
+
+    public var quantization: BaseConfiguration.Quantization?
+    public var perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    enum CodingKeys: String, CodingKey {
+        case architectures
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case hiddenAct = "hidden_act"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case vocabSize = "vocab_size"
+        case ropeTheta = "rope_theta"
+        case rmsNormEps = "rms_norm_eps"
+        case attentionBias = "attention_bias"
+        case attentionDropout = "attention_dropout"
+        case useCache = "use_cache"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case groupSize = "group_size"
+        case audioChannels = "audio_channels"
+        case delayPattern = "delay_pattern"
+        case speechVocabSize = "speech_vocab_size"
+        case speechZeroembIdx = "speech_zeroemb_idx"
+        case localDim = "local_dim"
+        case localLayers = "local_layers"
+        case localAttentionHeads = "local_attn_heads"
+        case localFFNDim = "local_ffn_dim"
+        case localAttentionDropout = "local_attn_dropout"
+        case inputLocalLayers = "input_local_layers"
+        case inputLocalDim = "input_local_dim"
+        case inputFullAttention = "input_full_attention"
+        case nRVQ = "n_rvq"
+        case addInputLocalTransformer = "add_input_local_transformer"
+        case addSpeechSOSPEOSP = "add_speech_sosp_eosp"
+        case audioConfig = "audio_config"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "qwen2"
+        hiddenSize = try container.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 4096
+        intermediateSize = try container.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 11_008
+        numHiddenLayers = try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 36
+        numAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 32
+        numKeyValueHeads = try container.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 8
+        headDim = try container.decodeIfPresent(Int.self, forKey: .headDim) ?? 128
+        hiddenAct = try container.decodeIfPresent(String.self, forKey: .hiddenAct) ?? "silu"
+        maxPositionEmbeddings = try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 8192
+        vocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 151_680
+        ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 640_000
+        rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? true
+        attentionDropout = try container.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? 0.0
+        useCache = try container.decodeIfPresent(Bool.self, forKey: .useCache) ?? true
+        tieWordEmbeddings = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+
+        groupSize = try container.decodeIfPresent(Int.self, forKey: .groupSize) ?? 4
+        audioChannels = try container.decodeIfPresent(Int.self, forKey: .audioChannels) ?? 8
+        delayPattern = try decodeStringEncodedInts(
+            from: container,
+            key: .delayPattern,
+            defaultValue: "0-1-2-3-4-5-6-7"
+        )
+        speechVocabSize = try decodeStringEncodedInts(
+            from: container,
+            key: .speechVocabSize,
+            defaultValue: "1025-1025-129-129-129-129-129-129"
+        )
+        speechZeroembIdx = try decodeStringEncodedInts(
+            from: container,
+            key: .speechZeroembIdx,
+            defaultValue: "1024-1024-128-128-128-128-128-128"
+        )
+        localDim = try container.decodeIfPresent(Int.self, forKey: .localDim) ?? 1024
+        localLayers = try container.decodeIfPresent(Int.self, forKey: .localLayers) ?? 16
+        localAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .localAttentionHeads) ?? 64
+        localFFNDim = try container.decodeIfPresent(Int.self, forKey: .localFFNDim) ?? 4096
+        localAttentionDropout = try container.decodeIfPresent(Float.self, forKey: .localAttentionDropout) ?? 0.1
+        inputLocalLayers = try container.decodeIfPresent(Int.self, forKey: .inputLocalLayers) ?? 6
+        inputLocalDim = try container.decodeIfPresent(Int.self, forKey: .inputLocalDim) ?? 1024
+        inputFullAttention = try container.decodeIfPresent(Bool.self, forKey: .inputFullAttention) ?? true
+        nRVQ = try container.decodeIfPresent(Int.self, forKey: .nRVQ) ?? 20
+        addInputLocalTransformer = try container.decodeIfPresent(Bool.self, forKey: .addInputLocalTransformer) ?? true
+        addSpeechSOSPEOSP = try container.decodeIfPresent(Bool.self, forKey: .addSpeechSOSPEOSP) ?? false
+        audioConfig = try container.decodeIfPresent(MiMoV2ASRAudioConfig.self, forKey: .audioConfig)
+
+        let baseConfig = try? BaseConfiguration(from: decoder)
+        let globalQuant = try container.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantization)
+        let altGlobalQuant = try container.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantizationConfig)
+        quantization = globalQuant ?? altGlobalQuant
+        perLayerQuantization = baseConfig?.perLayerQuantization
+    }
+
+    public var architectureName: String? {
+        architectures.first
+    }
+
+    public var isMiMoV2ASR: Bool {
+        architectureName == "MiMoV2ASRForCausalLM"
+    }
+
+    public var parsedSpeechVocabSizes: [Int] {
+        speechVocabSize.split(separator: "-").compactMap { Int($0) }
+    }
+
+    public var parsedSpeechEmptyIDs: [Int] {
+        speechZeroembIdx.split(separator: "-").compactMap { Int($0) }
+    }
+
+    public var parsedDelayPattern: [Int] {
+        delayPattern.split(separator: "-").compactMap { Int($0) }
+    }
+
+    public var activeSpeechCodebookSizes: [Int] {
+        Array(parsedSpeechVocabSizes.prefix(audioChannels))
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoV2ASRCore.swift
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/MiMoV2ASRCore.swift
@@ -1,0 +1,307 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+struct MiMoTransformerConfiguration: Sendable {
+    let hiddenSize: Int
+    let hiddenLayers: Int
+    let intermediateSize: Int
+    let attentionHeads: Int
+    let kvHeads: Int
+    let vocabularySize: Int?
+    let rmsNormEps: Float
+    let ropeTheta: Float
+    let attentionBias: Bool
+    let useCausalMask: Bool
+}
+
+private final class MiMoAttention: Module {
+    let config: MiMoTransformerConfiguration
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var wq: Linear
+    @ModuleInfo(key: "k_proj") var wk: Linear
+    @ModuleInfo(key: "v_proj") var wv: Linear
+    @ModuleInfo(key: "o_proj") var wo: Linear
+
+    let rope: RoPE
+
+    init(_ config: MiMoTransformerConfiguration) {
+        self.config = config
+
+        let headDim = config.hiddenSize / config.attentionHeads
+        self.scale = pow(Float(headDim), -0.5)
+
+        _wq.wrappedValue = Linear(
+            config.hiddenSize,
+            config.attentionHeads * headDim,
+            bias: config.attentionBias
+        )
+        _wk.wrappedValue = Linear(
+            config.hiddenSize,
+            config.kvHeads * headDim,
+            bias: config.attentionBias
+        )
+        _wv.wrappedValue = Linear(
+            config.hiddenSize,
+            config.kvHeads * headDim,
+            bias: config.attentionBias
+        )
+        _wo.wrappedValue = Linear(config.attentionHeads * headDim, config.hiddenSize, bias: false)
+
+        self.rope = RoPE(dimensions: headDim, traditional: false, base: config.ropeTheta)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        queries = queries
+            .reshaped(batch, sequence, config.attentionHeads, -1)
+            .transposed(0, 2, 1, 3)
+        keys = keys
+            .reshaped(batch, sequence, config.kvHeads, -1)
+            .transposed(0, 2, 1, 3)
+        values = values
+            .reshaped(batch, sequence, config.kvHeads, -1)
+            .transposed(0, 2, 1, 3)
+
+        queries = applyRotaryPosition(rope, to: queries, cache: cache)
+        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+
+        let output = attentionWithCacheUpdate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            cache: cache,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(batch, sequence, -1)
+
+        return wo(output)
+    }
+}
+
+private final class MiMoMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+
+    init(config: MiMoTransformerConfiguration) {
+        _gate.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _down.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        _up.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(silu(gate(x)) * up(x))
+    }
+}
+
+private final class MiMoTransformerBlock: Module {
+    @ModuleInfo(key: "self_attn") var attention: MiMoAttention
+    let mlp: MiMoMLP
+
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(_ config: MiMoTransformerConfiguration) {
+        _attention.wrappedValue = MiMoAttention(config)
+        self.mlp = MiMoMLP(config: config)
+        _inputLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        var residual = attention(inputLayerNorm(x), mask: mask, cache: cache)
+        let hidden = x + residual
+        residual = mlp(postAttentionLayerNorm(hidden))
+        return hidden + residual
+    }
+}
+
+final class MiMoTransformerBackbone: Module, KVCacheDimensionProvider {
+    let config: MiMoTransformerConfiguration
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding?
+    fileprivate let layers: [MiMoTransformerBlock]
+    let norm: RMSNorm
+
+    var kvHeads: [Int] {
+        (0..<config.hiddenLayers).map { _ in config.kvHeads }
+    }
+
+    init(_ config: MiMoTransformerConfiguration, includeEmbeddings: Bool) {
+        self.config = config
+        if includeEmbeddings, let vocabularySize = config.vocabularySize {
+            _embedTokens.wrappedValue = Embedding(
+                embeddingCount: vocabularySize,
+                dimensions: config.hiddenSize
+            )
+        } else {
+            _embedTokens.wrappedValue = nil
+        }
+        self.layers = (0..<config.hiddenLayers).map { _ in MiMoTransformerBlock(config) }
+        self.norm = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ inputIDs: MLXArray? = nil,
+        inputEmbeddings: MLXArray? = nil,
+        cache: [KVCache]? = nil
+    ) -> MLXArray {
+        let hidden: MLXArray
+        if let inputEmbeddings {
+            hidden = inputEmbeddings
+        } else if let inputIDs, let embedTokens {
+            hidden = embedTokens(inputIDs)
+        } else {
+            fatalError("MiMoTransformerBackbone requires input IDs with embeddings or explicit input embeddings.")
+        }
+
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode
+        if config.useCausalMask {
+            mask = createAttentionMask(h: hidden, cache: cache?.first)
+        } else {
+            mask = .none
+        }
+
+        var output = hidden
+        for (index, layer) in layers.enumerated() {
+            output = layer(output, mask: mask, cache: cache?[index])
+        }
+        return norm(output)
+    }
+}
+
+final class MiMoV2ASRCore: Module, BaseLanguageModel {
+    let config: MiMoV2ASRConfig
+
+    @ModuleInfo(key: "model") var model: MiMoTransformerBackbone
+    @ModuleInfo(key: "local_transformer") var localTransformer: MiMoTransformerBackbone
+    @ModuleInfo(key: "input_local_transformer") var inputLocalTransformer: MiMoTransformerBackbone
+    @ModuleInfo(key: "local_transformer_lm_heads") var localTransformerLMHeads: [Linear]
+    @ModuleInfo(key: "speech_embeddings") var speechEmbeddings: [Embedding]
+    @ModuleInfo(key: "speech_group_downcast") var speechGroupDowncast: Linear
+    @ModuleInfo(key: "hidden_states_downcast") var hiddenStatesDowncast: Linear
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    init(config: MiMoV2ASRConfig) {
+        self.config = config
+
+        let globalConfig = MiMoTransformerConfiguration(
+            hiddenSize: config.hiddenSize,
+            hiddenLayers: config.numHiddenLayers,
+            intermediateSize: config.intermediateSize,
+            attentionHeads: config.numAttentionHeads,
+            kvHeads: config.numKeyValueHeads,
+            vocabularySize: config.vocabSize,
+            rmsNormEps: config.rmsNormEps,
+            ropeTheta: config.ropeTheta,
+            attentionBias: config.attentionBias,
+            useCausalMask: true
+        )
+        _model.wrappedValue = MiMoTransformerBackbone(globalConfig, includeEmbeddings: true)
+
+        let localConfig = MiMoTransformerConfiguration(
+            hiddenSize: config.localDim,
+            hiddenLayers: config.localLayers,
+            intermediateSize: config.localFFNDim,
+            attentionHeads: config.localAttentionHeads,
+            kvHeads: config.localAttentionHeads,
+            vocabularySize: nil,
+            rmsNormEps: config.rmsNormEps,
+            ropeTheta: config.ropeTheta,
+            attentionBias: config.attentionBias,
+            useCausalMask: true
+        )
+        _localTransformer.wrappedValue = MiMoTransformerBackbone(localConfig, includeEmbeddings: false)
+
+        let inputLocalConfig = MiMoTransformerConfiguration(
+            hiddenSize: config.inputLocalDim,
+            hiddenLayers: config.inputLocalLayers,
+            intermediateSize: config.inputLocalDim * 4,
+            attentionHeads: config.localAttentionHeads,
+            kvHeads: config.localAttentionHeads,
+            vocabularySize: nil,
+            rmsNormEps: config.rmsNormEps,
+            ropeTheta: config.ropeTheta,
+            attentionBias: config.attentionBias,
+            useCausalMask: !config.inputFullAttention
+        )
+        _inputLocalTransformer.wrappedValue = MiMoTransformerBackbone(inputLocalConfig, includeEmbeddings: false)
+
+        _localTransformerLMHeads.wrappedValue = config.activeSpeechCodebookSizes.map {
+            Linear(config.localDim, $0, bias: false)
+        }
+        _speechEmbeddings.wrappedValue = config.activeSpeechCodebookSizes.enumerated().map { index, size in
+            Embedding(
+                embeddingCount: size,
+                dimensions: config.inputLocalDim
+            )
+        }
+        _speechGroupDowncast.wrappedValue = Linear(
+            config.inputLocalDim * config.groupSize,
+            config.hiddenSize,
+            bias: false
+        )
+        _hiddenStatesDowncast.wrappedValue = Linear(config.hiddenSize, config.localDim, bias: false)
+        _lmHead.wrappedValue = Linear(config.hiddenSize, config.vocabSize, bias: false)
+    }
+
+    func makeGlobalCache() -> [KVCache] {
+        (0..<model.kvHeads.count).map { _ in KVCacheSimple() }
+    }
+
+    func makeLocalCache() -> [KVCache] {
+        (0..<localTransformer.kvHeads.count).map { _ in KVCacheSimple() }
+    }
+
+    func textEmbedding(_ inputIDs: MLXArray) -> MLXArray {
+        guard let embedTokens = model.embedTokens else {
+            fatalError("MiMoV2ASRCore global embed_tokens are not initialized.")
+        }
+        return embedTokens(inputIDs)
+    }
+
+    func textLogits(_ hiddenStates: MLXArray) -> MLXArray {
+        lmHead(hiddenStates)
+    }
+
+    func localLogits(channel: Int, hiddenStates: MLXArray) -> MLXArray {
+        localTransformerLMHeads[channel](hiddenStates)
+    }
+
+    static func load(
+        modelDirectory: URL,
+        config: MiMoV2ASRConfig
+    ) throws -> MiMoV2ASRCore {
+        let model = MiMoV2ASRCore(config: config)
+        try loadWeights(
+            modelDirectory: modelDirectory,
+            model: model,
+            quantization: config.quantization,
+            perLayerQuantization: config.perLayerQuantization
+        )
+        return model
+    }
+
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights
+    }
+}

--- a/Sources/MLXAudioSTT/Models/MiMoV2ASR/README.md
+++ b/Sources/MLXAudioSTT/Models/MiMoV2ASR/README.md
@@ -1,0 +1,38 @@
+# MiMo-V2.5-ASR
+
+MLX Swift implementation of XiaomiMiMo's MiMo-V2.5-ASR speech-to-text model.
+
+[Hugging Face Model Repo](https://huggingface.co/mlx-community/MiMo-V2.5-ASR-MLX)
+
+## Swift Example
+
+```swift
+import MLXAudioCore
+import MLXAudioSTT
+
+let (_, audio) = try loadAudioArray(from: audioURL)
+
+let model = try await MiMoV2ASRModel.fromPretrained("mlx-community/MiMo-V2.5-ASR-MLX")
+
+let output = model.generate(audio: audio)
+print(output.text)
+```
+
+The published `mlx_manifest.json` resolves `mlx-community/MiMo-Audio-Tokenizer` automatically. For offline or fully local setups, you can still pass `tokenizerPath` explicitly.
+
+The published tokenizer repo is the MLX encoder/RVQ subset used by MiMo ASR. It does not include the full decoder/vocoder stack from the original `XiaomiMiMo/MiMo-Audio-Tokenizer` release.
+
+## Streaming Example
+
+```swift
+for try await event in model.generateStream(audio: audio) {
+    switch event {
+    case .token(let token):
+        print(token, terminator: "")
+    case .result(let result):
+        print("\nFinal text: \(result.text)")
+    case .info:
+        break
+    }
+}
+```

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -267,7 +267,11 @@ enum App {
             throw AppError.inputFileNotFound(inputURL.path)
         }
 
+        let loadStartTime = CFAbsoluteTimeGetCurrent()
         let model = try await loadModel(repo: options.model)
+        let modelLoadTime = CFAbsoluteTimeGetCurrent() - loadStartTime
+
+        let audioPrepStartTime = CFAbsoluteTimeGetCurrent()
         let (inputSampleRate, inputAudio) = try loadAudioArray(from: inputURL)
         let targetSampleRate: Int
         switch model {
@@ -281,6 +285,7 @@ enum App {
             inputSampleRate: inputSampleRate,
             targetSampleRate: targetSampleRate
         )
+        let audioPrepTime = CFAbsoluteTimeGetCurrent() - audioPrepStartTime
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
@@ -359,7 +364,10 @@ enum App {
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
             print("\n==========")
             print("Saved file to: \(options.outputPath!).\(options.format.rawValue)")
-            print(String(format: "Processing time: %.2f seconds", elapsed))
+            print(String(format: "Model load time: %.2f seconds", modelLoadTime))
+            print(String(format: "Audio prep time: %.2f seconds", audioPrepTime))
+            print(String(format: "Model generation time: %.2f seconds", output.totalTime))
+            print(String(format: "End-to-end post-load time: %.2f seconds", elapsed))
             print(String(format: "Prompt: %d tokens, %.3f tokens-per-sec", output.promptTokens, output.promptTps))
             print(String(format: "Generation: %d tokens, %.3f tokens-per-sec", output.generationTokens, output.generationTps))
             print(String(format: "Peak memory: %.2f GB", output.peakMemoryUsage))

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -17,7 +17,7 @@ enum AppError: Error, LocalizedError, CustomStringConvertible {
         case .inputFileNotFound(let path):
             "Input audio file not found: \(path)"
         case .unsupportedModelRepo(let repo):
-            "Unsupported STT model repo: \(repo). Expected FireRedASR2, SenseVoice, GLMASR, Qwen3ASR, VoxtralRealtime, CohereTranscribe, Parakeet, or Qwen3ForcedAligner."
+            "Unsupported STT model repo: \(repo). Expected FireRedASR2, SenseVoice, GLM-ASR, Qwen3-ASR, MiMo-V2.5-ASR, VoxtralRealtime, CohereTranscribe, Parakeet, or Qwen3-ForcedAligner."
         case .missingTextForForcedAlignment:
             "--text is required when using a forced aligner model."
         case .streamUnsupportedForForcedAligner:
@@ -222,7 +222,7 @@ private struct Options {
             Options:
               --model <repo>                Model repo id.
                                             Default: mlx-community/Qwen3-ASR-0.6B-4bit
-                                            Supported families: FireRedASR2, SenseVoice, Qwen3-ASR, GLM-ASR, Voxtral, Cohere, Parakeet, Qwen3-ForcedAligner
+                                            Supported families: FireRedASR2, SenseVoice, Qwen3-ASR, GLM-ASR, MiMo-V2.5-ASR, Voxtral, Cohere, Parakeet, Qwen3-ForcedAligner
               --audio <path>                Input audio file (required if not passed as trailing arg)
               --output-path <path>          Output path stem (required). Extension is appended from --format.
               --format <txt|srt|vtt|json>   Output format. Default: txt
@@ -269,7 +269,18 @@ enum App {
 
         let model = try await loadModel(repo: options.model)
         let (inputSampleRate, inputAudio) = try loadAudioArray(from: inputURL)
-        let audio = try prepareAudioForSTT(inputAudio, inputSampleRate: inputSampleRate, targetSampleRate: 16000)
+        let targetSampleRate: Int
+        switch model {
+        case .stt(let sttModel) where sttModel is MiMoV2ASRModel:
+            targetSampleRate = 24_000
+        default:
+            targetSampleRate = 16000
+        }
+        let audio = try prepareAudioForSTT(
+            inputAudio,
+            inputSampleRate: inputSampleRate,
+            targetSampleRate: targetSampleRate
+        )
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
@@ -278,8 +289,8 @@ enum App {
             print("Audio path: \(inputURL.path)")
             print("Output path: \(options.outputPath!).\(options.format.rawValue)")
             print("Format: \(options.format.rawValue)")
-            if inputSampleRate != 16000 {
-                print("Resampled audio: \(inputSampleRate) Hz -> 16000 Hz")
+            if inputSampleRate != targetSampleRate {
+                print("Resampled audio: \(inputSampleRate) Hz -> \(targetSampleRate) Hz")
             }
             if options.frameThreshold != 25 {
                 print("Warning: --frame-threshold is currently ignored by this CLI.")
@@ -418,6 +429,9 @@ enum App {
         }
         if lower.contains("sensevoice") {
             return .stt(try await SenseVoiceModel.fromPretrained(repo))
+        }
+        if lower.contains("mimo") {
+            return .stt(try await MiMoV2ASRModel.fromPretrained(repo))
         }
 
         throw AppError.unsupportedModelRepo(repo)

--- a/Tests/MiMoV2ASRConfigTests.swift
+++ b/Tests/MiMoV2ASRConfigTests.swift
@@ -1,0 +1,124 @@
+import Testing
+
+@testable import MLXAudioSTT
+
+@Suite("MiMo V2 ASR Config Tests")
+struct MiMoV2ASRConfigTests {
+    @Test func mimoAudioTokenizerConfigDecodesOfficialShape() throws {
+        let json = """
+        {
+          "max_audio_seconds": 1800,
+          "stride_size": 2,
+          "avg_pooler": 2,
+          "d_model": 1280,
+          "encoder_layers": 32,
+          "encoder_skip_layer_id": 3,
+          "encoder_attention_heads": 20,
+          "encoder_ffn_dim": 5120,
+          "nfft": 960,
+          "n_mels": 128,
+          "sampling_rate": 24000,
+          "hop_length": 240,
+          "window_size": 960,
+          "num_quantizers": 20,
+          "codebook_size": [1024, 1024, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128],
+          "threshold_ema_dead_code": 2,
+          "position_embedding_type": "rope",
+          "rope_theta": 10000,
+          "rope_type": "default",
+          "ln_type": "LayerNorm",
+          "vocoder_attention_heads": 16,
+          "vocoder_attn_window_size": [40, 10]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let config = try JSONDecoder().decode(MiMoAudioTokenizerConfig.self, from: data)
+
+        #expect(config.dModel == 1280)
+        #expect(config.encoderLayers == 32)
+        #expect(config.nMels == 128)
+        #expect(config.samplingRate == 24000)
+        #expect(config.numQuantizers == 20)
+        #expect(config.activeCodebookSizes(prefixCount: 8) == [1024, 1024, 128, 128, 128, 128, 128, 128])
+    }
+
+    @Test func mimoV2ASRConfigDecodesOfficialShape() throws {
+        let json = """
+        {
+          "architectures": ["MiMoV2ASRForCausalLM"],
+          "model_type": "qwen2",
+          "hidden_size": 4096,
+          "intermediate_size": 11008,
+          "num_hidden_layers": 36,
+          "num_attention_heads": 32,
+          "num_key_value_heads": 8,
+          "head_dim": 128,
+          "hidden_act": "silu",
+          "max_position_embeddings": 8192,
+          "vocab_size": 151680,
+          "rope_theta": 640000,
+          "rms_norm_eps": 1e-6,
+          "attention_bias": true,
+          "attention_dropout": 0.0,
+          "use_cache": true,
+          "tie_word_embeddings": false,
+          "group_size": 4,
+          "audio_channels": 8,
+          "delay_pattern": "0-1-2-3-4-5-6-7",
+          "speech_vocab_size": "1025-1025-129-129-129-129-129-129",
+          "speech_zeroemb_idx": "1024-1024-128-128-128-128-128-128",
+          "local_dim": 1024,
+          "local_layers": 16,
+          "local_attn_heads": 64,
+          "local_ffn_dim": 4096,
+          "local_attn_dropout": 0.1,
+          "input_local_layers": 6,
+          "input_local_dim": 1024,
+          "input_full_attention": true,
+          "n_rvq": 20,
+          "add_input_local_transformer": true,
+          "add_speech_sosp_eosp": false,
+          "audio_config": {
+            "tokenizer_version": "v1",
+            "speech_vocab_size": "1025-1025-129-129-129-129-129-129",
+            "speech_zeroemb_idx": "1024-1024-128-128-128-128-128-128",
+            "group_size": 4,
+            "audio_channels": 8,
+            "input_local_layers": 6,
+            "input_local_dim": 1024,
+            "input_full_attention": true,
+            "input_local_attn_heads": 64,
+            "input_local_head_dim": 16,
+            "input_local_intermediate_size": 4096,
+            "input_local_hidden_dropout": 0.1,
+            "out_hidden_size": 4096,
+            "rope_theta": 640000,
+            "partial_rotary_factor": 1.0,
+            "projection_layers": 1,
+            "add_post_norm": true,
+            "audio_segment_size": 6000
+          },
+          "quantization_config": {
+            "group_size": 64,
+            "bits": 4,
+            "mode": "affine"
+          }
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let config = try JSONDecoder().decode(MiMoV2ASRConfig.self, from: data)
+
+        #expect(config.isMiMoV2ASR)
+        #expect(config.modelType == "qwen2")
+        #expect(config.hiddenSize == 4096)
+        #expect(config.audioChannels == 8)
+        #expect(config.groupSize == 4)
+        #expect(config.nRVQ == 20)
+        #expect(config.parsedDelayPattern == [0, 1, 2, 3, 4, 5, 6, 7])
+        #expect(config.activeSpeechCodebookSizes == [1025, 1025, 129, 129, 129, 129, 129, 129])
+        #expect(config.audioConfig?.audioSegmentSize == 6000)
+        #expect(config.quantization?.bits == 4)
+        #expect(config.quantization?.groupSize == 64)
+    }
+
+}


### PR DESCRIPTION
Add `MiMo-V2.5-ASR` support to `mlx-audio-swift` STT.

Changes:
- add a native `MiMoV2ASR` model family
- detect MiMo repos in the STT CLI
- resolve the external `MiMo-Audio-Tokenizer` dependency from `mlx_manifest.json`
- add README entries and a model README
- add config decoding coverage for the MiMo configs

Validation:
- `swift build --target MLXAudioSTT`
- `swift build --product mlx-audio-swift-stt`
- `intention.wav` -> `Intention.`
- `conversational_a.wav` -> expected coffee / Kaldi paragraph

Closes #183.
