### PR TITLE
Add Nemotron 3.5 ASR streaming model support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ let package = Package(
                 "Models/FireRedASR2/README.md",
                 "Models/GLMASR/README.md",
                 "Models/GraniteSpeech/README.md",
+                "Models/NemotronASR/README.md",
                 "Models/Parakeet/README.md",
                 "Models/Qwen3ASR/README.md",
                 "Models/SenseVoice/README.md",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MLXAudio follows a modular design allowing you to import only what you need:
 - **MLXAudioCore**: Base types, protocols, and utilities
 - **MLXAudioCodecs**: Audio codec implementations (SNAC, Encodec, Vocos, Mimi, DACVAE)
 - **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, Fish Audio S2 Pro, Soprano, VyvoTTS, Orpheus, Marvis TTS, Pocket TTS)
-- **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Voxtral Realtime, Cohere Transcribe, Parakeet, GLMASR)
+- **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Voxtral Realtime, Cohere Transcribe, Parakeet, Nemotron ASR, GLMASR)
 - **MLXAudioVAD**: Voice Activity Detection & Speaker Diarization (Sortformer, SmartTurn)
 - **MLXAudioSTS**: Speech-to-Speech models (LFM2.5-Audio, SAM-Audio, MossFormer2-SE, DeepFilterNet)
 - **MLXAudioUI**: SwiftUI components for audio interfaces
