### PR TITLE
[Perf] Run the Parakeet Conformer encoder on the Apple Neural Engine (CoreML)

### DIFF
--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetCoreMLEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetCoreMLEncoder.swift
@@ -1,0 +1,142 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+import MLX
+
+/// Drop-in CoreML/ANE replacement for the MLX Conformer encoder. The model is
+/// fixed-shape because ANE requires it (RangeDim → 0% residency), so each chunk's mel
+/// is padded to `fixedFrames` and the output cropped back to the true subsampled length.
+public final class ParakeetCoreMLEncoder: @unchecked Sendable {
+    private let model: MLModel
+    private let featIn: Int
+    /// The fixed mel-frame count the model was converted at (e.g. 1000 = 10 s). Callers use
+    /// this to keep their chunking ≤ this length, since longer mel is cropped.
+    public let fixedFrames: Int
+    private let subsamplingFactor: Int
+    private let inputName: String
+    private let outputName: String
+    /// Expected encoder output width (`d_model`); when set, `encode` rejects a model whose
+    /// output doesn't match the loaded checkpoint instead of returning mis-shaped features.
+    private let expectedDModel: Int?
+    /// One subsampling stage on a length. Parakeet: `(L-1)/2+1`; encoders with different conv
+    /// padding (e.g. Nemotron's pad-before-stride `floor(L/2)+1`) inject their own so the ANE
+    /// output is cropped to the right valid width.
+    private let subsampledLengthStep: (Int) -> Int
+
+    public init(
+        modelURL: URL,
+        featIn: Int,
+        fixedFrames: Int,
+        subsamplingFactor: Int,
+        dModel: Int? = nil,
+        subsampledLengthStep: (@Sendable (Int) -> Int)? = nil,
+        computeUnits: MLComputeUnits = .all,
+        inputName: String = "features",
+        outputName: String = "encoded"
+    ) throws {
+        let compiledURL: URL
+        if modelURL.pathExtension == "mlmodelc" {
+            compiledURL = modelURL
+        } else {
+            compiledURL = try MLModel.compileModel(at: modelURL)
+        }
+        let config = MLModelConfiguration()
+        config.computeUnits = computeUnits
+        self.model = try MLModel(contentsOf: compiledURL, configuration: config)
+        self.featIn = featIn
+        self.fixedFrames = fixedFrames
+        self.subsamplingFactor = subsamplingFactor
+        self.inputName = inputName
+        self.outputName = outputName
+        self.expectedDModel = dModel
+        self.subsampledLengthStep = subsampledLengthStep ?? { ($0 - 1) / 2 + 1 }
+    }
+
+    /// Parakeet default: `floor((L-1)/2)+1`, log2(factor) times. `step` overrides the per-stage
+    /// rule for encoders whose conv padding differs (e.g. Nemotron's `floor(L/2)+1`).
+    static func subsampledLength(
+        frames: Int,
+        subsamplingFactor: Int,
+        step: (Int) -> Int = { ($0 - 1) / 2 + 1 }
+    ) -> Int {
+        var l = frames
+        let steps = Int(log2(Double(subsamplingFactor)))
+        for _ in 0..<steps { l = step(l) }
+        return l
+    }
+
+    private func encodedLength(for frames: Int) -> Int {
+        Self.subsampledLength(frames: frames, subsamplingFactor: subsamplingFactor, step: subsampledLengthStep)
+    }
+
+    /// Encode one chunk. `features`: `[1, T, featIn]` (any float dtype).
+    /// Returns `(encoded [1, T', dModel], lengths [1])`, dtype = `outputDType`.
+    public func encode(_ features: MLXArray, outputDType: DType) throws -> (MLXArray, MLXArray) {
+        // Fixed-shape ANE model: it only handles a single chunk that fits the window.
+        // Throw (rather than silently truncate a long chunk or scramble a multi-item batch)
+        // so callers — which invoke `encode` via `try?` — fall back to the MLX encoder and
+        // still produce a complete, correct result.
+        guard features.shape[0] == 1 else {
+            throw STTError.invalidInput("CoreML encoder handles batch size 1 (got \(features.shape[0])); falling back to MLX")
+        }
+        let trueFrames = features.shape[1]
+        guard trueFrames <= fixedFrames else {
+            throw STTError.invalidInput(
+                "chunk of \(trueFrames) mel frames exceeds the fixed CoreML window of \(fixedFrames); "
+                    + "use a shorter --chunk-duration or the MLX encoder")
+        }
+        let clamped = trueFrames
+
+        var mel = features.asType(.float32)
+        if trueFrames < fixedFrames {
+            mel = padded(mel, widths: [.init((0, 0)), .init((0, fixedFrames - trueFrames)), .init((0, 0))])
+        }
+        // mel is [1, fixedFrames, featIn] row-major; CoreML wants [1, featIn, fixedFrames].
+        let melFlat = mel.asArray(Float.self)  // index = t * featIn + f
+        let input = try MLMultiArray(shape: [1, NSNumber(value: featIn), NSNumber(value: fixedFrames)], dataType: .float32)
+        input.dataPointer.withMemoryRebound(to: Float.self, capacity: featIn * fixedFrames) { dst in
+            for t in 0..<fixedFrames {
+                for f in 0..<featIn {
+                    dst[f * fixedFrames + t] = melFlat[t * featIn + f]
+                }
+            }
+        }
+
+        let provider = try MLDictionaryFeatureProvider(dictionary: [inputName: MLFeatureValue(multiArray: input)])
+        let out = try model.prediction(from: provider)
+        guard let enc = out.featureValue(for: outputName)?.multiArrayValue else {
+            throw STTError.invalidInput("CoreML encoder produced no '\(outputName)' output")
+        }
+
+        let dModel = enc.shape[1].intValue
+        let tFull = enc.shape[2].intValue
+        guard expectedDModel == nil || dModel == expectedDModel else {
+            throw STTError.invalidInput(
+                "CoreML encoder output dim \(dModel) ≠ model d_model \(expectedDModel!); this ANE "
+                    + "encoder doesn't match the loaded checkpoint — falling back to MLX")
+        }
+        // ANE outputs are often stride-padded, so honor strides rather than reading the
+        // raw buffer sequentially (which would scramble frames).
+        let s1 = enc.strides[1].intValue
+        let s2 = enc.strides[2].intValue
+        let count = dModel * tFull
+        let capacity = (dModel - 1) * s1 + (tFull - 1) * s2 + 1
+        var encFloats = [Float](repeating: 0, count: count)  // packed [d * tFull + t]
+        if enc.dataType == .float16 {
+            let p = enc.dataPointer.bindMemory(to: UInt16.self, capacity: capacity)
+            for d in 0..<dModel { for t in 0..<tFull { encFloats[d * tFull + t] = Float(Float16(bitPattern: p[d * s1 + t * s2])) } }
+        } else {
+            let p = enc.dataPointer.bindMemory(to: Float.self, capacity: capacity)
+            for d in 0..<dModel { for t in 0..<tFull { encFloats[d * tFull + t] = p[d * s1 + t * s2] } }
+        }
+
+        let validLen = encodedLength(for: clamped)
+        var encoded = MLXArray(encFloats, [1, dModel, tFull]).transposed(0, 2, 1)
+        if validLen < tFull {
+            encoded = encoded[0..., 0..<validLen, 0...]
+        }
+        let lengths = MLXArray([Int32(validLen)]).asType(.int32)
+        return (encoded.asType(outputDType), lengths)
+    }
+}
+#endif

