### PR TITLE
Fix Qwen3-TTS CustomVoice voice parsing

### DIFF
--- a/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3TTS/Qwen3TTS.swift
@@ -358,10 +358,11 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
             ttsPadEmbed = prepared.2
             refCodes = prepared.3
         } else {
-            // For CustomVoice models: voice is a speaker name, not free-text instruct.
+            // CustomVoice accepts `voice` as "speaker, instruction".
             let isCVModel = config.ttsModelType == "custom_voice"
-            let speaker: String? = isCVModel ? instruct : nil
-            let effectiveInstruct: String? = isCVModel ? nil : instruct
+            let customVoicePrompt = isCVModel ? Self.parseCustomVoicePrompt(instruct) : nil
+            let speaker: String? = isCVModel ? customVoicePrompt?.speaker : nil
+            let effectiveInstruct: String? = isCVModel ? customVoicePrompt?.instruction : instruct
             let prepared = prepareGenerationInputs(
                 text: text,
                 language: language,
@@ -565,6 +566,30 @@ public final class Qwen3TTSModel: Module, SpeechGenerationModel, @unchecked Send
 
         eval(audio)
         return audio
+    }
+
+    static func parseCustomVoicePrompt(_ voice: String?) -> (speaker: String, instruction: String?)? {
+        guard let voice = voice?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !voice.isEmpty else {
+            return nil
+        }
+
+        guard let commaIndex = voice.firstIndex(of: ",") else {
+            return (speaker: voice, instruction: nil)
+        }
+
+        let speaker = voice[..<commaIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        let instructionStart = voice.index(after: commaIndex)
+        let instruction = voice[instructionStart...].trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !speaker.isEmpty else {
+            return (speaker: voice, instruction: nil)
+        }
+
+        return (
+            speaker: String(speaker),
+            instruction: instruction.isEmpty ? nil : String(instruction)
+        )
     }
 
     // MARK: - Reference conditioning

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -916,6 +916,19 @@ private final class CountingFishAE: EchoTTSAudioCodec, @unchecked Sendable {
 @Suite("Qwen3TTS")
 struct Qwen3TTSTests {
 
+    @Test func customVoicePromptSplitsSpeakerAndInstruction() {
+        let combined = Qwen3TTSModel.parseCustomVoicePrompt("Vivian, very happy and excited.")
+        #expect(combined?.speaker == "Vivian")
+        #expect(combined?.instruction == "very happy and excited.")
+
+        let speakerOnly = Qwen3TTSModel.parseCustomVoicePrompt(" Vivian ")
+        #expect(speakerOnly?.speaker == "Vivian")
+        #expect(speakerOnly?.instruction == nil)
+
+        #expect(Qwen3TTSModel.parseCustomVoicePrompt(nil)?.speaker == nil)
+        #expect(Qwen3TTSModel.parseCustomVoicePrompt("   ")?.speaker == nil)
+    }
+
     @Test func prepareReferenceConditioningBuildsReusableReferenceState() async throws {
         let fixture = try await makeTinyQwen3TTSModel(
             ttsModelType: "voice_design",


### PR DESCRIPTION
## Summary

Fix Qwen3-TTS CustomVoice `voice` parsing so the README-documented format works:

```swift
voice: "Vivian, very happy and excited."
```

For CustomVoice models, this is now parsed as:

- speaker: Vivian
- instruction: very happy and excited.

Speaker-only usage like voice: "Vivian" is unchanged.

## Validation

- Added a focused Qwen3TTS test for CustomVoice prompt parsing.
- Verified the CLI no longer treats "Vivian, very happy and excited." as a full speaker key.

```
xcodebuild -scheme MLXAudio-Package -destination 'platform=macOS' test -only-testing:'MLXAudioTests/Qwen3TTSTests/customVoicePromptSplitsSpeakerAndInstruction()' 2>&1
```

## Fixes

Fixes #185