@@ -136,6 +136,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 | Voxtral Realtime | [Voxtral README](Sources/MLXAudioSTT/Models/VoxtralRealtime/README.md) | [mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16) |
 | Cohere Transcribe | [Cohere Transcribe README](Sources/MLXAudioSTT/Models/CohereTranscribe/README.md) | [beshkenadze/cohere-transcribe-03-2026-mlx-fp16](https://huggingface.co/beshkenadze/cohere-transcribe-03-2026-mlx-fp16) |
 | Parakeet | [Parakeet README](Sources/MLXAudioSTT/Models/Parakeet/README.md) | [mlx-community/parakeet-tdt-0.6b-v3](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3) |
+| Nemotron ASR | [Nemotron ASR README](Sources/MLXAudioSTT/Models/NemotronASR/README.md) | [mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit](https://huggingface.co/mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit) |
 | GLMASR | [GLMASR README](Sources/MLXAudioSTT/Models/GLMASR/README.md) | [mlx-community/GLM-ASR-Nano-2512-4bit](https://huggingface.co/mlx-community/GLM-ASR-Nano-2512-4bit) |
 
 ### STS Models

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRAudio.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRAudio.swift
@@ -1,0 +1,125 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+enum NemotronASRAudio {
+    static func logMelSpectrogram(
+        _ audio: MLXArray,
+        config: NemotronASRPreprocessConfig
+    ) -> MLXArray {
+        let originalDType = audio.dtype
+        var x = audio
+
+        if config.padTo > 0 && x.shape[0] < config.padTo {
+            let padLength = config.padTo - x.shape[0]
+            let paddedTail = MLXArray(Array(repeating: config.padValue, count: padLength))
+            x = MLX.concatenated([x, paddedTail], axis: 0)
+        }
+
+        if config.preemph > 0 && x.shape[0] > 1 {
+            let first = x[0..<1]
+            let rest = x[1...] - Float(config.preemph) * x[..<(x.shape[0] - 1)]
+            x = MLX.concatenated([first, rest], axis: 0)
+        }
+
+        let window = makeWindow(name: config.window, winLength: config.winLength, fftLength: config.nFft)
+        let stftOutput = stft(
+            audio: x,
+            window: window,
+            nFft: config.nFft,
+            hopLength: config.hopLength,
+            padMode: .constant
+        )
+
+        let power = MLX.abs(stftOutput).square().asType(originalDType)
+        let filters = melFilters(
+            sampleRate: config.sampleRate,
+            nFft: config.nFft,
+            nMels: config.features,
+            norm: "slaney",
+            melScale: .slaney
+        )
+
+        var mel = MLX.matmul(power, filters.asType(power.dtype))
+        mel = MLX.log(mel + MLXArray(config.logZeroGuardValue, dtype: mel.dtype))
+
+        switch config.normalize.lowercased() {
+        case "na", "none":
+            return mel.expandedDimensions(axis: 0).asType(originalDType)
+        case "per_feature":
+            let mean = MLX.mean(mel, axis: 0, keepDims: true)
+            let denominator = max(mel.dim(0) - 1, 1)
+            let variance = MLX.sum((mel - mean).square(), axis: 0, keepDims: true) / Float(denominator)
+            let std = MLX.sqrt(variance)
+            mel = (mel - mean) / (std + MLXArray(1e-5, dtype: mel.dtype))
+        default:
+            let mean = MLX.mean(mel)
+            let std = MLX.std(mel)
+            mel = (mel - mean) / (std + MLXArray(1e-5, dtype: mel.dtype))
+        }
+
+        return mel.expandedDimensions(axis: 0).asType(originalDType)
+    }
+
+    private static func makeWindow(name: String, winLength: Int, fftLength: Int) -> MLXArray {
+        let base: MLXArray
+        switch name.lowercased() {
+        case "hann", "hanning":
+            base = hanningWindow(size: winLength)
+        case "hamming":
+            base = hammingWindow(size: winLength)
+        case "blackman":
+            base = blackmanWindow(size: winLength)
+        case "bartlett":
+            base = bartlettWindow(size: winLength)
+        default:
+            base = hanningWindow(size: winLength)
+        }
+
+        if winLength >= fftLength {
+            return base[0..<fftLength]
+        }
+
+        let left = (fftLength - winLength) / 2
+        let right = fftLength - winLength - left
+        return MLX.concatenated([
+            MLXArray.zeros([left]),
+            base,
+            MLXArray.zeros([right])
+        ], axis: 0)
+    }
+
+    private static func hammingWindow(size: Int) -> MLXArray {
+        if size <= 1 {
+            return MLXArray(Array(repeating: Float(1), count: max(size, 1)))
+        }
+        let denom = Float(size - 1)
+        let values = (0..<size).map { n in
+            Float(0.54) - Float(0.46) * cos(2 * Float.pi * Float(n) / denom)
+        }
+        return MLXArray(values)
+    }
+
+    private static func blackmanWindow(size: Int) -> MLXArray {
+        if size <= 1 {
+            return MLXArray(Array(repeating: Float(1), count: max(size, 1)))
+        }
+        let denom = Float(size - 1)
+        let values = (0..<size).map { n in
+            let k = 2 * Float.pi * Float(n) / denom
+            return Float(0.42) - Float(0.5) * cos(k) + Float(0.08) * cos(2 * k)
+        }
+        return MLXArray(values)
+    }
+
+    private static func bartlettWindow(size: Int) -> MLXArray {
+        if size <= 1 {
+            return MLXArray(Array(repeating: Float(1), count: max(size, 1)))
+        }
+        let mid = Float(size - 1) / 2
+        let values = (0..<size).map { n in
+            Float(1) - abs((Float(n) - mid) / mid)
+        }
+        return MLXArray(values)
+    }
+}

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRConfig.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRConfig.swift
@@ -1,0 +1,309 @@
+import Foundation
+
+public struct NemotronASRPreprocessConfig: Codable, Sendable {
+    public let sampleRate: Int
+    public let features: Int
+    public let nFft: Int
+    public let windowSize: Float
+    public let windowStride: Float
+    public let window: String
+    public let preemph: Float
+    public let dither: Float
+    public let normalize: String
+    public let logZeroGuardValue: Float
+    public let padTo: Int
+    public let padValue: Float
+
+    enum CodingKeys: String, CodingKey {
+        case sampleRate = "sample_rate"
+        case features
+        case nFft = "n_fft"
+        case windowSize = "window_size"
+        case windowStride = "window_stride"
+        case window
+        case preemph
+        case dither
+        case normalize
+        case logZeroGuardValue = "log_zero_guard_value"
+        case padTo = "pad_to"
+        case padValue = "pad_value"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 16_000
+        features = try container.decodeIfPresent(Int.self, forKey: .features) ?? 128
+        nFft = try container.decodeIfPresent(Int.self, forKey: .nFft) ?? 512
+        windowSize = try container.decodeIfPresent(Float.self, forKey: .windowSize) ?? 0.025
+        windowStride = try container.decodeIfPresent(Float.self, forKey: .windowStride) ?? 0.01
+        window = try container.decodeIfPresent(String.self, forKey: .window) ?? "hann"
+        preemph = try container.decodeIfPresent(Float.self, forKey: .preemph) ?? 0.97
+        dither = try container.decodeIfPresent(Float.self, forKey: .dither) ?? 1e-5
+        normalize = try container.decodeIfPresent(String.self, forKey: .normalize) ?? "NA"
+        logZeroGuardValue = try container.decodeIfPresent(Float.self, forKey: .logZeroGuardValue) ?? pow(2, -24)
+        padTo = try container.decodeIfPresent(Int.self, forKey: .padTo) ?? 0
+        padValue = try container.decodeIfPresent(Float.self, forKey: .padValue) ?? 0
+    }
+
+    public init(
+        sampleRate: Int = 16_000,
+        features: Int = 128,
+        nFft: Int = 512,
+        windowSize: Float = 0.025,
+        windowStride: Float = 0.01,
+        window: String = "hann",
+        preemph: Float = 0.97,
+        dither: Float = 1e-5,
+        normalize: String = "NA",
+        logZeroGuardValue: Float = pow(2, -24),
+        padTo: Int = 0,
+        padValue: Float = 0
+    ) {
+        self.sampleRate = sampleRate
+        self.features = features
+        self.nFft = nFft
+        self.windowSize = windowSize
+        self.windowStride = windowStride
+        self.window = window
+        self.preemph = preemph
+        self.dither = dither
+        self.normalize = normalize
+        self.logZeroGuardValue = logZeroGuardValue
+        self.padTo = padTo
+        self.padValue = padValue
+    }
+
+    public var winLength: Int {
+        Int(windowSize * Float(sampleRate))
+    }
+
+    public var hopLength: Int {
+        Int(windowStride * Float(sampleRate))
+    }
+}
+
+public enum NemotronASRConvContextSize: Codable, Sendable, Equatable {
+    case causal
+    case explicit(left: Int, right: Int)
+
+    public init(from decoder: Decoder) throws {
+        let single = try decoder.singleValueContainer()
+        if let string = try? single.decode(String.self), string.lowercased() == "causal" {
+            self = .causal
+            return
+        }
+        let values = try single.decode([Int].self)
+        self = .explicit(left: values.first ?? 0, right: values.dropFirst().first ?? 0)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var single = encoder.singleValueContainer()
+        switch self {
+        case .causal:
+            try single.encode("causal")
+        case .explicit(let left, let right):
+            try single.encode([left, right])
+        }
+    }
+}
+
+public struct NemotronASRConformerConfig: Codable, Sendable {
+    public let featIn: Int
+    public let nLayers: Int
+    public let dModel: Int
+    public let nHeads: Int
+    public let ffExpansionFactor: Int
+    public let subsamplingFactor: Int
+    public let subsamplingConvChannels: Int
+    public let convKernelSize: Int
+    public let causalDownsampling: Bool
+    public let convContextSize: NemotronASRConvContextSize
+    public let convNormType: String
+    public let selfAttentionModel: String
+    public let attContextStyle: String
+    public let attContextSize: [[Int]]
+    public let posEmbMaxLen: Int
+    public let useBias: Bool
+    public let xscaling: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case featIn = "feat_in"
+        case nLayers = "n_layers"
+        case dModel = "d_model"
+        case nHeads = "n_heads"
+        case ffExpansionFactor = "ff_expansion_factor"
+        case subsamplingFactor = "subsampling_factor"
+        case subsamplingConvChannels = "subsampling_conv_channels"
+        case convKernelSize = "conv_kernel_size"
+        case causalDownsampling = "causal_downsampling"
+        case convContextSize = "conv_context_size"
+        case convNormType = "conv_norm_type"
+        case selfAttentionModel = "self_attention_model"
+        case attContextStyle = "att_context_style"
+        case attContextSize = "att_context_size"
+        case posEmbMaxLen = "pos_emb_max_len"
+        case useBias = "use_bias"
+        case xscaling
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        featIn = try container.decodeIfPresent(Int.self, forKey: .featIn) ?? 128
+        nLayers = try container.decodeIfPresent(Int.self, forKey: .nLayers) ?? 24
+        dModel = try container.decodeIfPresent(Int.self, forKey: .dModel) ?? 1024
+        nHeads = try container.decodeIfPresent(Int.self, forKey: .nHeads) ?? 8
+        ffExpansionFactor = try container.decodeIfPresent(Int.self, forKey: .ffExpansionFactor) ?? 4
+        subsamplingFactor = try container.decodeIfPresent(Int.self, forKey: .subsamplingFactor) ?? 8
+        subsamplingConvChannels = try container.decodeIfPresent(Int.self, forKey: .subsamplingConvChannels) ?? 256
+        convKernelSize = try container.decodeIfPresent(Int.self, forKey: .convKernelSize) ?? 9
+        causalDownsampling = try container.decodeIfPresent(Bool.self, forKey: .causalDownsampling) ?? true
+        convContextSize = try container.decodeIfPresent(NemotronASRConvContextSize.self, forKey: .convContextSize) ?? .causal
+        convNormType = try container.decodeIfPresent(String.self, forKey: .convNormType) ?? "layer_norm"
+        selfAttentionModel = try container.decodeIfPresent(String.self, forKey: .selfAttentionModel) ?? "rel_pos"
+        attContextStyle = try container.decodeIfPresent(String.self, forKey: .attContextStyle) ?? "chunked_limited"
+        attContextSize = try container.decodeIfPresent([[Int]].self, forKey: .attContextSize) ?? [[56, 13]]
+        posEmbMaxLen = try container.decodeIfPresent(Int.self, forKey: .posEmbMaxLen) ?? 5000
+        useBias = try container.decodeIfPresent(Bool.self, forKey: .useBias) ?? false
+        xscaling = try container.decodeIfPresent(Bool.self, forKey: .xscaling) ?? false
+    }
+
+    public init(
+        featIn: Int = 128,
+        nLayers: Int = 24,
+        dModel: Int = 1024,
+        nHeads: Int = 8,
+        ffExpansionFactor: Int = 4,
+        subsamplingFactor: Int = 8,
+        subsamplingConvChannels: Int = 256,
+        convKernelSize: Int = 9,
+        causalDownsampling: Bool = true,
+        convContextSize: NemotronASRConvContextSize = .causal,
+        convNormType: String = "layer_norm",
+        selfAttentionModel: String = "rel_pos",
+        attContextStyle: String = "chunked_limited",
+        attContextSize: [[Int]] = [[56, 13]],
+        posEmbMaxLen: Int = 5000,
+        useBias: Bool = false,
+        xscaling: Bool = false
+    ) {
+        self.featIn = featIn
+        self.nLayers = nLayers
+        self.dModel = dModel
+        self.nHeads = nHeads
+        self.ffExpansionFactor = ffExpansionFactor
+        self.subsamplingFactor = subsamplingFactor
+        self.subsamplingConvChannels = subsamplingConvChannels
+        self.convKernelSize = convKernelSize
+        self.causalDownsampling = causalDownsampling
+        self.convContextSize = convContextSize
+        self.convNormType = convNormType
+        self.selfAttentionModel = selfAttentionModel
+        self.attContextStyle = attContextStyle
+        self.attContextSize = attContextSize
+        self.posEmbMaxLen = posEmbMaxLen
+        self.useBias = useBias
+        self.xscaling = xscaling
+    }
+}
+
+public struct NemotronASRPromptConfig: Codable, Sendable {
+    public let numPrompts: Int
+    public let promptHidden: Int
+    public let promptDictionary: [String: Int]
+
+    enum CodingKeys: String, CodingKey {
+        case numPrompts = "num_prompts"
+        case promptHidden = "prompt_hidden"
+        case promptDictionary = "prompt_dictionary"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        numPrompts = try container.decodeIfPresent(Int.self, forKey: .numPrompts) ?? 128
+        promptHidden = try container.decodeIfPresent(Int.self, forKey: .promptHidden) ?? 2048
+        promptDictionary = try container.decodeIfPresent([String: Int].self, forKey: .promptDictionary) ?? [:]
+    }
+
+    public init(numPrompts: Int = 128, promptHidden: Int = 2048, promptDictionary: [String: Int] = [:]) {
+        self.numPrompts = numPrompts
+        self.promptHidden = promptHidden
+        self.promptDictionary = promptDictionary
+    }
+}
+
+public struct NemotronASRPredictConfig: Codable, Sendable {
+    public let predHidden: Int
+    public let predRnnLayers: Int
+    public let vocabSize: Int
+    public let blankAsPad: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case predHidden = "pred_hidden"
+        case predRnnLayers = "pred_rnn_layers"
+        case vocabSize = "vocab_size"
+        case blankAsPad = "blank_as_pad"
+    }
+}
+
+public struct NemotronASRJointConfig: Codable, Sendable {
+    public let jointHidden: Int
+    public let activation: String
+    public let encoderHidden: Int
+    public let predHidden: Int
+    public let numClasses: Int
+
+    enum CodingKeys: String, CodingKey {
+        case jointHidden = "joint_hidden"
+        case activation
+        case encoderHidden = "encoder_hidden"
+        case predHidden = "pred_hidden"
+        case numClasses = "num_classes"
+    }
+}
+
+public struct NemotronASRConfig: Codable, Sendable {
+    public let modelType: String
+    public let target: String
+    public let preprocessor: NemotronASRPreprocessConfig
+    public let encoder: NemotronASRConformerConfig
+    public let prompt: NemotronASRPromptConfig
+    public let decoder: NemotronASRPredictConfig
+    public let joint: NemotronASRJointConfig
+    public let vocabulary: [String]
+    public let defaultLanguage: String
+    public let defaultAttContextSize: [Int]
+    public let maxSymbols: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case target
+        case preprocessor
+        case encoder
+        case prompt
+        case decoder
+        case joint
+        case vocabulary
+        case defaultLanguage = "default_language"
+        case defaultAttContextSize = "default_att_context_size"
+        case maxSymbols = "max_symbols"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "nemotron_asr"
+        self.target = try container.decodeIfPresent(String.self, forKey: .target)
+            ?? "nemo.collections.asr.models.rnnt_bpe_models_prompt.EncDecRNNTBPEModelWithPrompt"
+        self.preprocessor = try container.decodeIfPresent(NemotronASRPreprocessConfig.self, forKey: .preprocessor)
+            ?? NemotronASRPreprocessConfig()
+        self.encoder = try container.decodeIfPresent(NemotronASRConformerConfig.self, forKey: .encoder)
+            ?? NemotronASRConformerConfig()
+        self.prompt = try container.decodeIfPresent(NemotronASRPromptConfig.self, forKey: .prompt)
+            ?? NemotronASRPromptConfig()
+        self.decoder = try container.decode(NemotronASRPredictConfig.self, forKey: .decoder)
+        self.joint = try container.decode(NemotronASRJointConfig.self, forKey: .joint)
+        self.vocabulary = try container.decodeIfPresent([String].self, forKey: .vocabulary) ?? []
+        self.defaultLanguage = try container.decodeIfPresent(String.self, forKey: .defaultLanguage) ?? "auto"
+        self.defaultAttContextSize = try container.decodeIfPresent([Int].self, forKey: .defaultAttContextSize) ?? [56, 13]
+        self.maxSymbols = try container.decodeIfPresent(Int.self, forKey: .maxSymbols)
+    }
+}

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRConformer.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRConformer.swift
@@ -1,0 +1,296 @@
+import Foundation
+import MLX
+import MLXNN
+
+private let nemotronASRNegInf: Float = -1e9
+
+enum NemotronASRAttentionMask {
+    static func createChunkedLimitedMask(seqLen: Int, leftContext: Int, rightContext: Int) -> MLXArray {
+        let chunkSize = max(rightContext + 1, 1)
+        let leftChunks = leftContext >= 0 ? leftContext / chunkSize : 1_000_000
+
+        let positions = MLX.arange(seqLen, dtype: .float32)
+        let chunkIndex = floor(positions / Float(chunkSize)).asType(.int32)
+        let queryChunks = chunkIndex.expandedDimensions(axis: 1)
+        let keyChunks = chunkIndex.expandedDimensions(axis: 0)
+        let diff = queryChunks - keyChunks
+        let visible = logicalAnd(diff .>= MLXArray(Int32(0)), diff .<= MLXArray(Int32(leftChunks)))
+        let mask = MLX.where(visible, MLXArray(Float(0)), MLXArray(nemotronASRNegInf)).asType(.float32)
+        return mask.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    }
+}
+
+final class NemotronASRFeedForward: Module {
+    @ModuleInfo(key: "linear1") var linear1: Linear
+    @ModuleInfo(key: "linear2") var linear2: Linear
+
+    init(dModel: Int, dFF: Int, useBias: Bool) {
+        self._linear1.wrappedValue = Linear(dModel, dFF, bias: useBias)
+        self._linear2.wrappedValue = Linear(dFF, dModel, bias: useBias)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(silu(linear1(x)))
+    }
+}
+
+final class NemotronASRConvolution: Module {
+    @ModuleInfo(key: "pointwise_conv1") var pointwiseConv1: Conv1d
+    @ModuleInfo(key: "depthwise_conv") var depthwiseConv: Conv1d
+    @ModuleInfo(key: "batch_norm") var batchNorm: LayerNorm
+    @ModuleInfo(key: "pointwise_conv2") var pointwiseConv2: Conv1d
+
+    let padLeft: Int
+    let padRight: Int
+
+    init(args: NemotronASRConformerConfig) {
+        let context = args.convContextSize
+        switch context {
+        case .causal:
+            self.padLeft = args.convKernelSize - 1
+            self.padRight = 0
+        case .explicit(let left, let right):
+            self.padLeft = left
+            self.padRight = right
+        }
+
+        self._pointwiseConv1.wrappedValue = Conv1d(
+            inputChannels: args.dModel,
+            outputChannels: args.dModel * 2,
+            kernelSize: 1,
+            stride: 1,
+            padding: 0,
+            bias: args.useBias
+        )
+        self._depthwiseConv.wrappedValue = Conv1d(
+            inputChannels: args.dModel,
+            outputChannels: args.dModel,
+            kernelSize: args.convKernelSize,
+            stride: 1,
+            padding: 0,
+            groups: args.dModel,
+            bias: args.useBias
+        )
+        self._batchNorm.wrappedValue = LayerNorm(dimensions: args.dModel)
+        self._pointwiseConv2.wrappedValue = Conv1d(
+            inputChannels: args.dModel,
+            outputChannels: args.dModel,
+            kernelSize: 1,
+            stride: 1,
+            padding: 0,
+            bias: args.useBias
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let pw = pointwiseConv1(x)
+        let split = pw.split(parts: 2, axis: 2)
+        var y = split[0] * sigmoid(split[1])
+        y = MLX.padded(y, widths: [.init(0), .init((padLeft, padRight)), .init(0)])
+        y = depthwiseConv(y)
+        y = batchNorm(y)
+        y = silu(y)
+        return pointwiseConv2(y)
+    }
+}
+
+final class NemotronASRCausalDwStridingSubsampling: Module {
+    let subsamplingFactor: Int
+    let samplingNum: Int
+    let stride: Int = 2
+    let kernelSize: Int = 3
+    let padLeft: Int = 2
+    let padRight: Int = 1
+    let convChannels: Int
+
+    @ModuleInfo(key: "conv0") var conv0: Conv2d
+    @ModuleInfo(key: "depthwise_layers") var depthwiseLayers: [Conv2d]
+    @ModuleInfo(key: "pointwise_layers") var pointwiseLayers: [Conv2d]
+    @ModuleInfo(key: "out") var out: Linear
+
+    init(args: NemotronASRConformerConfig) {
+        self.subsamplingFactor = args.subsamplingFactor
+        self.samplingNum = Int(log2(Double(args.subsamplingFactor)))
+        self.convChannels = args.subsamplingConvChannels
+
+        var finalFreqDim = args.featIn
+        for _ in 0..<samplingNum {
+            finalFreqDim = Int(floor(Double(finalFreqDim + padLeft + padRight - kernelSize) / Double(stride)) + 1)
+            if finalFreqDim < 1 {
+                finalFreqDim = 1
+            }
+        }
+
+        self._conv0.wrappedValue = Conv2d(
+            inputChannels: 1,
+            outputChannels: convChannels,
+            kernelSize: 3,
+            stride: 2,
+            padding: 0
+        )
+
+        var depthwise: [Conv2d] = []
+        var pointwise: [Conv2d] = []
+        if samplingNum > 1 {
+            depthwise.reserveCapacity(samplingNum - 1)
+            pointwise.reserveCapacity(samplingNum - 1)
+            for _ in 0..<(samplingNum - 1) {
+                depthwise.append(
+                    Conv2d(
+                        inputChannels: convChannels,
+                        outputChannels: convChannels,
+                        kernelSize: 3,
+                        stride: 2,
+                        padding: 0,
+                        groups: convChannels
+                    )
+                )
+                pointwise.append(
+                    Conv2d(
+                        inputChannels: convChannels,
+                        outputChannels: convChannels,
+                        kernelSize: 1,
+                        stride: 1,
+                        padding: 0
+                    )
+                )
+            }
+        }
+        self._depthwiseLayers.wrappedValue = depthwise
+        self._pointwiseLayers.wrappedValue = pointwise
+        self._out.wrappedValue = Linear(convChannels * finalFreqDim, args.dModel)
+    }
+
+    func callAsFunction(_ x: MLXArray, lengths: MLXArray) -> (MLXArray, MLXArray) {
+        var outLengths = lengths.asType(.float32)
+        for _ in 0..<samplingNum {
+            outLengths = floor((outLengths + Float(padLeft + padRight - kernelSize)) / Float(stride)) + 1
+        }
+
+        var y = x.expandedDimensions(axis: 3)
+        y = causalPad2D(y)
+        y = relu(conv0(y))
+
+        if !depthwiseLayers.isEmpty {
+            for i in depthwiseLayers.indices {
+                y = causalPad2D(y)
+                y = pointwiseLayers[i](depthwiseLayers[i](y))
+                y = relu(y)
+            }
+        }
+
+        let batch = y.shape[0]
+        let time = y.shape[1]
+        let freq = y.shape[2]
+        let channels = y.shape[3]
+        y = y.transposed(0, 1, 3, 2).reshaped([batch, time, channels * freq])
+        y = out(y)
+        return (y, outLengths.asType(.int32))
+    }
+
+    private func causalPad2D(_ x: MLXArray) -> MLXArray {
+        MLX.padded(
+            x,
+            widths: [.init(0), .init((padLeft, padRight)), .init((padLeft, padRight)), .init(0)]
+        )
+    }
+}
+
+final class NemotronASRConformerBlock: Module {
+    @ModuleInfo(key: "norm_feed_forward1") var normFeedForward1: LayerNorm
+    @ModuleInfo(key: "feed_forward1") var feedForward1: NemotronASRFeedForward
+
+    @ModuleInfo(key: "norm_self_att") var normSelfAtt: LayerNorm
+    @ModuleInfo(key: "self_attn") var selfAttn: ParakeetRelPositionMultiHeadAttention
+
+    @ModuleInfo(key: "norm_conv") var normConv: LayerNorm
+    @ModuleInfo(key: "conv") var conv: NemotronASRConvolution
+
+    @ModuleInfo(key: "norm_feed_forward2") var normFeedForward2: LayerNorm
+    @ModuleInfo(key: "feed_forward2") var feedForward2: NemotronASRFeedForward
+
+    @ModuleInfo(key: "norm_out") var normOut: LayerNorm
+
+    init(args: NemotronASRConformerConfig) {
+        let ffHidden = args.dModel * args.ffExpansionFactor
+
+        self._normFeedForward1.wrappedValue = LayerNorm(dimensions: args.dModel)
+        self._feedForward1.wrappedValue = NemotronASRFeedForward(dModel: args.dModel, dFF: ffHidden, useBias: args.useBias)
+
+        self._normSelfAtt.wrappedValue = LayerNorm(dimensions: args.dModel)
+        self._selfAttn.wrappedValue = ParakeetRelPositionMultiHeadAttention(
+            nHead: args.nHeads,
+            nFeat: args.dModel,
+            bias: args.useBias
+        )
+
+        self._normConv.wrappedValue = LayerNorm(dimensions: args.dModel)
+        self._conv.wrappedValue = NemotronASRConvolution(args: args)
+
+        self._normFeedForward2.wrappedValue = LayerNorm(dimensions: args.dModel)
+        self._feedForward2.wrappedValue = NemotronASRFeedForward(dModel: args.dModel, dFF: ffHidden, useBias: args.useBias)
+        self._normOut.wrappedValue = LayerNorm(dimensions: args.dModel)
+    }
+
+    func callAsFunction(_ x: MLXArray, posEmb: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        var y = x + MLXArray(Float(0.5)).asType(x.dtype) * feedForward1(normFeedForward1(x))
+        let yNorm = normSelfAtt(y)
+        y = y + selfAttn(yNorm, yNorm, yNorm, posEmb: posEmb, mask: mask)
+        y = y + conv(normConv(y))
+        y = y + MLXArray(Float(0.5)).asType(y.dtype) * feedForward2(normFeedForward2(y))
+        return normOut(y)
+    }
+}
+
+final class NemotronASRConformer: Module {
+    let args: NemotronASRConformerConfig
+
+    @ModuleInfo(key: "pos_enc") var posEnc: ParakeetRelPositionalEncoding
+    @ModuleInfo(key: "pre_encode") var preEncode: NemotronASRCausalDwStridingSubsampling
+    @ModuleInfo(key: "layers") var layers: [NemotronASRConformerBlock]
+
+    init(args: NemotronASRConformerConfig) {
+        self.args = args
+        self._posEnc.wrappedValue = ParakeetRelPositionalEncoding(
+            dModel: args.dModel,
+            maxLen: args.posEmbMaxLen,
+            scaleInput: args.xscaling
+        )
+        self._preEncode.wrappedValue = NemotronASRCausalDwStridingSubsampling(args: args)
+        self._layers.wrappedValue = (0..<args.nLayers).map { _ in
+            NemotronASRConformerBlock(args: args)
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        lengths: MLXArray? = nil,
+        attContextSize: [Int]? = nil
+    ) -> (MLXArray, MLXArray) {
+        let inLengths = lengths ?? MLXArray(Array(repeating: Int32(x.shape[1]), count: x.shape[0])).asType(.int32)
+        let encoded = preEncode(x, lengths: inLengths)
+        var h = encoded.0
+        let outLengths = encoded.1
+        let positional = posEnc(h)
+        h = positional.0
+        let posEmb = positional.1
+
+        let context = attContextSize ?? args.attContextSize.first ?? [56, 13]
+        let leftContext = context.first ?? 56
+        let rightContext = context.dropFirst().first ?? 13
+        let mask: MLXArray?
+        if args.attContextStyle == "chunked_limited" {
+            mask = NemotronASRAttentionMask
+                .createChunkedLimitedMask(seqLen: h.shape[1], leftContext: leftContext, rightContext: rightContext)
+                .asType(h.dtype)
+        } else {
+            mask = nil
+        }
+
+        for layer in layers {
+            h = layer(h, posEmb: posEmb, mask: mask)
+        }
+
+        return (h, outLengths)
+    }
+}

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
@@ -1,0 +1,541 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXAudioCore
+import MLXLMCommon
+import HuggingFace
+
+public final class NemotronASRModel: Module, STTGenerationModel {
+    public let config: NemotronASRConfig
+    public let preprocessConfig: NemotronASRPreprocessConfig
+    public let encoderConfig: NemotronASRConformerConfig
+    public let vocabulary: [String]
+    public let promptDictionary: [String: Int]
+    public let numPrompts: Int
+    public let blankTokenID: Int
+    public let defaultLanguage: String
+    public let defaultAttContextSize: [Int]
+    public let maxSymbols: Int?
+
+    public var computeDType: DType = .bfloat16
+
+    @ModuleInfo(key: "encoder") var encoder: NemotronASRConformer
+    @ModuleInfo(key: "prompt_kernel") var promptKernel: NemotronASRPromptKernel
+    @ModuleInfo(key: "decoder") var decoder: ParakeetPredictNetwork
+    @ModuleInfo(key: "joint") var joint: ParakeetJointNetwork
+
+    public var defaultGenerationParameters: STTGenerateParameters {
+        STTGenerateParameters(
+            maxTokens: 8192,
+            temperature: 0.0,
+            topP: 0.95,
+            topK: 0,
+            verbose: false,
+            language: defaultLanguage,
+            chunkDuration: 1200.0,
+            minChunkDuration: 1.0
+        )
+    }
+
+    public init(_ config: NemotronASRConfig) {
+        self.config = config
+        self.preprocessConfig = config.preprocessor
+        self.encoderConfig = config.encoder
+        self.vocabulary = config.vocabulary
+        self.promptDictionary = config.prompt.promptDictionary
+        self.numPrompts = config.prompt.numPrompts
+        self.blankTokenID = config.decoder.vocabSize
+        self.defaultLanguage = config.defaultLanguage
+        self.defaultAttContextSize = config.defaultAttContextSize
+        self.maxSymbols = config.maxSymbols
+
+        self._encoder.wrappedValue = NemotronASRConformer(args: config.encoder)
+        self._promptKernel.wrappedValue = NemotronASRPromptKernel(
+            dModel: config.encoder.dModel,
+            numPrompts: config.prompt.numPrompts,
+            promptHidden: config.prompt.promptHidden
+        )
+        self._decoder.wrappedValue = ParakeetPredictNetwork(
+            args: ParakeetPredictConfig(
+                blankAsPad: config.decoder.blankAsPad,
+                vocabSize: config.decoder.vocabSize,
+                prednet: ParakeetPredictNetworkConfig(
+                    predHidden: config.decoder.predHidden,
+                    predRnnLayers: config.decoder.predRnnLayers
+                )
+            )
+        )
+        self._joint.wrappedValue = ParakeetJointNetwork(
+            args: ParakeetJointConfig(
+                numClasses: config.joint.numClasses,
+                vocabulary: config.vocabulary,
+                jointnet: ParakeetJointNetworkConfig(
+                    jointHidden: config.joint.jointHidden,
+                    activation: config.joint.activation,
+                    encoderHidden: config.joint.encoderHidden,
+                    predHidden: config.joint.predHidden
+                )
+            )
+        )
+    }
+
+    public func generate(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> STTOutput {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let audio1D = normalizeAudioToMono(audio).asType(.float32)
+        let sampleRate = preprocessConfig.sampleRate
+        let totalSamples = audio1D.shape[0]
+        let audioDuration = Double(totalSamples) / Double(sampleRate)
+        let chunkDuration = Double(generationParameters.chunkDuration)
+        let result: ParakeetAlignedResult
+
+        if chunkDuration <= 0 || audioDuration <= chunkDuration {
+            result = decodeChunk(audio1D, language: generationParameters.language)
+        } else {
+            let chunkSamples = max(1, Int(chunkDuration * Double(sampleRate)))
+            let overlapDuration = 2.0
+            let overlapSamples = max(0, min(chunkSamples - 1, Int(overlapDuration * Double(sampleRate))))
+            let stepSamples = max(1, chunkSamples - overlapSamples)
+
+            var allTokens: [ParakeetAlignedToken] = []
+            var start = 0
+            while start < totalSamples {
+                let end = min(start + chunkSamples, totalSamples)
+                let chunkResult = decodeChunk(audio1D[start..<end], language: generationParameters.language)
+                var chunkTokens = flattenTokens(from: chunkResult)
+                let chunkOffset = Double(start) / Double(sampleRate)
+                for i in chunkTokens.indices {
+                    chunkTokens[i].start += chunkOffset
+                }
+
+                allTokens = mergeTokenSequences(
+                    existing: allTokens,
+                    incoming: chunkTokens,
+                    overlapDuration: overlapDuration
+                )
+                start += stepSamples
+            }
+            result = ParakeetAlignment.sentencesToResult(ParakeetAlignment.tokensToSentences(allTokens))
+        }
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+        return STTOutput(
+            text: result.text,
+            segments: result.segments,
+            language: generationParameters.language,
+            totalTime: elapsed
+        )
+    }
+
+    public func generateStream(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters
+    ) -> AsyncThrowingStream<STTGeneration, Error> {
+        AsyncThrowingStream { continuation in
+            let audio1D = self.normalizeAudioToMono(audio).asType(.float32)
+            let sampleRate = self.preprocessConfig.sampleRate
+            let totalSamples = audio1D.shape[0]
+            let audioDuration = Double(totalSamples) / Double(sampleRate)
+            let requestedChunk = Double(generationParameters.chunkDuration)
+            let chunkDuration = requestedChunk >= 1199 ? 5.0 : max(0.5, requestedChunk)
+            let overlapDuration = 1.0
+
+            let chunkSamples = max(1, Int(chunkDuration * Double(sampleRate)))
+            let overlapSamples = max(0, min(chunkSamples - 1, Int(overlapDuration * Double(sampleRate))))
+            let stepSamples = max(1, chunkSamples - overlapSamples)
+
+            var allTokens: [ParakeetAlignedToken] = []
+            var previousText = ""
+            var start = 0
+
+            while start < totalSamples {
+                let end = min(start + chunkSamples, totalSamples)
+                let isLast = end >= totalSamples
+                let chunkResult = self.decodeChunk(audio1D[start..<end], language: generationParameters.language)
+                var chunkTokens = self.flattenTokens(from: chunkResult)
+                let chunkOffset = Double(start) / Double(sampleRate)
+                for i in chunkTokens.indices {
+                    chunkTokens[i].start += chunkOffset
+                }
+
+                allTokens = self.mergeTokenSequences(
+                    existing: allTokens,
+                    incoming: chunkTokens,
+                    overlapDuration: overlapDuration
+                )
+
+                let currentResult = ParakeetAlignment.sentencesToResult(
+                    ParakeetAlignment.tokensToSentences(allTokens)
+                )
+                let fullText = currentResult.text
+                let nextText = fullText.hasPrefix(previousText)
+                    ? String(fullText.dropFirst(previousText.count))
+                    : fullText
+                previousText = fullText
+
+                if !nextText.isEmpty {
+                    continuation.yield(.token(nextText))
+                }
+
+                if isLast {
+                    continuation.yield(
+                        .result(
+                            STTOutput(
+                                text: currentResult.text,
+                                segments: currentResult.segments,
+                                language: generationParameters.language,
+                                totalTime: audioDuration
+                            )
+                        )
+                    )
+                    continuation.finish()
+                    return
+                }
+
+                start += stepSamples
+            }
+
+            continuation.yield(
+                .result(
+                    STTOutput(
+                        text: previousText,
+                        language: generationParameters.language,
+                        totalTime: audioDuration
+                    )
+                )
+            )
+            continuation.finish()
+        }
+    }
+
+    func decode(
+        mel: MLXArray,
+        language: String? = nil,
+        attContextSize: [Int]? = nil
+    ) -> ParakeetAlignedResult {
+        var features = mel
+        if features.ndim == 2 {
+            features = features.expandedDimensions(axis: 0)
+        }
+
+        assert(
+            features.ndim == 3 && features.shape[2] == preprocessConfig.features,
+            "Nemotron ASR input feature shape mismatch: expected [B, T, \(preprocessConfig.features)], got \(features.shape)"
+        )
+
+        features = features.asType(computeDType)
+        let encoded = encoder(features, attContextSize: attContextSize ?? defaultAttContextSize)
+        let prompted = applyPrompt(encoded.0, language: language)
+        eval(prompted, encoded.1)
+
+        let frameSeconds = Double(encoderConfig.subsamplingFactor * preprocessConfig.hopLength)
+            / Double(preprocessConfig.sampleRate)
+        var results: [ParakeetAlignedToken] = []
+        let maxLength = Int(encoded.1[0].item(Int32.self))
+        var lastToken = blankTokenID
+        var decoderState: ParakeetLSTMState?
+        var time = 0
+        var newSymbols = 0
+
+        while time < maxLength {
+            let frame = prompted[0..., time..<(time + 1), 0...]
+            let currentToken: MLXArray? = lastToken == blankTokenID
+                ? nil
+                : MLXArray(Int32(lastToken)).reshaped([1, 1]).asType(.int32)
+
+            let decoderOutput = decoder(currentToken, state: decoderState)
+            let pred = decoderOutput.0.asType(frame.dtype)
+            let proposedState: ParakeetLSTMState = (
+                hidden: decoderOutput.1.hidden?.asType(frame.dtype),
+                cell: decoderOutput.1.cell?.asType(frame.dtype)
+            )
+
+            let jointOutput = joint(frame, pred)
+            eval(jointOutput)
+            let token = jointOutput.argMax(axis: -1).item(Int.self)
+            let step = ParakeetDecodingLogic.rnntStep(
+                predictedToken: token,
+                blankToken: blankTokenID,
+                time: time,
+                newSymbols: newSymbols,
+                maxSymbols: maxSymbols
+            )
+
+            if step.emittedToken {
+                lastToken = token
+                decoderState = proposedState
+                if !NemotronASRTokenizer.isSpecialToken(token, vocabulary: vocabulary) {
+                    results.append(
+                        ParakeetAlignedToken(
+                            id: token,
+                            text: NemotronASRTokenizer.decode(tokens: [token], vocabulary: vocabulary),
+                            start: Double(time) * frameSeconds,
+                            duration: frameSeconds
+                        )
+                    )
+                }
+            }
+
+            time = step.nextTime
+            newSymbols = step.nextNewSymbols
+        }
+
+        let aligned = ParakeetAlignment.sentencesToResult(ParakeetAlignment.tokensToSentences(results))
+        if aligned.text.isEmpty {
+            return aligned
+        }
+        return aligned
+    }
+
+    func applyPrompt(_ encoded: MLXArray, language: String? = nil) -> MLXArray {
+        let promptIndex = resolvePromptIndex(language)
+        let batch = encoded.shape[0]
+        let time = encoded.shape[1]
+        let promptIDs = MLXArray(Array(repeating: Int32(promptIndex), count: batch * time))
+            .reshaped([batch, time])
+            .expandedDimensions(axis: 2)
+        let promptRange = MLX.arange(numPrompts, dtype: .int32).reshaped([1, 1, numPrompts])
+        let oneHot = MLX.where(promptRange .== promptIDs, MLXArray(Float(1)), MLXArray(Float(0))).asType(encoded.dtype)
+        let conditioned = MLX.concatenated([encoded, oneHot], axis: 2)
+        return promptKernel(conditioned)
+    }
+
+    func resolvePromptIndex(_ language: String?) -> Int {
+        let resolvedLanguage = language ?? defaultLanguage
+        if let index = promptDictionary[resolvedLanguage] {
+            return index
+        }
+        if let index = promptDictionary[defaultLanguage] {
+            return index
+        }
+        return 0
+    }
+
+    private func normalizeAudioToMono(_ audio: MLXArray) -> MLXArray {
+        audio.ndim > 1 ? audio.mean(axis: -1) : audio
+    }
+
+    private func decodeChunk(_ chunkAudio: MLXArray, language: String?) -> ParakeetAlignedResult {
+        let mel = NemotronASRAudio.logMelSpectrogram(chunkAudio, config: preprocessConfig)
+        return decode(mel: mel, language: language)
+    }
+
+    private func flattenTokens(from result: ParakeetAlignedResult) -> [ParakeetAlignedToken] {
+        result.sentences.flatMap { $0.tokens }
+    }
+
+    private func mergeTokenSequences(
+        existing: [ParakeetAlignedToken],
+        incoming: [ParakeetAlignedToken],
+        overlapDuration: Double
+    ) -> [ParakeetAlignedToken] {
+        if existing.isEmpty { return incoming }
+        if incoming.isEmpty { return existing }
+
+        do {
+            return try ParakeetAlignment.mergeLongestContiguous(existing, incoming, overlapDuration: overlapDuration)
+        } catch {
+            return ParakeetAlignment.mergeLongestCommonSubsequence(existing, incoming, overlapDuration: overlapDuration)
+        }
+    }
+}
+
+final class NemotronASRPromptKernel: Module {
+    @ModuleInfo(key: "0") var linear0: Linear
+    @ModuleInfo(key: "2") var linear2: Linear
+
+    init(dModel: Int, numPrompts: Int, promptHidden: Int) {
+        self._linear0.wrappedValue = Linear(dModel + numPrompts, promptHidden)
+        self._linear2.wrappedValue = Linear(promptHidden, dModel)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(relu(linear0(x)))
+    }
+}
+
+public extension NemotronASRModel {
+    private static func normalizedConfigData(_ rawData: Data) -> Data {
+        guard var text = String(data: rawData, encoding: .utf8) else {
+            return rawData
+        }
+
+        text = text.replacingOccurrences(of: "-Infinity", with: "null")
+        text = text.replacingOccurrences(of: "Infinity", with: "null")
+        text = text.replacingOccurrences(of: "NaN", with: "null")
+        return Data(text.utf8)
+    }
+
+    static func fromDirectory(
+        _ modelDir: URL,
+        computeDType: DType = .bfloat16
+    ) throws -> NemotronASRModel {
+        let configURL = modelDir.appendingPathComponent("config.json")
+        let rawConfigData = try Data(contentsOf: configURL)
+        let configData = normalizedConfigData(rawConfigData)
+        let config = try JSONDecoder().decode(NemotronASRConfig.self, from: configData)
+        let quantConfig = try JSONDecoder().decode(NemotronASRQuantizationConfig.self, from: configData)
+
+        let model = NemotronASRModel(config)
+        var weights: [String: MLXArray] = [:]
+        let files = try FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: nil)
+        let safetensors = files.filter { $0.pathExtension == "safetensors" }
+        for file in safetensors {
+            let shard = try MLX.loadArrays(url: file)
+            weights.merge(shard) { _, new in new }
+        }
+
+        let sanitized = sanitize(weights: weights)
+
+        if let perLayerQuant = quantConfig.perLayerQuantization {
+            quantize(model: model) { path, _ in
+                if sanitized["\(path).scales"] != nil {
+                    return perLayerQuant.quantization(layer: path)?.asTuple
+                }
+                return nil
+            }
+        }
+
+        try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
+        model.computeDType = computeDType
+
+        let casted = Dictionary(
+            uniqueKeysWithValues: model.parameters().flattened().map { key, value -> (String, MLXArray) in
+                guard value.dtype.isFloatingPoint, value.dtype != computeDType else {
+                    return (key, value)
+                }
+                return (key, value.asType(computeDType))
+            }
+        )
+        try model.update(parameters: ModuleParameters.unflattened(casted), verify: .noUnusedKeys)
+
+        model.train(false)
+        eval(model)
+        return model
+    }
+
+    static func fromPretrained(
+        _ modelPath: String = "mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit",
+        computeDType: DType = .bfloat16,
+        cache: HubCache = .default
+    ) async throws -> NemotronASRModel {
+        let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+
+        guard let repoID = Repo.ID(rawValue: modelPath) else {
+            throw NSError(
+                domain: "NemotronASRModel",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelPath)"]
+            )
+        }
+
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try fromDirectory(modelDir, computeDType: computeDType)
+    }
+}
+
+private extension NemotronASRModel {
+    static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var sanitized: [String: MLXArray] = [:]
+        sanitized.reserveCapacity(weights.count)
+
+        for (key, value) in weights {
+            guard let remapped = remapKey(key) else { continue }
+            sanitized[remapped] = value
+        }
+
+        return sanitized
+    }
+
+    static func remapKey(_ key: String) -> String? {
+        var newKey = key
+        newKey = newKey.replacingOccurrences(of: "joint.joint_net.2.", with: "joint.joint_net.")
+        newKey = newKey.replacingOccurrences(of: ".pos_bias_u", with: ".posBiasU")
+        newKey = newKey.replacingOccurrences(of: ".pos_bias_v", with: ".posBiasV")
+
+        if let converted = remapPreEncodeConvListKey(newKey) {
+            newKey = converted
+        } else if shouldSkipPreEncodeConvListKey(newKey) {
+            return nil
+        }
+
+        return newKey
+    }
+
+    static func remapPreEncodeConvListKey(_ key: String) -> String? {
+        let pieces = key.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard pieces.count >= 5 else { return nil }
+        guard pieces[0] == "encoder", pieces[1] == "pre_encode", pieces[2] == "conv" else { return nil }
+        guard let rawIndex = Int(pieces[3]) else { return nil }
+
+        let suffix = pieces.dropFirst(4).joined(separator: ".")
+
+        if rawIndex == 0 {
+            return "encoder.pre_encode.conv0.\(suffix)"
+        }
+        if rawIndex < 2 {
+            return nil
+        }
+
+        let shifted = rawIndex - 2
+        let block = shifted / 3
+        let mod = shifted % 3
+
+        if mod == 0 {
+            return "encoder.pre_encode.depthwise_layers.\(block).\(suffix)"
+        }
+        if mod == 1 {
+            return "encoder.pre_encode.pointwise_layers.\(block).\(suffix)"
+        }
+
+        return nil
+    }
+
+    static func shouldSkipPreEncodeConvListKey(_ key: String) -> Bool {
+        let pieces = key.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard pieces.count >= 5 else { return false }
+        guard pieces[0] == "encoder", pieces[1] == "pre_encode", pieces[2] == "conv" else { return false }
+        guard let rawIndex = Int(pieces[3]), rawIndex >= 2 else { return false }
+
+        let shifted = rawIndex - 2
+        return shifted % 3 == 2
+    }
+}
+
+private struct NemotronASRQuantizationConfig: Decodable {
+    let perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    init(from decoder: Decoder) throws {
+        if let base = try? BaseConfiguration(from: decoder) {
+            self.perLayerQuantization = base.perLayerQuantization
+            return
+        }
+
+        struct FlatQuantization: Decodable {
+            let groupSize: Int
+            let bits: Int
+            enum CodingKeys: String, CodingKey {
+                case groupSize = "group_size"
+                case bits
+            }
+        }
+        enum Keys: String, CodingKey { case quantization }
+        let container = try decoder.container(keyedBy: Keys.self)
+        if let q = try? container.decode(FlatQuantization.self, forKey: .quantization) {
+            self.perLayerQuantization = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(groupSize: q.groupSize, bits: q.bits),
+                perLayerQuantization: [:]
+            )
+        } else {
+            self.perLayerQuantization = nil
+        }
+    }
+}

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRTokenizer.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRTokenizer.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum NemotronASRTokenizer {
+    static func isLanguageTag(_ piece: String) -> Bool {
+        piece.hasPrefix("<") && piece.hasSuffix(">") && piece.contains("-")
+    }
+
+    static func isSpecialToken(_ tokenId: Int, vocabulary: [String]) -> Bool {
+        guard tokenId >= 0, tokenId < vocabulary.count else { return false }
+        let piece = vocabulary[tokenId]
+        return isLanguageTag(piece)
+            || (piece.hasPrefix("<|") && piece.hasSuffix("|>"))
+            || piece == "<unk>"
+            || piece == "<pad>"
+    }
+
+    static func decode(tokens: [Int], vocabulary: [String], stripLanguageTags: Bool = true) -> String {
+        var parts: [String] = []
+        parts.reserveCapacity(tokens.count)
+
+        for token in tokens {
+            guard token >= 0, token < vocabulary.count else { continue }
+            let piece = vocabulary[token]
+            if stripLanguageTags, isSpecialToken(token, vocabulary: vocabulary) {
+                continue
+            }
+            parts.append(piece.replacingOccurrences(of: "▁", with: " "))
+        }
+
+        return parts.joined()
+    }
+
+    static func detectedLanguage(tokens: [Int], vocabulary: [String]) -> String? {
+        for token in tokens {
+            guard token >= 0, token < vocabulary.count else { continue }
+            let piece = vocabulary[token]
+            if isLanguageTag(piece) {
+                return String(piece.dropFirst().dropLast())
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/MLXAudioSTT/Models/NemotronASR/README.md
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/README.md
@@ -1,0 +1,22 @@
+# Nemotron ASR
+
+Swift support for NVIDIA Nemotron 3.5 ASR streaming checkpoints converted to MLX.
+
+```swift
+import MLXAudioSTT
+
+let model = try await NemotronASRModel.fromPretrained(
+    "mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit"
+)
+let output = model.generate(audio: audio, generationParameters: .init(language: "auto"))
+print(output.text)
+```
+
+Supported repositories:
+
+| Model | Description |
+| --- | --- |
+| `mlx-community/nemotron-3.5-asr-streaming-0.6b` | bf16 checkpoint |
+| `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit` | 8-bit quantized checkpoint |
+
+The implementation follows the NeMo `EncDecRNNTBPEModelWithPrompt` layout: causal FastConformer encoder, chunked-limited relative attention, language prompt conditioning, and greedy RNN-T decoding.

--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetConfig.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetConfig.swift
@@ -147,6 +147,12 @@ public struct ParakeetPredictNetworkConfig: Codable, Sendable {
         case predRnnLayers = "pred_rnn_layers"
         case rnnHiddenSize = "rnn_hidden_size"
     }
+
+    public init(predHidden: Int, predRnnLayers: Int, rnnHiddenSize: Int? = nil) {
+        self.predHidden = predHidden
+        self.predRnnLayers = predRnnLayers
+        self.rnnHiddenSize = rnnHiddenSize
+    }
 }
 
 public struct ParakeetJointNetworkConfig: Codable, Sendable {
@@ -161,6 +167,13 @@ public struct ParakeetJointNetworkConfig: Codable, Sendable {
         case encoderHidden = "encoder_hidden"
         case predHidden = "pred_hidden"
     }
+
+    public init(jointHidden: Int, activation: String, encoderHidden: Int, predHidden: Int) {
+        self.jointHidden = jointHidden
+        self.activation = activation
+        self.encoderHidden = encoderHidden
+        self.predHidden = predHidden
+    }
 }
 
 public struct ParakeetPredictConfig: Codable, Sendable {
@@ -172,6 +185,12 @@ public struct ParakeetPredictConfig: Codable, Sendable {
         case blankAsPad = "blank_as_pad"
         case vocabSize = "vocab_size"
         case prednet
+    }
+
+    public init(blankAsPad: Bool, vocabSize: Int, prednet: ParakeetPredictNetworkConfig) {
+        self.blankAsPad = blankAsPad
+        self.vocabSize = vocabSize
+        self.prednet = prednet
     }
 }
 
@@ -194,6 +213,18 @@ public struct ParakeetJointConfig: Codable, Sendable {
         vocabulary = try container.decode([String].self, forKey: .vocabulary)
         jointnet = try container.decode(ParakeetJointNetworkConfig.self, forKey: .jointnet)
         numExtraOutputs = try container.decodeIfPresent(Int.self, forKey: .numExtraOutputs) ?? 0
+    }
+
+    public init(
+        numClasses: Int,
+        vocabulary: [String],
+        jointnet: ParakeetJointNetworkConfig,
+        numExtraOutputs: Int = 0
+    ) {
+        self.numClasses = numClasses
+        self.vocabulary = vocabulary
+        self.jointnet = jointnet
+        self.numExtraOutputs = numExtraOutputs
     }
 }
 

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -17,7 +17,7 @@ enum AppError: Error, LocalizedError, CustomStringConvertible {
         case .inputFileNotFound(let path):
             "Input audio file not found: \(path)"
         case .unsupportedModelRepo(let repo):
-            "Unsupported STT model repo: \(repo). Expected FireRedASR2, SenseVoice, GLMASR, Qwen3ASR, VoxtralRealtime, CohereTranscribe, Parakeet, or Qwen3ForcedAligner."
+            "Unsupported STT model repo: \(repo). Expected NemotronASR, FireRedASR2, SenseVoice, GLMASR, Qwen3ASR, VoxtralRealtime, CohereTranscribe, Parakeet, or Qwen3ForcedAligner."
         case .missingTextForForcedAlignment:
             "--text is required when using a forced aligner model."
         case .streamUnsupportedForForcedAligner:
@@ -412,6 +412,9 @@ enum App {
         }
         if lower.contains("parakeet") {
             return .stt(try await ParakeetModel.fromPretrained(repo))
+        }
+        if lower.contains("nemotron") {
+            return .stt(try await NemotronASRModel.fromPretrained(repo))
         }
         if lower.contains("firered") || lower.contains("fire-red") {
             return .stt(try await FireRedASR2Model.fromPretrained(repo))

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -14,6 +14,7 @@
 //      -only-testing:MLXAudioTests/SenseVoiceTests \
 //      -only-testing:MLXAudioTests/SenseVoiceNetworkTests \
 //      -only-testing:MLXAudioTests/ParakeetSTTTests \
+//      -only-testing:MLXAudioTests/NemotronASRTests \
 //      -only-testing:MLXAudioTests/VoxtralRealtimeSTTTests \
 //      -only-testing:MLXAudioTests/CohereTranscribeModuleSetupTests \
 //      -only-testing:MLXAudioTests/CohereTranscribeSTTTests \
@@ -31,6 +32,7 @@
 //    -only-testing:'MLXAudioTests/SenseVoiceTests'
 //    -only-testing:'MLXAudioTests/SenseVoiceNetworkTests'
 //    -only-testing:'MLXAudioTests/ParakeetSTTTests'
+//    -only-testing:'MLXAudioTests/NemotronASRTests'
 //    -only-testing:'MLXAudioTests/VoxtralRealtimeSTTTests'
 //    -only-testing:'MLXAudioTests/CohereTranscribeModuleSetupTests'
 //    -only-testing:'MLXAudioTests/CohereTranscribeSTTTests'
@@ -2485,6 +2487,158 @@ struct ParakeetSTTTests {
 
         #expect(mel.ndim == 3)
         #expect(mel.reshaped(-1)[0].item(Float.self).isFinite)
+    }
+}
+
+struct NemotronASRTests {
+    private var mlxRuntimeEnabled: Bool {
+        ProcessInfo.processInfo.environment["MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS"] == "1"
+    }
+
+    private func tinyConfigJSON() -> String {
+        """
+        {
+          "model_type": "nemotron_asr",
+          "preprocessor": {
+            "sample_rate": 16000,
+            "features": 16,
+            "n_fft": 64,
+            "window_size": 0.004,
+            "window_stride": 0.002,
+            "window": "hann",
+            "preemph": 0.97,
+            "dither": 0.0,
+            "normalize": "NA"
+          },
+          "encoder": {
+            "feat_in": 16,
+            "n_layers": 1,
+            "d_model": 16,
+            "n_heads": 2,
+            "ff_expansion_factor": 2,
+            "subsampling_factor": 4,
+            "subsampling_conv_channels": 4,
+            "conv_kernel_size": 3,
+            "causal_downsampling": true,
+            "conv_context_size": "causal",
+            "conv_norm_type": "layer_norm",
+            "self_attention_model": "rel_pos",
+            "att_context_style": "chunked_limited",
+            "att_context_size": [[4, 1]],
+            "pos_emb_max_len": 64,
+            "use_bias": false,
+            "xscaling": false
+          },
+          "prompt": {
+            "num_prompts": 4,
+            "prompt_hidden": 16,
+            "prompt_dictionary": {"en-US": 0, "auto": 1}
+          },
+          "decoder": {
+            "pred_hidden": 8,
+            "pred_rnn_layers": 1,
+            "vocab_size": 6,
+            "blank_as_pad": true
+          },
+          "joint": {
+            "joint_hidden": 8,
+            "activation": "relu",
+            "encoder_hidden": 16,
+            "pred_hidden": 8,
+            "num_classes": 6
+          },
+          "vocabulary": ["<unk>", "<en-US>", "▁hello", "▁world", "!", "a"],
+          "default_language": "auto",
+          "default_att_context_size": [4, 1],
+          "max_symbols": 3
+        }
+        """
+    }
+
+    private func tinyModel() throws -> NemotronASRModel {
+        let config = try JSONDecoder().decode(NemotronASRConfig.self, from: Data(tinyConfigJSON().utf8))
+        let model = NemotronASRModel(config)
+        eval(model.parameters())
+        model.train(false)
+        return model
+    }
+
+    @Test func configDecodesPromptAndStreamingContext() throws {
+        let config = try JSONDecoder().decode(NemotronASRConfig.self, from: Data(tinyConfigJSON().utf8))
+        #expect(config.modelType == "nemotron_asr")
+        #expect(config.encoder.causalDownsampling == true)
+        #expect(config.encoder.attContextSize == [[4, 1]])
+        #expect(config.prompt.promptDictionary["en-US"] == 0)
+        #expect(config.defaultLanguage == "auto")
+    }
+
+    @Test func chunkedLimitedMaskMatchesNeMoVisibility() {
+        guard mlxRuntimeEnabled else {
+            print("Skipping Nemotron ASR MLX runtime test. Set MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS=1 to enable.")
+            return
+        }
+
+        let mask = NemotronASRAttentionMask.createChunkedLimitedMask(seqLen: 6, leftContext: 2, rightContext: 1)
+        let values = mask[0, 0].asArray(Float.self)
+
+        func visibleRow(_ row: Int) -> [Bool] {
+            let start = row * 6
+            return (0..<6).map { values[start + $0] == 0 }
+        }
+
+        #expect(visibleRow(0) == [true, true, false, false, false, false])
+        #expect(visibleRow(2) == [true, true, true, true, false, false])
+        #expect(visibleRow(5) == [false, false, true, true, true, true])
+    }
+
+    @Test func encoderAndPromptShapes() throws {
+        guard mlxRuntimeEnabled else {
+            print("Skipping Nemotron ASR MLX runtime test. Set MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS=1 to enable.")
+            return
+        }
+
+        let model = try tinyModel()
+        let values = (0..<(1 * 40 * 16)).map { Float($0 % 17) / 17.0 }
+        let mel = MLXArray(values).reshaped([1, 40, 16])
+
+        let encoded = model.encoder(mel, attContextSize: [4, 1])
+        let prompted = model.applyPrompt(encoded.0, language: "en-US")
+
+        #expect(encoded.0.shape[0] == 1)
+        #expect(encoded.0.shape[2] == model.encoderConfig.dModel)
+        #expect(prompted.shape == encoded.0.shape)
+        #expect(encoded.0.shape[1] == Int(encoded.1[0].item(Int32.self)))
+    }
+
+    @Test func decodeRunsWithoutLeakingLanguageTags() throws {
+        guard mlxRuntimeEnabled else {
+            print("Skipping Nemotron ASR MLX runtime test. Set MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS=1 to enable.")
+            return
+        }
+
+        let model = try tinyModel()
+        let sampleCount = 48 * 16
+        let values: [Float] = (0..<sampleCount).map { index in
+            Float((index * 7) % 23) / 23.0
+        }
+        let mel = MLXArray(values).reshaped([1, 48, 16])
+        let result = model.decode(mel: mel, language: "auto", attContextSize: [4, 1])
+
+        #expect(result.text.contains("<") == false)
+    }
+
+    @Test func tokenizerStripsLanguageTags() {
+        let vocab = ["<unk>", "<en-US>", "▁hello", "▁world", "!", "<"]
+        #expect(NemotronASRTokenizer.isLanguageTag("<en-US>") == true)
+        #expect(NemotronASRTokenizer.isLanguageTag("<") == false)
+        #expect(NemotronASRTokenizer.isSpecialToken(1, vocabulary: vocab) == true)
+        #expect(NemotronASRTokenizer.isSpecialToken(2, vocabulary: vocab) == false)
+        #expect(NemotronASRTokenizer.decode(tokens: [1, 2, 3, 4], vocabulary: vocab) == " hello world!")
+        #expect(
+            NemotronASRTokenizer.decode(tokens: [1, 2, 3, 4], vocabulary: vocab, stripLanguageTags: false)
+            == "<en-US> hello world!"
+        )
+        #expect(NemotronASRTokenizer.detectedLanguage(tokens: [1, 2, 3], vocabulary: vocab) == "en-US")
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `NemotronASRModel` for mlx-community Nemotron 3.5 ASR streaming checkpoints
- Implement Nemotron-specific config parsing, causal FastConformer, chunked-limited attention mask, language prompt kernel, tokenizer, and greedy RNNT decoding
- Wire Nemotron repos into the STT CLI and README model table

## Supported checkpoints
- `mlx-community/nemotron-3.5-asr-streaming-0.6b`
- `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit`

## Tests
- `swift test --filter NemotronASRTests`

Note: MLX runtime shape/decode tests are gated behind `MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS=1` because `swift test` on this machine does not package the MLX `default.metallib`; default Nemotron tests still cover config parsing and tokenizer behavior.