### PR TITLE
perf(sortformer): single bulk readback in predsToSegments (~1.8x streaming)

### DIFF
--- a/Sources/MLXAudioVAD/Models/Sortformer/Sortformer.swift
+++ b/Sources/MLXAudioVAD/Models/Sortformer/Sortformer.swift
@@ -1288,38 +1288,35 @@ public class SortformerModel: Module {
         minDuration: Float = 0.0,
         mergeGap: Float = 0.0
     ) -> [DiarizationSegment] {
+        let numFrames = preds.dim(0)
         let numSpeakers = preds.dim(1)
         var segments = [DiarizationSegment]()
 
+        // Single bulk GPU->CPU readback (row-major [frame, speaker]); all change
+        // detection runs in pure Swift to avoid per-frame .item() round-trips.
+        let flat = preds.asType(.float32).reshaped([-1]).asArray(Float.self)
+
         for spk in 0..<numSpeakers {
-            let activity = preds[0..., spk] .> threshold
-            if !MLX.any(activity).item(Bool.self) {
-                continue
-            }
-
-            let padded = MLX.concatenated([
-                MLXArray.zeros([1]).asType(DType.bool),
-                activity,
-                MLXArray.zeros([1]).asType(DType.bool)
-            ])
-            let changes = padded[1...].asType(DType.int32) - padded[..<(-1)].asType(DType.int32)
-            eval(changes)
-
-            let changesList: [Int32] = (0..<changes.dim(0)).map { changes[$0].item(Int32.self) }
-
-            let starts = changesList.enumerated().compactMap { $0.element == 1 ? $0.offset : nil }
-            let ends = changesList.enumerated().compactMap { $0.element == -1 ? $0.offset : nil }
-
             var spkSegments = [DiarizationSegment]()
-            for (s, e) in zip(starts, ends) {
-                let startTime = Float(s) * frameDuration
-                let endTime = Float(e) * frameDuration
-                let duration = endTime - startTime
-
-                if duration >= minDuration {
-                    spkSegments.append(DiarizationSegment(
-                        start: startTime, end: endTime, speaker: spk
-                    ))
+            var segStart = -1
+            for f in 0..<numFrames {
+                let active = flat[f * numSpeakers + spk] > threshold
+                if active {
+                    if segStart < 0 { segStart = f }
+                } else if segStart >= 0 {
+                    let startTime = Float(segStart) * frameDuration
+                    let endTime = Float(f) * frameDuration
+                    if endTime - startTime >= minDuration {
+                        spkSegments.append(DiarizationSegment(start: startTime, end: endTime, speaker: spk))
+                    }
+                    segStart = -1
+                }
+            }
+            if segStart >= 0 {
+                let startTime = Float(segStart) * frameDuration
+                let endTime = Float(numFrames) * frameDuration
+                if endTime - startTime >= minDuration {
+                    spkSegments.append(DiarizationSegment(start: startTime, end: endTime, speaker: spk))
                 }
             }
 

--- a/Tests/MLXAudioVADTests.swift
+++ b/Tests/MLXAudioVADTests.swift
@@ -515,6 +515,31 @@ struct SortformerPostprocessingTests {
             #expect(segments[i].start >= segments[i - 1].start)
         }
     }
+
+    @Test func predsToSegmentsExactBoundaries() {
+        // Pin the exact frame->time mapping the bulk-readback edge detection must
+        // preserve: a start edge, an inactive-close edge, and — critically — a
+        // segment active through the FINAL frame (the tail branch other tests miss).
+        let frameDuration: Float = 0.08
+        let nFrames = 12
+        let nSpk = 1
+        var predsData = [Float](repeating: 0.0, count: nFrames * nSpk)
+        for i in 3...7 { predsData[i] = 0.9 }          // mid segment: frames 3..7
+        for i in 10..<nFrames { predsData[i] = 0.9 }   // trailing: frames 10..11 -> end
+
+        let preds = MLXArray(predsData).reshaped(nFrames, nSpk)
+        let segments = SortformerModel.predsToSegments(preds, frameDuration: frameDuration)
+
+        #expect(segments.count == 2)
+
+        // Mid segment: starts at frame 3, closes at the first inactive frame (8).
+        #expect(abs(segments[0].start - 3 * frameDuration) < 1e-5)   // 0.24
+        #expect(abs(segments[0].end - 8 * frameDuration) < 1e-5)     // 0.64
+
+        // Trailing segment: active through the last frame -> end == nFrames * dur.
+        #expect(abs(segments[1].start - 10 * frameDuration) < 1e-5)  // 0.80
+        #expect(abs(segments[1].end - Float(nFrames) * frameDuration) < 1e-5)  // 0.96
+    }
 }
 
 // MARK: - Smart Turn Config Tests


### PR DESCRIPTION
## What

`predsToSegments` built its result by reading the change-detection array **one frame at a time** via `.item()` — a synchronous GPU→CPU round-trip per frame, per speaker, per call. Replace it with a **single bulk `asArray()` readback** followed by pure-Swift change detection.

```swift
// before — per-frame sync readback
let changesList: [Int32] = (0..<changes.dim(0)).map { changes[$0].item(Int32.self) }
// after — one bulk readback, pure-Swift edge detection
let flat = preds.asType(.float32).reshaped([-1]).asArray(Float.self)
```

## Why

On a long streaming run the old path issues **~95k synchronous `.item()` round-trips** over the file. Each one stalls the CPU on the Metal stream; they dominate all non-encoder time. A single bulk readback per call removes them.

## Impact — before → after (Swift, same machine/session, 32-min file, streaming)

| | **Before** | **After** |
|---|---|---|
| `predsToSegments` readback | per-frame `.item()` — **~95k** GPU→CPU syncs over the file | **1** bulk `asArray()` per call |
| `predsToSegments` cost / chunk (profiled) | readback-dominated | **~0.5 ms** |
| Streaming inference (1929 s audio) | **106.0 s** · RTF **18.2×** | **57.4 s** · RTF **33.6×** |
| Speedup | — | **≈ 1.85×** |
| Output vs before | — | **0.0% DER** (bit-identical) |

> Absolute RTF is thermal/load-dependent; the **1.85×** is the same-session A/B that isolates *this* change. Encoder forward (≈95% of runtime) is untouched.

## Scope / blast radius

- **One file, one function** (`Sortformer.swift::predsToSegments`), +24/−27.
- Pure refactor of the post-processing readback; no API, signature, or behavior change.
- Covered by the existing `SortformerPostprocessingTests` (basic / empty / min-duration / merge-gap / sorted).

## Testing

- Adds **`predsToSegmentsExactBoundaries`** — a regression test that pins the exact frame→time mapping the refactor rewrote: start edge, inactive-close edge, and a segment **active through the final frame** (the tail branch the existing tests never exercised).
- `predsToSegments` unit tests pass via CI (`xcodebuild test`).
- Note: these tests can't run via `swift test` locally — the SwiftPM test bundle fails to load the Metal default lib (`Failed to load the default metallib`); CI's `xcodebuild` path (with MetalToolchain) runs them correctly.
- Behavior-preservation additionally validated empirically (0.0% DER, bit-identical RTTM on real audio).

---
_Validated on a fork: build + tests (incl. the new boundary test) green via the same `xcodebuild` CI._