--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
@@ -34,6 +34,7 @@ public final class ParakeetModel: Module, STTGenerationModel {
     enum EncoderExecutionImplementation: Sendable {
         case plain
         case compiled
+        case coreML
     }
 
     struct TDTTraceStep: Sendable, Equatable {
@@ -52,6 +53,9 @@ public final class ParakeetModel: Module, STTGenerationModel {
 
     var tdtDecoderImplementation: TDTDecoderImplementation?
     var encoderExecutionImplementation: EncoderExecutionImplementation?
+    #if canImport(CoreML)
+    var coreMLEncoder: ParakeetCoreMLEncoder?
+    #endif
     var tdtTraceEmitter: (@Sendable (TDTTraceStep) -> Void)?
     private var compiledEncoderFeaturesByShape: [String: @Sendable (MLXArray) -> MLXArray] = [:]
 
@@ -122,8 +126,19 @@ public final class ParakeetModel: Module, STTGenerationModel {
         let sampleRate = preprocessConfig.sampleRate
         let totalSamples = audio1D.shape[0]
         let audioDuration = Double(totalSamples) / Double(sampleRate)
-        let chunkDuration = Double(generationParameters.chunkDuration)
+        var chunkDuration = Double(generationParameters.chunkDuration)
         let overlapDuration = 2.0
+        #if canImport(CoreML)
+        // The fixed-shape ANE encoder fits only `fixedFrames` mel frames; force chunking ≤ that
+        // window (overlap-merge restitches) so long audio actually uses the ANE path instead of
+        // silently falling back to MLX on one oversized chunk. (A few frames of margin keep the
+        // boundary attention clean.)
+        if let coreMLEncoder {
+            let hopSeconds = Double(preprocessConfig.hopLength) / Double(sampleRate)
+            let maxChunkSeconds = Double(coreMLEncoder.fixedFrames - 4) * hopSeconds
+            chunkDuration = chunkDuration <= 0 ? maxChunkSeconds : min(chunkDuration, maxChunkSeconds)
+        }
+        #endif
 
         let result: ParakeetAlignedResult
         if chunkDuration <= 0 || audioDuration <= chunkDuration {
@@ -313,8 +328,93 @@ public final class ParakeetModel: Module, STTGenerationModel {
             let encodedFeatures = compiledEncoderFeatures(for: features)(features)
             let encodedLengths = computeEncodedLengths(from: resolvedLengths)
             return (encodedFeatures, encodedLengths)
+        case .coreML:
+            #if canImport(CoreML)
+            if let coreMLEncoder,
+               let result = try? coreMLEncoder.encode(features, outputDType: computeDType) {
+                return result
+            }
+            #endif
+            return encoder(features, lengths: resolvedLengths)  // fallback if CoreML unavailable
         }
     }
+
+    /// How to source the optional CoreML/ANE Conformer encoder (default `.off` = pure MLX).
+    public enum ANEEncoder: Sendable {
+        case off
+        case on                  // download `defaultANEEncoderRepo` (parakeet-tdt-0.6b-v3); other checkpoints: use `.repo`/`.package`
+        case repo(String)        // download a specific Hugging Face repo
+        case package(URL)        // a local .mlpackage / .mlmodelc
+    }
+
+    public static let defaultANEEncoderRepo = "beshkenadze/parakeet-tdt-0.6b-v3-coreml-ane"
+
+    /// Apply an `ANEEncoder` option. No-op for `.off` or when CoreML is unavailable.
+    public func applyANEEncoder(_ option: ANEEncoder, cache: HubCache = .default) async throws {
+        #if canImport(CoreML)
+        switch option {
+        case .off: break
+        case .on: try await enableCoreMLEncoder(repo: Self.defaultANEEncoderRepo, cache: cache)
+        case .repo(let repo): try await enableCoreMLEncoder(repo: repo, cache: cache)
+        case .package(let url): try enableCoreMLEncoder(modelURL: url)
+        }
+        #endif
+    }
+
+    #if canImport(CoreML)
+    /// Route the Conformer encoder through CoreML/ANE; decoder and chunking stay in MLX.
+    public func enableCoreMLEncoder(modelURL: URL, fixedFrames: Int = 1000) throws {
+        coreMLEncoder = try ParakeetCoreMLEncoder(
+            modelURL: modelURL,
+            featIn: encoderConfig.featIn,
+            fixedFrames: fixedFrames,
+            subsamplingFactor: encoderConfig.subsamplingFactor,
+            dModel: encoderConfig.dModel
+        )
+        encoderExecutionImplementation = .coreML
+    }
+
+    /// Download a CoreML encoder `.mlpackage` from a Hugging Face repo, then route through it.
+    public func enableCoreMLEncoder(repo: String, cache: HubCache = .default) async throws {
+        let url = try await Self.downloadANEEncoderPackage(repo: repo, cache: cache)
+        try enableCoreMLEncoder(modelURL: url)
+    }
+
+    static func downloadANEEncoderPackage(repo: String, cache: HubCache = .default) async throws -> URL {
+        guard let repoID = Repo.ID(rawValue: repo) else {
+            throw NSError(domain: "ParakeetModel", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid ANE encoder repo: \(repo)"])
+        }
+        let hfToken = ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+        let client = (hfToken?.isEmpty == false)
+            ? HubClient(host: HubClient.defaultHost, bearerToken: hfToken!, cache: cache)
+            : HubClient(cache: cache)
+        let dir = (client.cache ?? cache).cacheDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(repo.replacingOccurrences(of: "/", with: "_"))
+
+        if let cached = findEncoderPackage(in: dir) { return cached }
+
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await client.downloadSnapshot(
+            of: repoID, kind: .model, to: dir, revision: "main",
+            matching: ["*.json", "*.mlmodel", "*.bin", "*.weights", "*.mil", "*.espresso.*"],
+            progressHandler: { _ in }
+        )
+        guard let pkg = findEncoderPackage(in: dir) else {
+            throw NSError(domain: "ParakeetModel", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey: "No .mlpackage/.mlmodelc found in \(repo)"])
+        }
+        return pkg
+    }
+
+    static func findEncoderPackage(in dir: URL) -> URL? {
+        guard let items = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        else { return nil }
+        return items.first { ["mlpackage", "mlmodelc"].contains($0.pathExtension) }
+    }
+    #endif
 
     func compiledEncoderFeatures(for features: MLXArray) -> @Sendable (MLXArray) -> MLXArray {
         let key = "\(features.shape)-\(features.dtype)"
@@ -1054,7 +1154,8 @@ public extension ParakeetModel {
     static func fromPretrained(
         _ modelPath: String,
         computeDType: DType = .bfloat16,
-        cache: HubCache = .default
+        cache: HubCache = .default,
+        aneEncoder: ANEEncoder = .off
     ) async throws -> ParakeetModel {
         let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
             ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
@@ -1073,7 +1174,9 @@ public extension ParakeetModel {
             hfToken: hfToken,
             cache: cache
         )
-        return try fromDirectory(modelDir, computeDType: computeDType)
+        let model = try fromDirectory(modelDir, computeDType: computeDType)
+        try await model.applyANEEncoder(aneEncoder, cache: cache)
+        return model
     }
 }
 

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -78,6 +78,8 @@ private struct Options {
     var prefillStepSize = 2048
     var genKwargsRaw: String? = nil
     var text = ""
+    var coremlEncoder: String? = nil
+    var ane = false
 
     var temperature: Float? = nil
     var topP: Float? = nil
@@ -139,6 +141,11 @@ private struct Options {
             case "--text":
                 guard let v = it.next() else { throw CLIError.missingValue(arg) }
                 options.text = v
+            case "--coreml-encoder":
+                guard let v = it.next() else { throw CLIError.missingValue(arg) }
+                options.coremlEncoder = v
+            case "--ane":
+                options.ane = true
             case "--help", "-h":
                 printUsage()
                 exit(0)
@@ -271,6 +278,18 @@ enum App {
         let (inputSampleRate, inputAudio) = try loadAudioArray(from: inputURL)
         let audio = try prepareAudioForSTT(inputAudio, inputSampleRate: inputSampleRate, targetSampleRate: 16000)
 
+        #if canImport(CoreML)
+        if case .stt(let m) = model, let parakeet = m as? ParakeetModel {
+            if let coremlPath = options.coremlEncoder {
+                try parakeet.enableCoreMLEncoder(modelURL: resolveURL(path: coremlPath))
+                if options.verbose { print("CoreML/ANE encoder enabled: \(coremlPath)") }
+            } else if options.ane {
+                try await parakeet.enableCoreMLEncoder(repo: ParakeetModel.defaultANEEncoderRepo)
+                if options.verbose { print("ANE encoder enabled: \(ParakeetModel.defaultANEEncoderRepo)") }
+            }
+        }
+        #endif
+
         let startTime = CFAbsoluteTimeGetCurrent()
 
         if options.verbose {
@@ -346,9 +365,11 @@ enum App {
 
         if options.verbose {
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+            let audioSeconds = Double(audio.size) / 16000.0
             print("\n==========")
             print("Saved file to: \(options.outputPath!).\(options.format.rawValue)")
             print(String(format: "Processing time: %.2f seconds", elapsed))
+            print(String(format: "RTF: %.1fx realtime (%.1fs audio / %.2fs)", audioSeconds / elapsed, audioSeconds, elapsed))
             print(String(format: "Prompt: %d tokens, %.3f tokens-per-sec", output.promptTokens, output.promptTps))
             print(String(format: "Generation: %d tokens, %.3f tokens-per-sec", output.generationTokens, output.generationTps))
             print(String(format: "Peak memory: %.2f GB", output.peakMemoryUsage))

--- a/Tests/ParakeetCoreMLEncoderTests.swift
+++ b/Tests/ParakeetCoreMLEncoderTests.swift
@@ -1,0 +1,41 @@
+#if canImport(CoreML)
+import Foundation
+import Testing
+
+@testable import MLXAudioSTT
+
+@Suite("Parakeet CoreML Encoder Tests")
+struct ParakeetCoreMLEncoderTests {
+    /// The wrapper's output-length math must match `ParakeetModel.computeEncodedLengths`
+    /// (NeMo dw-striding: `floor((L-1)/2)+1`, log2(factor) times).
+    @Test func subsampledLengthMatchesDwStriding() {
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 1000, subsamplingFactor: 8) == 125)
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 995, subsamplingFactor: 8) == 125)
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 128, subsamplingFactor: 8) == 16)
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 1, subsamplingFactor: 8) == 1)
+    }
+
+    /// A missing/invalid `.mlpackage` must surface as a thrown error (the model then falls
+    /// back to the MLX encoder), never a crash.
+    @Test func throwsOnMissingModel() {
+        let bogus = URL(fileURLWithPath: "/nonexistent/parakeet_enc.mlpackage")
+        #expect(throws: (any Error).self) {
+            _ = try ParakeetCoreMLEncoder(
+                modelURL: bogus, featIn: 128, fixedFrames: 1000, subsamplingFactor: 8)
+        }
+    }
+
+    /// Resolving the downloaded encoder picks the `.mlpackage` (or `.mlmodelc`) directory.
+    @Test func findsEncoderPackageInDirectory() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("parakeet-coreml-findtest")
+        try? fm.removeItem(at: base)
+        let pkg = base.appendingPathComponent("enc.mlpackage")
+        try fm.createDirectory(at: pkg, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: base) }
+
+        #expect(ParakeetModel.findEncoderPackage(in: base)?.lastPathComponent == "enc.mlpackage")
+        #expect(ParakeetModel.findEncoderPackage(in: pkg) == nil)  // empty dir → nothing
+    }
+}
+#endif


