### PR TITLE
FireRedASR2Model: hide CMVN runtime arrays from strict-verify reflection

### DIFF
--- a/Sources/MLXAudioSTT/Models/FireRedASR2/FireRedASR2Model.swift
+++ b/Sources/MLXAudioSTT/Models/FireRedASR2/FireRedASR2Model.swift
@@ -741,6 +741,17 @@ private struct FireRedASR2CMVN: Decodable {
     let istd: [Float]
 }
 
+/// Boxes the per-instance CMVN statistics so MLX's parameter reflection does
+/// not pick them up as expected `MLXArray` parameters of `FireRedASR2Model`.
+/// Without this indirection, `Module.update(parameters:verify: .all)` rejects
+/// the load with `keyNotFound(path: ["cmvnMeans"|"cmvnIstd"], ...)` because the
+/// safetensors checkpoint doesn't carry weights at those paths — they're
+/// computed at runtime from `cmvn.json` via `loadAssets(from:)`.
+private final class FireRedASR2CMVNStats {
+    var means: MLXArray?
+    var istd: MLXArray?
+}
+
 public final class FireRedASR2Model: Module, STTGenerationModel {
     public let config: FireRedASR2Config
 
@@ -748,8 +759,17 @@ public final class FireRedASR2Model: Module, STTGenerationModel {
     @ModuleInfo(key: "decoder") var decoder: FireRedASR2TransformerDecoder
 
     var tokenizer: FireRedASR2Tokenizer?
-    var cmvnMeans: MLXArray?
-    var cmvnIstd: MLXArray?
+    private let cmvnStats = FireRedASR2CMVNStats()
+
+    var cmvnMeans: MLXArray? {
+        get { cmvnStats.means }
+        set { cmvnStats.means = newValue }
+    }
+
+    var cmvnIstd: MLXArray? {
+        get { cmvnStats.istd }
+        set { cmvnStats.istd = newValue }
+    }
 
     public var vocabulary: [String] {
         tokenizer?.vocabulary ?? []

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -2800,6 +2800,30 @@ struct FireRedASR2Tests {
     }
 }
 
+@Suite("FireRed ASR 2 Cached Tests", .serialized)
+struct FireRedASR2CachedTests {
+
+    /// Loads the model from a pre-existing on-disk snapshot pointed to by
+    /// MLXAUDIO_FIRERED_DIR. Useful for verifying load behaviour without
+    /// touching the network or HubCache.default. Set MLXAUDIO_FIRERED_DIR=/path
+    /// to enable; otherwise this test is a no-op.
+    @Test func fireredLoadsFromLocalDirectory() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let dirPath = env["MLXAUDIO_FIRERED_DIR"], !dirPath.isEmpty else {
+            print("Skipping FireRed cached test. Set MLXAUDIO_FIRERED_DIR=<path> to enable.")
+            return
+        }
+
+        let url = URL(fileURLWithPath: dirPath, isDirectory: true)
+        let model = try FireRedASR2Model.fromDirectory(url)
+
+        #expect(model.config.modelType == "fireredasr2")
+        #expect(model.cmvnMeans != nil)
+        #expect(model.cmvnIstd != nil)
+        #expect(!model.vocabulary.isEmpty)
+    }
+}
+
 @Suite("FireRed ASR 2 Network Tests", .serialized)
 struct FireRedASR2NetworkTests {
 


### PR DESCRIPTION
## Summary

`FireRedASR2Model.fromDirectory(_:)` currently fails every load against `mlx-community/FireRedASR2-AED-mlx` with:

```
.keyNotFound(path: ["cmvnMeans"], modules: ["FireRedASR2Model"])
```

`var cmvnMeans: MLXArray?` and `var cmvnIstd: MLXArray?` on `FireRedASR2Model` are picked up by MLX's `Module` Mirror reflection as expected checkpoint parameters. The safetensors snapshot doesn't carry weights at those paths — they're populated at runtime from `cmvn.json` via `loadAssets(from:)` — so `Module.update(parameters:verify: .all)` rejects the load and the model never initialises.

Same class of bug as #162 (Marvis): a `Module` property typed as `MLXArray?` that only exists as runtime state gets enrolled as a checkpoint key.

## Fix

Box the two arrays in a private `final class` (`FireRedASR2CMVNStats`). Mirror sees a single `cmvnStats` field whose type is neither `Module` nor `MLXArray`, so MLX skips it. The public `cmvnMeans` / `cmvnIstd` accessors become computed properties that delegate to the box, so existing call sites — including `if let cmvnMeans, let cmvnIstd { … }` inside `generate(…)` and `#expect(model.cmvnMeans != nil)` in `FireRedASR2NetworkTests` — keep compiling and behaving identically.

```swift
private final class FireRedASR2CMVNStats {
    var means: MLXArray?
    var istd: MLXArray?
}

public final class FireRedASR2Model: Module, STTGenerationModel {
    ...
    private let cmvnStats = FireRedASR2CMVNStats()

    var cmvnMeans: MLXArray? {
        get { cmvnStats.means }
        set { cmvnStats.means = newValue }
    }
    var cmvnIstd: MLXArray? { ... }
```

## Reproduction

Adds a new offline test `FireRedASR2CachedTests.fireredLoadsFromLocalDirectory` that calls `FireRedASR2Model.fromDirectory` against an on-disk snapshot pointed to by `MLXAUDIO_FIRERED_DIR`. The test makes it trivial to reproduce the bug against any local snapshot without network access or `HubCache.default` setup.

On `8ae0c74` (hehehai/mlx-audio-swift) — same `FireRedASR2Model.swift` as `Blaizzy/main` at this commit — pointing the env var at a fully downloaded `mlx-community/FireRedASR2-AED-mlx` snapshot:

**Before the patch:**
```
✘ Test fireredLoadsFromLocalDirectory() failed after 2.683 seconds with 1 issue.
✘ recorded an issue: Caught error: .keyNotFound(path: ["cmvnMeans"], modules: ["FireRedASR2Model"])
** TEST FAILED **
```

**After the patch:**
```
✔ Test fireredLoadsFromLocalDirectory() passed after 3.493 seconds.
✔ Suite "FireRed ASR 2 Cached Tests" passed after 3.494 seconds.
** TEST SUCCEEDED **
```

Full FireRed test suite (5 existing unit tests + the new offline load test) all green:

```
✔ Test configDefaultsAndDecoding() passed
✔ Test fbankExtractionShape() passed
✔ Test tokenizerCleanup() passed
✔ Test encoderAndDecoderShapes() passed
✔ Test sanitizeRemapsAndTransposesWeights() passed
✔ Test fireredLoadsFromLocalDirectory() passed
** TEST SUCCEEDED **
```

## Verified on

- macOS 26.5 / Xcode 26.5 / arm64
- `xcodebuild test -scheme MLXAudio-Package -destination 'platform=macOS' -only-testing:'MLXAudioTests/FireRedASR2Tests' -only-testing:'MLXAudioTests/FireRedASR2CachedTests' CODE_SIGNING_ALLOWED=NO`
- `MLXAUDIO_FIRERED_DIR` pointed at `~/Library/Containers/com.voxt.Voxt/Data/Library/Caches/huggingface/hub/mlx-audio/mlx-community_FireRedASR2-AED-mlx` (4.5 GB snapshot from HuggingFace)

## Discovered via

[hehehai/voxt#78](https://github.com/hehehai/voxt) — a Voxt user reported FireRed silently failing with the unhelpful `MLX model is unavailable` overlay; the in-app log file surfaced the underlying `keyNotFound` consistently, and the fix is upstream.
