### PR TITLE
fix(MossTTS): gate homeDirectoryForCurrentUser behind #if os(macOS)

### DIFF
--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift
@@ -355,7 +355,12 @@ public final class MossTTSModel: Module, SpeechGenerationModel, @unchecked Senda
     private static func findCachedHubSnapshot(repo: String) -> URL? {
         let components = repo.split(separator: "/", maxSplits: 1).map(String.init)
         guard components.count == 2 else { return nil }
+        #if os(macOS)
         let home = FileManager.default.homeDirectoryForCurrentUser
+        #else
+        let home = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        #endif
         let snapshotsDir = home
             .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
             .appendingPathComponent("models--\(components[0])--\(components[1])", isDirectory: true)


### PR DESCRIPTION
## Problem

iOS builds of `MLXAudioTTS` fail to compile after #179 (MOSS-TTS):

```
Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift:358:40:
error: 'homeDirectoryForCurrentUser' is unavailable in iOS
```

`FileManager.homeDirectoryForCurrentUser` is macOS-only. The call sits inside `findCachedHubSnapshot`, which probes `~/.cache/huggingface/hub` for a locally cached snapshot before falling back to a network download.

## Fix

Gate the macOS-only API behind `#if os(macOS)` and, on iOS (and any other non-macOS platforms), fall back to the user's caches directory:

```swift
#if os(macOS)
let home = FileManager.default.homeDirectoryForCurrentUser
#else
let home = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
    ?? URL(fileURLWithPath: NSTemporaryDirectory())
#endif
```

The cache-lookup logic still works on both platforms — on iOS it just probes the app's sandboxed caches directory instead, which is the correct equivalent of `~/.cache` for that platform.

## Scope

- One file touched: `Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift`
- No behavior change on macOS
- iOS now compiles and resolves snapshots from the sandboxed caches dir

## Test plan

- [x] Compiles on iOS (verified in downstream consumer)
- [x] No change on macOS (`#if os(macOS)` branch preserves prior behavior)