### PR DESCRIPTION
# Run the Parakeet Conformer encoder on the Apple Neural Engine (CoreML)

## Summary

Adds an **optional CoreML/ANE path for the Parakeet Conformer encoder**, behind a flag.
The encoder (≈95% of the compute) runs on the Apple Neural Engine via CoreML while the
TDT decoder and chunking stay in MLX. Same transcript, lower power, and a small speedup
on top.

It plugs into the existing `EncoderExecutionImplementation` hook in `ParakeetModel`
(new `.coreML` case + `enableCoreMLEncoder(modelURL:)`), so the decode path is untouched.
It falls back to the MLX encoder if CoreML is unavailable. **Public `MLModel` +
`MLComputeUnits` only — no private ANE APIs.**

```bash
# auto-downloads the prebuilt encoder from Hugging Face
mlx-audio-swift-stt --model beshkenadze/parakeet-tdt-0.6b-v3-mlx-fp16 \
    --audio in.wav --output-path out --ane --chunk-duration 9.95
```

```swift
// .off (default) · .on (default HF repo) · .repo("id") · .package(localURL)
let model = try await ParakeetModel.fromPretrained(repo, aneEncoder: .on)
```

## Why

ANE has no public API — CoreML is the only sanctioned route, and MLX is GPU/Metal only.
Splitting the graph at the encoder boundary (static feed-forward → CoreML/ANE; the
autoregressive TDT loop → MLX) is a clean, lossless way to reach the ANE. The payoff is
mostly **power/thermal** (the encoder leaves the GPU), with a speedup as a bonus.

## Results

Measured on **M1 Max**, `parakeet-tdt-0.6b-v3`, a 20.8-min TED-LIUM 3 talk, chunk 9.95s.

| Metric | all-MLX | hybrid (CoreML/ANE encoder) |
|---|---|---|
| **ANE residency** (encoder) | — | **100%** (0 CPU / 0 GPU ops, 0 graph interruptions) |
| **WER** vs reference | 7.28% | **7.11%** · agreement **1.07%** |
| **RTF** (Swift release, interleaved) | ~95× | **~131×** → **~1.38×** |
| **GPU power** (sustained) | 17.3 W | **3.0 W** (**÷5.8**) |
| **Package power** | 23.4 W | **10.3 W** (**÷2.3**) — ANE encoder ≈ 0.9 W |

- The transcript is reproduced ~1:1 (2786 vs 2802 words); the residual is the
  fp16-vs-bf16 difference (CoreML-fp16 is actually *closer* to fp32 than the shipped
  MLX-bf16 encoder).
- Residency **holds at the 1.1b** variant too (100%, 0 interruptions).

## How it works

- **Fixed input shape** (a fixed mel-frame count, e.g. 1000 = 10s) — required for ANE
  residency; a dynamic (`RangeDim`) time axis drops it to 0%. The Swift wrapper pads each
  chunk's mel to the fixed length and crops the output via the subsampling formula. Keep
  `--chunk-duration ≤ frames·10ms`.
- The ANE output `MLMultiArray` is stride-padded, so the wrapper reads it by strides.
- Conversion (NeMo → `.mlpackage`) lives in `tools/coreml-ane/` (`convert_encoder.py` +
  `convert_traced.py`); see the README. `--fp16-io` gives 100% ANE / 0 CPU ops.

## Scope

- Swift: `ParakeetCoreMLEncoder.swift`, `ParakeetModel.swift` (the `.coreML` case),
  `App.swift` (the `--coreml-encoder` flag).
- Tooling: `tools/coreml-ane/` converter + README.

## Limitations / follow-ups

- The `.mlpackage` is not bundled (it's large). A prebuilt one is hosted on Hugging Face
  ([`beshkenadze/parakeet-tdt-0.6b-v3-coreml-ane`](https://huggingface.co/beshkenadze/parakeet-tdt-0.6b-v3-coreml-ane));
  users can also convert it via the tooling.
- MLX↔CoreML marshaling currently uses CPU copies; a zero-copy IOSurface-backed
  `MLMultiArray` would lift the Swift RTF further (the power win is independent).
- RTF numbers are M1 Max; newer ANE generations should do better.

## Testing

- New CI-safe unit tests (`Tests/ParakeetCoreMLEncoderTests.swift`, swift-testing): the
  output-length math matches the dw-striding formula, and a missing `.mlpackage` throws
  (→ MLX fallback). No ANE/model/network needed; `swift test`: 2/2 pass.
- Builds clean (`release`); transcript parity verified against the all-MLX path on the
  full talk.
- The decode path is unchanged (the encoder is swapped behind the existing hook).
