### PR TITLE
feat: add LoRA, text normalization, and retry support to VoxCPM2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -123,6 +123,7 @@ let package = Package(
                 "Models/Soprano/README.md",
                 "Models/StyleTTS2/KittenTTS/README.md",
                 "Models/StyleTTS2/Kokoro/README.md",
+                "Models/VoxCPM2/README.md",
             ]
         ),
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 | Model | Model README | HuggingFace Repo |
 |-------|--------------|------------------|
 | Qwen3-TTS | [Qwen3-TTS README](Sources/MLXAudioTTS/Models/Qwen3TTS/README.md) | [mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit) |
+| VoxCPM2 | [VoxCPM2 README](Sources/MLXAudioTTS/Models/VoxCPM2/README.md) | [aufklarer/VoxCPM2-MLX-bf16](https://huggingface.co/aufklarer/VoxCPM2-MLX-bf16) |
 | Fish Audio S2 Pro | [Fish Audio S2 Pro README](Sources/MLXAudioTTS/Models/FishSpeech/README.md) | [mlx-community/fish-audio-s2-pro-8bit](https://huggingface.co/mlx-community/fish-audio-s2-pro-8bit) |
 | Soprano | [Soprano README](Sources/MLXAudioTTS/Models/Soprano/README.md) | [mlx-community/Soprano-80M-bf16](https://huggingface.co/mlx-community/Soprano-80M-bf16) |
 | VyvoTTS | [VyvoTTS README](Sources/MLXAudioTTS/Models/Qwen3/README.md) | [mlx-community/VyvoTTS-EN-Beta-4bit](https://huggingface.co/mlx-community/VyvoTTS-EN-Beta-4bit) |

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/AudioVAE.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/AudioVAE.swift
@@ -1,0 +1,694 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+// MARK: - Snake
+
+public final class Snake1d: Module {
+    public var alpha: MLXArray
+
+    public init(channels: Int) {
+        self.alpha = MLXArray.ones([1, 1, channels])
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        return x + (1.0 / (alpha + 1e-9)) * (sin(alpha * x) * sin(alpha * x))
+    }
+
+    public func loadAlpha(_ alpha: MLXArray) {
+        self.alpha = alpha
+    }
+}
+
+public final class TableEmbedding: Module {
+    public var weight: MLXArray
+    private let dimensions: Int
+    private let storageShape: [Int]
+
+    public init(embeddingCount: Int, dimensions: Int) {
+        let scale = sqrt(1.0 / Float(max(1, dimensions)))
+        self.dimensions = dimensions
+        if dimensions == 64 {
+            self.storageShape = [embeddingCount, 8, 8]
+        } else {
+            self.storageShape = [embeddingCount, dimensions]
+        }
+        self.weight = MLXRandom.normal(self.storageShape, scale: scale)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let gathered = weight[x]
+        if dimensions == 64 {
+            return gathered.reshaped([gathered.dim(0), dimensions])
+        }
+        return gathered
+    }
+
+    public func loadWeight(_ weight: MLXArray) {
+        if dimensions == 64 {
+            self.weight = weight.reshaped(storageShape)
+        } else {
+            self.weight = weight
+        }
+    }
+}
+
+// MARK: - Causal Conv Wrappers
+
+public final class VoxCPM2CausalConv1d: Module {
+    public var weight: MLXArray
+    public var bias: MLXArray?
+    public let stride: Int
+    public let dilation: Int
+    public let groups: Int
+    private let padVal: Int
+    private let outputPadding: Int
+
+    public init(
+        inputChannels: Int,
+        outputChannels: Int,
+        kernelSize: Int,
+        stride: Int = 1,
+        dilation: Int = 1,
+        padding: Int = 0,
+        outputPadding: Int = 0,
+        groups: Int = 1,
+        bias: Bool = true
+    ) {
+        self.padVal = padding
+        self.outputPadding = outputPadding
+        self.stride = stride
+        self.dilation = dilation
+        self.groups = groups
+
+        let scale = Float(1.0 / Double(max(1, inputChannels * kernelSize)))
+        self.weight = MLXRandom.uniform(
+            low: -scale,
+            high: scale,
+            [outputChannels, kernelSize, max(1, inputChannels / groups)]
+        )
+        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        if padVal > 0 {
+            let pad = max(0, padVal * 2 - outputPadding)
+            let zeros = MLXArray.zeros([x.dim(0), pad, x.dim(2)], dtype: x.dtype)
+            h = concatenated([zeros, h], axis: 1)
+        }
+        var y = conv1d(h, weight, stride: stride, padding: 0, dilation: dilation, groups: groups)
+        if let bias {
+            y = y + bias
+        }
+        return y
+    }
+}
+
+public final class VoxCPM2CausalTransposeConv1d: Module {
+    public var weight: MLXArray
+    public var bias: MLXArray?
+    public let stride: Int
+    public let groups: Int
+    private let padVal: Int
+    private let outputPadding: Int
+
+    public init(
+        inputChannels: Int,
+        outputChannels: Int,
+        kernelSize: Int,
+        stride: Int = 1,
+        padding: Int = 0,
+        outputPadding: Int = 0,
+        groups: Int = 1,
+        bias: Bool = true
+    ) {
+        self.padVal = padding
+        self.outputPadding = outputPadding
+        self.stride = stride
+        self.groups = groups
+
+        let scale = Float(1.0 / Double(max(1, inputChannels * kernelSize)))
+        self.weight = MLXRandom.uniform(
+            low: -scale,
+            high: scale,
+            [outputChannels, kernelSize, max(1, inputChannels / groups)]
+        )
+        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = convTransposed1d(x, weight, stride: stride, padding: 0, groups: groups)
+        if let bias {
+            y = y + bias
+        }
+        let trim = padVal * 2 - outputPadding
+        if trim > 0 {
+            y = y[0..., 0..<(y.dim(1) - trim), 0...]
+        }
+        return y
+    }
+}
+
+public final class ConvStack1d: Module {
+    @ModuleInfo public var layers: [VoxCPM2CausalConv1d]
+
+    public init(layers: [VoxCPM2CausalConv1d]) {
+        self._layers = ModuleInfo(wrappedValue: layers)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h)
+        }
+        return h
+    }
+}
+
+public final class CausalEncoderBlockStack: Module {
+    @ModuleInfo public var layers: [CausalEncoderBlock]
+
+    public init(layers: [CausalEncoderBlock]) {
+        self._layers = ModuleInfo(wrappedValue: layers)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h)
+        }
+        return h
+    }
+}
+
+public final class CausalDecoderBlockStack: Module {
+    @ModuleInfo public var layers: [CausalDecoderBlock]
+
+    public init(layers: [CausalDecoderBlock]) {
+        self._layers = ModuleInfo(wrappedValue: layers)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h)
+        }
+        return h
+    }
+}
+
+public final class SRConditionWeights {
+    public var scale: [MLXArray]
+    public var bias: [MLXArray]
+
+    public init(scale: [MLXArray], bias: [MLXArray]) {
+        self.scale = scale
+        self.bias = bias
+    }
+}
+
+public final class SampleRateConditionLayerStack: Module {
+    @ModuleInfo public var layers: [SampleRateConditionLayer]
+
+    public init(layers: [SampleRateConditionLayer]) {
+        self._layers = ModuleInfo(wrappedValue: layers)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, srCond: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h, srCond: srCond)
+        }
+        return h
+    }
+}
+
+// MARK: - Encoder / Decoder Residual Units
+
+public final class CausalResidualUnit: Module {
+    @ModuleInfo var snake1: Snake1d
+    @ModuleInfo var conv1: VoxCPM2CausalConv1d
+    @ModuleInfo var snake2: Snake1d
+    @ModuleInfo var conv2: VoxCPM2CausalConv1d
+
+    public init(dim: Int = 16, dilation: Int = 1, kernel: Int = 7, groups: Int = 1) {
+        let pad = ((kernel - 1) * dilation) / 2
+        self._snake1 = ModuleInfo(wrappedValue: Snake1d(channels: dim))
+        self._conv1 = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(
+            inputChannels: dim,
+            outputChannels: dim,
+            kernelSize: kernel,
+            dilation: dilation,
+            padding: pad,
+            groups: groups
+        ))
+        self._snake2 = ModuleInfo(wrappedValue: Snake1d(channels: dim))
+        self._conv2 = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(
+            inputChannels: dim,
+            outputChannels: dim,
+            kernelSize: 1
+        ))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let residual = x
+        var h = snake1(x)
+        h = conv1(h)
+        h = snake2(h)
+        h = conv2(h)
+        return residual + h
+    }
+}
+
+public final class CausalEncoderBlock: Module {
+    @ModuleInfo var res1: CausalResidualUnit
+    @ModuleInfo var res2: CausalResidualUnit
+    @ModuleInfo var res3: CausalResidualUnit
+    @ModuleInfo var snake: Snake1d
+    @ModuleInfo var conv: VoxCPM2CausalConv1d
+
+    public init(outputDim: Int = 16, inputDim: Int? = nil, stride: Int = 1, groups: Int = 1) {
+        let input = inputDim ?? outputDim / 2
+        self._res1 = ModuleInfo(wrappedValue: CausalResidualUnit(dim: input, dilation: 1, groups: groups))
+        self._res2 = ModuleInfo(wrappedValue: CausalResidualUnit(dim: input, dilation: 3, groups: groups))
+        self._res3 = ModuleInfo(wrappedValue: CausalResidualUnit(dim: input, dilation: 9, groups: groups))
+        self._snake = ModuleInfo(wrappedValue: Snake1d(channels: input))
+        self._conv = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(
+            inputChannels: input,
+            outputChannels: outputDim,
+            kernelSize: 2 * stride,
+            stride: stride,
+            padding: Int(ceil(Double(stride) / 2.0)),
+            outputPadding: stride % 2
+        ))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = res1(x)
+        h = res2(h)
+        h = res3(h)
+        h = snake(h)
+        return conv(h)
+    }
+}
+
+public final class CausalDecoderBlock: Module {
+    public let inputChannels: Int
+    @ModuleInfo var snake: Snake1d
+    @ModuleInfo var conv_t: VoxCPM2CausalTransposeConv1d
+    @ModuleInfo var noise: NoiseBlock?
+    @ModuleInfo var res1: CausalResidualUnit
+    @ModuleInfo var res2: CausalResidualUnit
+    @ModuleInfo var res3: CausalResidualUnit
+
+    public init(
+        inputDim: Int = 16,
+        outputDim: Int = 8,
+        stride: Int = 1,
+        groups: Int = 1,
+        useNoiseBlock: Bool = false
+    ) {
+        self.inputChannels = inputDim
+        self._snake = ModuleInfo(wrappedValue: Snake1d(channels: inputDim))
+        self._conv_t = ModuleInfo(wrappedValue: VoxCPM2CausalTransposeConv1d(
+            inputChannels: inputDim,
+            outputChannels: outputDim,
+            kernelSize: 2 * stride,
+            stride: stride,
+            padding: Int(ceil(Double(stride) / 2.0)),
+            outputPadding: stride % 2
+        ))
+        self._noise = ModuleInfo(wrappedValue: useNoiseBlock ? NoiseBlock(dim: outputDim) : nil)
+        self._res1 = ModuleInfo(wrappedValue: CausalResidualUnit(dim: outputDim, dilation: 1, groups: groups))
+        self._res2 = ModuleInfo(wrappedValue: CausalResidualUnit(dim: outputDim, dilation: 3, groups: groups))
+        self._res3 = ModuleInfo(wrappedValue: CausalResidualUnit(dim: outputDim, dilation: 9, groups: groups))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = snake(x)
+        h = conv_t(h)
+        if let noise { h = noise(h) }
+        h = res1(h)
+        h = res2(h)
+        h = res3(h)
+        return h
+    }
+}
+
+// MARK: - Conditioning Helpers
+
+public final class SampleRateConditionLayer: Module {
+    public let condType: String
+    @ModuleInfo var scale_embed: TableEmbedding
+    @ModuleInfo var bias_embed: TableEmbedding
+    private let srBoundaries: [Int]?
+
+    public init(
+        inputDim: Int,
+        srBinBuckets: Int,
+        condType: String = "scale_bias",
+        condDim: Int = 128,
+        outLayer: Bool = false,
+        srBoundaries: [Int]? = nil
+    ) {
+        self.condType = condType
+        self.srBoundaries = srBoundaries
+
+        self._scale_embed = ModuleInfo(
+            wrappedValue: TableEmbedding(embeddingCount: srBinBuckets, dimensions: inputDim)
+        )
+        self._bias_embed = ModuleInfo(
+            wrappedValue: TableEmbedding(embeddingCount: srBinBuckets, dimensions: inputDim)
+        )
+
+        if condType != "scale_bias" && condType != "scale_bias_init" {
+            fatalError("Invalid cond_type: \(condType)")
+        }
+        super.init()
+    }
+
+    public func getSrIdx(_ sr: MLXArray) -> Int {
+        guard let srBoundaries else {
+            return 0
+        }
+        let value = Int(sr.item(Int32.self))
+        return srBoundaries.reduce(0) { partial, boundary in
+            partial + (value >= boundary ? 1 : 0)
+        }
+    }
+
+    public func callAsFunction(_ x: MLXArray, srCond: MLXArray) -> MLXArray {
+        var h = x
+        let srIdx = MLXArray([Int32(getSrIdx(srCond))])
+        let scale = scale_embed(srIdx).expandedDimensions(axis: 1)
+        let bias = bias_embed(srIdx).expandedDimensions(axis: 1)
+        h = h * scale + bias
+        return h
+    }
+
+    public func loadScaleWeight(_ weight: MLXArray) {
+        self._scale_embed.wrappedValue.loadWeight(weight)
+    }
+
+    public func loadBiasWeight(_ weight: MLXArray) {
+        self._bias_embed.wrappedValue.loadWeight(weight)
+    }
+}
+
+public final class NoiseBlock: Module {
+    @ModuleInfo var linear: VoxCPM2CausalConv1d
+    private let noiseStd: Float
+
+    public init(dim: Int, noiseStd: Float = 0.003) {
+        self.noiseStd = noiseStd
+        self._linear = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(inputChannels: dim, outputChannels: dim, kernelSize: 1, bias: false))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let noise = MLXRandom.normal([x.dim(0), x.dim(1), 1], dtype: x.dtype) * MLXArray(noiseStd)
+        return x + noise * linear(x)
+    }
+}
+
+// MARK: - Encoder / Decoder
+
+public final class CausalEncoder: Module {
+    @ModuleInfo var conv_in: VoxCPM2CausalConv1d
+    @ModuleInfo var blocks: CausalEncoderBlockStack
+    @ModuleInfo var fc_mu: VoxCPM2CausalConv1d
+
+    public init(
+        dModel: Int = 64,
+        latentDim: Int = 32,
+        strides: [Int] = [2, 5, 8, 8],
+        depthwise: Bool = false
+    ) {
+        self._conv_in = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(inputChannels: 1, outputChannels: dModel, kernelSize: 7, padding: 3))
+        var outDim = dModel
+        var blocks: [CausalEncoderBlock] = []
+        for stride in strides {
+            let nextDim = outDim * 2
+            let groups = depthwise ? (nextDim / 2) : 1
+            blocks.append(CausalEncoderBlock(outputDim: nextDim, inputDim: outDim, stride: stride, groups: groups))
+            outDim = nextDim
+        }
+        self._blocks = ModuleInfo(wrappedValue: CausalEncoderBlockStack(layers: blocks))
+        self._fc_mu = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(inputChannels: outDim, outputChannels: latentDim, kernelSize: 3, padding: 1))
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv_in(x)
+        h = blocks(h)
+        return fc_mu(h)
+    }
+}
+
+public final class CausalDecoder: Module {
+    @ModuleInfo var conv_in: ConvStack1d
+    @ModuleInfo var blocks: CausalDecoderBlockStack
+    @ModuleInfo var srCondLayers: SampleRateConditionLayerStack
+    @ModuleInfo var snake_out: Snake1d
+    @ModuleInfo var conv_out: VoxCPM2CausalConv1d
+    public let srBoundaries: [Int]?
+
+    public init(
+        inputChannel: Int,
+        channels: Int,
+        rates: [Int],
+        depthwise: Bool = false,
+        dOut: Int = 1,
+        useNoiseBlock: Bool = false,
+        srBinBoundaries: [Int]? = nil,
+        condType: String = "scale_bias",
+        condDim: Int = 128,
+        condOutLayer: Bool = false,
+        srCondLayers: [SampleRateConditionLayer] = []
+    ) {
+        self.srBoundaries = srBinBoundaries
+        let convInLayers: [VoxCPM2CausalConv1d] = [
+            VoxCPM2CausalConv1d(
+                inputChannels: inputChannel,
+                outputChannels: inputChannel,
+                kernelSize: 7,
+                padding: 3,
+                groups: depthwise ? inputChannel : 1
+            ),
+            VoxCPM2CausalConv1d(
+                inputChannels: inputChannel,
+                outputChannels: channels,
+                kernelSize: 1
+            )
+        ]
+        self._conv_in = ModuleInfo(wrappedValue: ConvStack1d(layers: convInLayers))
+
+        var blocks: [CausalDecoderBlock] = []
+        for (idx, stride) in rates.enumerated() {
+            let inputDim = channels / (1 << idx)
+            let outputDim = channels / (1 << (idx + 1))
+            let groups = depthwise ? outputDim : 1
+            blocks.append(CausalDecoderBlock(
+                inputDim: inputDim,
+                outputDim: outputDim,
+                stride: stride,
+                groups: groups,
+                useNoiseBlock: useNoiseBlock
+            ))
+        }
+        self._blocks = ModuleInfo(wrappedValue: CausalDecoderBlockStack(layers: blocks))
+        self._srCondLayers = ModuleInfo(wrappedValue: SampleRateConditionLayerStack(layers: srCondLayers))
+        self._snake_out = ModuleInfo(wrappedValue: Snake1d(channels: channels / (1 << rates.count)))
+        self._conv_out = ModuleInfo(wrappedValue: VoxCPM2CausalConv1d(
+            inputChannels: channels / (1 << rates.count),
+            outputChannels: dOut,
+            kernelSize: 7,
+            padding: 3
+        ))
+
+        super.init()
+    }
+
+    public func getSrIdx(_ sr: MLXArray) -> MLXArray {
+        guard let srBoundaries else {
+            return MLXArray([Int32(0)])
+        }
+        let boundaries = MLXArray(srBoundaries.map(Int32.init))
+        let idx = sum(sr .>= boundaries).asType(.int32)
+        return idx.reshaped([1])
+    }
+
+    public func callAsFunction(_ x: MLXArray, srCond: MLXArray? = nil) -> MLXArray {
+        var h = x
+        h = conv_in(h)
+
+        let effectiveSrCond = srCond ?? MLXArray([Int32(48_000)])
+        if !srCondLayers.layers.isEmpty {
+            let count = min(blocks.layers.count, srCondLayers.layers.count)
+            for index in 0..<count {
+                h = srCondLayers.layers[index](h, srCond: effectiveSrCond)
+                h = blocks.layers[index](h)
+            }
+            if count < blocks.layers.count {
+                for index in count..<blocks.layers.count {
+                    h = blocks.layers[index](h)
+                }
+            }
+        } else {
+            for block in blocks.layers {
+                h = block(h)
+            }
+        }
+
+        h = snake_out(h)
+        h = conv_out(h)
+        return tanh(h)
+    }
+}
+
+// MARK: - Audio VAE
+
+public final class AudioVAE: Module {
+    public let config: AudioVAEConfig
+    public let hopLength: Int
+    public let chunkSize: Int
+    public let decodeChunkSize: Int
+    public let latentDim: Int
+    public let sampleRate: Int
+    public let outSampleRate: Int
+
+    @ModuleInfo public var encoder: CausalEncoder
+    @ModuleInfo public var decoder: CausalDecoder
+
+    public init(_ config: AudioVAEConfig) {
+        self.config = config
+        self.hopLength = config.encoderRates.reduce(1, *)
+        self.chunkSize = config.encoderRates.reduce(1, *)
+        self.decodeChunkSize = config.decoderRates.reduce(1, *)
+        self.latentDim = config.latentDim
+        self.sampleRate = config.sampleRate
+        self.outSampleRate = config.outSampleRate
+        self._encoder = ModuleInfo(wrappedValue: CausalEncoder(
+            dModel: config.encoderDim,
+            latentDim: config.latentDim,
+            strides: config.encoderRates,
+            depthwise: config.depthwise
+        ))
+        self._decoder = ModuleInfo(wrappedValue: CausalDecoder(
+            inputChannel: config.latentDim,
+            channels: config.decoderDim,
+            rates: config.decoderRates,
+            depthwise: config.depthwise,
+            dOut: 1,
+            useNoiseBlock: config.useNoiseBlock,
+            srBinBoundaries: config.srBinBoundaries,
+            condType: config.condType,
+            condDim: config.condDim,
+            condOutLayer: config.condOutLayer,
+            srCondLayers: config.decoderRates.enumerated().map { index, _ in
+                let inputDim = config.decoderDim / (1 << index)
+                return SampleRateConditionLayer(
+                    inputDim: inputDim,
+                    srBinBuckets: max(1, config.srBinBoundaries.count + 1),
+                    condType: config.condType,
+                    condDim: config.condDim,
+                    outLayer: config.condOutLayer && index == config.decoderRates.count - 1,
+                    srBoundaries: config.srBinBoundaries
+                )
+            }
+        ))
+        super.init()
+    }
+
+    public func encode(_ x: MLXArray, sampleRate: Int? = nil) -> MLXArray {
+        var h = x
+        if h.ndim == 2 {
+            h = h.expandedDimensions(axis: 2)
+        }
+        if h.shape[1] < h.shape[2] {
+            h = h.transposed(0, 2, 1)
+        }
+        h = preprocess(h, sampleRate: sampleRate)
+        return encoder(h)
+    }
+
+    public func decode(_ z: MLXArray, srCond: MLXArray? = nil) -> MLXArray {
+        let cond = srCond ?? MLXArray([Int32(outSampleRate)])
+        let out = decoder(z, srCond: cond)
+        return out.squeezed(axis: 2)
+    }
+
+    public func preprocess(_ audioData: MLXArray, sampleRate: Int? = nil) -> MLXArray {
+        let effectiveSampleRate = sampleRate ?? self.sampleRate
+        precondition(effectiveSampleRate == self.sampleRate, "AudioVAE expects \(self.sampleRate) Hz input")
+        let length = audioData.dim(1)
+        let rightPad = Int(ceil(Double(length) / Double(hopLength))) * hopLength - length
+        guard rightPad > 0 else { return audioData }
+        let pad = MLXArray.zeros([audioData.dim(0), rightPad, audioData.dim(2)], dtype: audioData.dtype)
+        return concatenated([audioData, pad], axis: 1)
+    }
+
+    public func sanitize(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Minimal fusion for weight-norm converted checkpoints.
+        var fused: [String: MLXArray] = [:]
+        let keys = Array(weights.keys).sorted()
+        var processed = Set<String>()
+
+        for key in keys {
+            if processed.contains(key) || key.contains("fc_logvar") {
+                continue
+            }
+            if key.hasSuffix(".weight_g") {
+                let base = String(key.dropLast(".weight_g".count))
+                let vKey = base + ".weight_v"
+                if let g = weights[key], let v = weights[vKey] {
+                    let vFlat = v.reshaped([v.shape[0], -1])
+                    let norm = sqrt((vFlat * vFlat).sum(axis: 1)).reshaped(g.shape)
+                    let w = g * (v / (norm + 1e-9))
+                    fused[base + ".weight"] = w
+                    processed.insert(key)
+                    processed.insert(vKey)
+                    continue
+                }
+            }
+            if key.hasSuffix(".weight_v") {
+                continue
+            }
+            fused[key] = weights[key]
+        }
+
+        var remapped: [String: MLXArray] = [:]
+        for (key, value) in fused {
+            if key.hasPrefix("audio_vae.") {
+                remapped[key] = value
+            } else if key.hasPrefix("encoder.") || key.hasPrefix("decoder.") {
+                remapped["audio_vae.\(key)"] = value
+            } else {
+                remapped[key] = value
+            }
+        }
+        return remapped
+    }
+
+    /// Promote all AudioVAE parameters to float32 after loading.
+    /// This mirrors the repo's existing traversal pattern used by `clearParameters()`
+    /// but preserves the loaded values.
+    public func castParametersToFloat32() {
+        apply(filter: Self.filterAll) { array in
+            array.asType(.float32)
+        }
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/AudioVAE.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/AudioVAE.swift
@@ -1,3 +1,5 @@
+// Adapted from soniqo/speech-swift's VoxCPM2TTS module (Apache-2.0).
+
 import Foundation
 import MLX
 import MLXFast

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/Configuration.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/Configuration.swift
@@ -1,0 +1,266 @@
+import Foundation
+
+public struct RopeScalingConfig: Codable, Sendable {
+    public var type: String = "longrope"
+    public var shortFactor: [Float] = []
+    public var longFactor: [Float] = []
+    public var originalMaxPositionEmbeddings: Int = 32768
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case shortFactor = "short_factor"
+        case longFactor = "long_factor"
+        case originalMaxPositionEmbeddings = "original_max_position_embeddings"
+    }
+
+    public init() {}
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decodeIfPresent(String.self, forKey: .type) ?? "longrope"
+        self.shortFactor = try container.decodeIfPresent([Float].self, forKey: .shortFactor) ?? []
+        self.longFactor = try container.decodeIfPresent([Float].self, forKey: .longFactor) ?? []
+        self.originalMaxPositionEmbeddings = try container.decodeIfPresent(
+            Int.self,
+            forKey: .originalMaxPositionEmbeddings
+        ) ?? 32768
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(shortFactor, forKey: .shortFactor)
+        try container.encode(longFactor, forKey: .longFactor)
+        try container.encode(originalMaxPositionEmbeddings, forKey: .originalMaxPositionEmbeddings)
+    }
+}
+
+public struct LMConfig: Codable, Sendable {
+    public var hiddenSize: Int = 2048
+    public var numHiddenLayers: Int = 28
+    public var numAttentionHeads: Int = 16
+    public var numKeyValueHeads: Int = 2
+    public var intermediateSize: Int = 6144
+    public var vocabSize: Int = 73448
+    public var rmsNormEps: Float = 1e-5
+    public var ropeTheta: Float = 10000.0
+    public var ropeScaling: RopeScalingConfig? = RopeScalingConfig()
+    public var scaleEmb: Int = 12
+    public var dimModelBase: Int = 256
+    public var scaleDepth: Float = 1.4
+    public var originalMaxPositionEmbeddings: Int = 32768
+    public var maxPositionEmbeddings: Int = 32768
+    public var bosTokenId: Int = 1
+    public var eosTokenId: Int = 2
+    public var useMup: Bool = false
+    public var kvChannels: Int? = 128
+    public var noRope: Bool = false
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case intermediateSize = "intermediate_size"
+        case vocabSize = "vocab_size"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeTheta = "rope_theta"
+        case ropeScaling = "rope_scaling"
+        case scaleEmb = "scale_emb"
+        case dimModelBase = "dim_model_base"
+        case scaleDepth = "scale_depth"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case useMup = "use_mup"
+        case kvChannels = "kv_channels"
+    }
+
+    public init() {}
+}
+
+public struct EncoderConfig: Codable, Sendable {
+    public var hiddenDim: Int = 1024
+    public var ffnDim: Int = 4096
+    public var numHeads: Int = 16
+    public var numLayers: Int = 12
+    public var kvChannels: Int? = 128
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenDim = "hidden_dim"
+        case ffnDim = "ffn_dim"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case kvChannels = "kv_channels"
+    }
+
+    public init() {}
+}
+
+public struct CFMConfig: Codable, Sendable {
+    public var sigmaMin: Float = 1e-6
+    public var solver: String = "euler"
+    public var tScheduler: String = "log-norm"
+    public var inferenceCfgRate: Float = 2.0
+
+    enum CodingKeys: String, CodingKey {
+        case sigmaMin = "sigma_min"
+        case solver
+        case tScheduler = "t_scheduler"
+        case inferenceCfgRate = "inference_cfg_rate"
+    }
+
+    public init() {}
+}
+
+public struct DiTConfig: Codable, Sendable {
+    public var hiddenDim: Int = 1024
+    public var ffnDim: Int = 4096
+    public var numHeads: Int = 16
+    public var numLayers: Int = 12
+    public var kvChannels: Int? = 128
+    public var ditMeanMode: Bool = false
+    public var cfmConfig: CFMConfig = CFMConfig()
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenDim = "hidden_dim"
+        case ffnDim = "ffn_dim"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case kvChannels = "kv_channels"
+        case ditMeanMode = "mean_mode"
+        case cfmConfig = "cfm_config"
+    }
+
+    public init() {}
+}
+
+public struct AudioVAEConfig: Codable, Sendable {
+    public var encoderDim: Int = 128
+    public var encoderRates: [Int] = [2, 5, 8, 8]
+    public var latentDim: Int = 64
+    public var decoderDim: Int = 2048
+    public var decoderRates: [Int] = [8, 6, 5, 2, 2, 2]
+    public var depthwise: Bool = true
+    public var sampleRate: Int = 16000
+    public var outSampleRate: Int = 48000
+    public var useNoiseBlock: Bool = false
+    public var srBinBoundaries: [Int] = [20000, 30000, 40000]
+    public var condType: String = "scale_bias"
+    public var condDim: Int = 128
+    public var condOutLayer: Bool = false
+
+    enum CodingKeys: String, CodingKey {
+        case encoderDim = "encoder_dim"
+        case encoderRates = "encoder_rates"
+        case latentDim = "latent_dim"
+        case decoderDim = "decoder_dim"
+        case decoderRates = "decoder_rates"
+        case depthwise
+        case sampleRate = "sample_rate"
+        case outSampleRate = "out_sample_rate"
+        case useNoiseBlock = "use_noise_block"
+        case srBinBoundaries = "sr_bin_boundaries"
+        case condType = "cond_type"
+        case condDim = "cond_dim"
+        case condOutLayer = "cond_out_layer"
+    }
+
+    public init() {}
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.encoderDim = try container.decodeIfPresent(Int.self, forKey: .encoderDim) ?? 128
+        self.encoderRates = try container.decodeIfPresent([Int].self, forKey: .encoderRates) ?? [2, 5, 8, 8]
+        self.latentDim = try container.decodeIfPresent(Int.self, forKey: .latentDim) ?? 64
+        self.decoderDim = try container.decodeIfPresent(Int.self, forKey: .decoderDim) ?? 2048
+        self.decoderRates = try container.decodeIfPresent([Int].self, forKey: .decoderRates) ?? [8, 6, 5, 2, 2, 2]
+        self.depthwise = try container.decodeIfPresent(Bool.self, forKey: .depthwise) ?? true
+        self.sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 16000
+        self.outSampleRate = try container.decodeIfPresent(Int.self, forKey: .outSampleRate) ?? 48000
+        self.useNoiseBlock = try container.decodeIfPresent(Bool.self, forKey: .useNoiseBlock) ?? false
+        self.srBinBoundaries = try container.decodeIfPresent([Int].self, forKey: .srBinBoundaries) ?? [20000, 30000, 40000]
+        self.condType = try container.decodeIfPresent(String.self, forKey: .condType) ?? "scale_bias"
+        self.condDim = try container.decodeIfPresent(Int.self, forKey: .condDim) ?? 128
+        self.condOutLayer = try container.decodeIfPresent(Bool.self, forKey: .condOutLayer) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(encoderDim, forKey: .encoderDim)
+        try container.encode(encoderRates, forKey: .encoderRates)
+        try container.encode(latentDim, forKey: .latentDim)
+        try container.encode(decoderDim, forKey: .decoderDim)
+        try container.encode(decoderRates, forKey: .decoderRates)
+        try container.encode(depthwise, forKey: .depthwise)
+        try container.encode(sampleRate, forKey: .sampleRate)
+        try container.encode(outSampleRate, forKey: .outSampleRate)
+        try container.encode(useNoiseBlock, forKey: .useNoiseBlock)
+        try container.encode(srBinBoundaries, forKey: .srBinBoundaries)
+        try container.encode(condType, forKey: .condType)
+        try container.encode(condDim, forKey: .condDim)
+        try container.encode(condOutLayer, forKey: .condOutLayer)
+    }
+}
+
+public struct QuantizationConfig: Codable, Sendable {
+    public var bits: Int = 16
+    public var groupSize: Int = 64
+    public var variant: String?
+
+    enum CodingKeys: String, CodingKey {
+        case bits
+        case groupSize = "group_size"
+        case variant
+    }
+
+    public init() {}
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.bits = try container.decodeIfPresent(Int.self, forKey: .bits) ?? 16
+        self.groupSize = try container.decodeIfPresent(Int.self, forKey: .groupSize) ?? 64
+        self.variant = try container.decodeIfPresent(String.self, forKey: .variant)
+    }
+
+    public var isQuantized: Bool { bits == 4 || bits == 8 }
+}
+
+public struct ModelArgs: Codable, Sendable {
+    public var lmConfig: LMConfig = LMConfig()
+    public var encoderConfig: EncoderConfig = EncoderConfig()
+    public var ditConfig: DiTConfig = DiTConfig()
+    public var audioVAEConfig: AudioVAEConfig = AudioVAEConfig()
+    public var patchSize: Int = 4
+    public var featDim: Int = 64
+    public var scalarQuantizationLatentDim: Int = 512
+    public var scalarQuantizationScale: Int = 9
+    public var residualLMNumLayers: Int = 8
+    public var residualLMNoRope: Bool = true
+    public var maxLength: Int = 8192
+    public var quantization: QuantizationConfig?
+
+    enum CodingKeys: String, CodingKey {
+        case lmConfig = "lm_config"
+        case encoderConfig = "encoder_config"
+        case ditConfig = "dit_config"
+        case audioVAEConfig = "audio_vae_config"
+        case patchSize = "patch_size"
+        case featDim = "feat_dim"
+        case scalarQuantizationLatentDim = "scalar_quantization_latent_dim"
+        case scalarQuantizationScale = "scalar_quantization_scale"
+        case residualLMNumLayers = "residual_lm_num_layers"
+        case residualLMNoRope = "residual_lm_no_rope"
+        case maxLength = "max_length"
+        case quantization
+    }
+
+    public init() {}
+
+    public static func load(from directory: URL) throws -> ModelArgs {
+        let configURL = directory.appendingPathComponent("config.json")
+        let data = try Data(contentsOf: configURL)
+        let decoder = JSONDecoder()
+        return try decoder.decode(ModelArgs.self, from: data)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/Configuration.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/Configuration.swift
@@ -1,3 +1,5 @@
+// Adapted from soniqo/speech-swift's VoxCPM2TTS module (Apache-2.0).
+
 import Foundation
 
 public struct RopeScalingConfig: Codable, Sendable {

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/LoRAConfig.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/LoRAConfig.swift
@@ -1,0 +1,92 @@
+// LoRA configuration for VoxCPM2 fine-tuning.
+//
+// Matches the official Python API's LoRA parameter schema:
+//   lora:
+//     enable_lm:   true   — attention layers in base_lm + residual_lm
+//     enable_dit:  true   — attention layers in DiT decoder (critical for voice quality)
+//     enable_proj: false  — projection heads
+//     r:     8            — rank (8 for speaker adaptation, 32–64 for new languages)
+//     alpha: 16
+//     dropout: 0.0
+
+import Foundation
+
+/// Configuration for LoRA (Low-Rank Adaptation) fine-tuning of a VoxCPM2 model.
+///
+/// LoRA freezes the base model and trains only small rank‑delta matrices,
+/// making it the recommended default starting point for voice adaptation.
+///
+/// Usage:
+/// ```swift
+/// let loraConfig = LoRAConfig(r: 8, alpha: 16)
+/// let model = try await VoxCPM2Model.fromModelDirectory(
+///     modelDir,
+///     loraConfig: loraConfig
+/// )
+/// try model.loadLoRA(weightsPath: "path/to/lora_weights.safetensors")
+/// model.setLoRAEnabled(true)
+/// ```
+public struct LoRAConfig: Codable, Sendable {
+    /// Apply LoRA to the attention layers of `base_lm` and `residual_lm`.
+    ///
+    /// Targets: `q_proj`, `k_proj`, `v_proj`, `o_proj` in every decoder layer
+    /// of both language models.
+    public var enableLM: Bool = true
+
+    /// Apply LoRA to the attention layers of the DiT decoder.
+    ///
+    /// Targets: `q_proj`, `k_proj`, `v_proj`, `o_proj` in the
+    /// `feat_decoder.estimator.decoder` (the diffusion‑backbone transformer).
+    ///
+    /// > Important: This is **critical for voice quality** — do not disable
+    /// > when fine‑tuning for voice cloning or timbre adaptation.
+    public var enableDiT: Bool = true
+
+    /// Apply LoRA to the linear projection heads.
+    ///
+    /// Targets: `enc_to_lm_proj`, `lm_to_dit_proj`, `res_to_dit_proj`,
+    /// `fusion_concat_proj`, `stop_proj`, `stop_head`.
+    ///
+    /// Usually left disabled — the projection heads are small and full‑rank
+    /// fine‑tuning suffices.
+    public var enableProj: Bool = false
+
+    /// LoRA rank. Lower = fewer parameters, faster training.
+    ///
+    /// - `r = 8`:  sufficient for speaker/voice adaptation
+    /// - `r = 32–64`: recommended for new languages or large domain shifts
+    public var r: Int = 8
+
+    /// LoRA alpha scaling factor. The effective scaling is `alpha / r`.
+    ///
+    /// A common starting point is `alpha = 16` for `r = 8` (ratio 2.0).
+    public var alpha: Int = 16
+
+    /// Dropout rate applied to the LoRA branch during training (0.0–1.0).
+    public var dropout: Float = 0.0
+
+    public init(
+        enableLM: Bool = true,
+        enableDiT: Bool = true,
+        enableProj: Bool = false,
+        r: Int = 8,
+        alpha: Int = 16,
+        dropout: Float = 0.0
+    ) {
+        self.enableLM = enableLM
+        self.enableDiT = enableDiT
+        self.enableProj = enableProj
+        self.r = r
+        self.alpha = alpha
+        self.dropout = dropout
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enableLM = "enable_lm"
+        case enableDiT = "enable_dit"
+        case enableProj = "enable_proj"
+        case r
+        case alpha
+        case dropout
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/LoRALinear.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/LoRALinear.swift
@@ -1,0 +1,80 @@
+// LoRA‑wrapped Linear layer for VoxCPM2 fine‑tuning.
+//
+// Wraps a frozen `Linear` base layer and adds trainable low‑rank matrices
+// A (in_dim × r) and B (out_dim × r). The forward pass computes:
+//
+//     output = base(x) + (x · Aᵀ · Bᵀ) × (α / r)
+//
+// The LoRA branch can be toggled on/off at runtime via `enabled`.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// A Linear layer augmented with a LoRA low‑rank adapter.
+///
+/// The base weights are frozen — only the LoRA matrices `loraA` and `loraB`
+/// are intended for training.  The branch is controlled by `enabled` so the
+/// same model can switch between fine‑tuned and base behaviour without
+/// reloading weights.
+public final class LoRALinear: Module, UnaryLayer {
+    /// The original frozen linear layer.
+    @ModuleInfo public var base: Linear
+
+    /// LoRA down‑projection: `inDim → r`
+    public var loraA: MLXArray
+
+    /// LoRA up‑projection: `r → outDim`
+    public var loraB: MLXArray
+
+    /// Rank of the low‑rank matrices.
+    public let r: Int
+
+    /// Scaling factor.  Effective scale = `alpha / Float(r)`.
+    public let alpha: Float
+
+    /// Whether the LoRA branch is active.
+    public var enabled: Bool = true
+
+    /// Wrap an existing `Linear` layer with LoRA matrices.
+    ///
+    /// - Parameters:
+    ///   - base: The linear layer to wrap (its weights are frozen).
+    ///   - r: LoRA rank.
+    ///   - alpha: Scaling factor (effective scale = alpha / r).
+    public init(base: Linear, r: Int = 8, alpha: Int = 16) {
+        self.r = r
+        self.alpha = Float(alpha)
+
+        let wShape = base.weight.shape
+        let inDim = wShape[1]
+        let outDim = wShape[0]
+
+        self._base = ModuleInfo(wrappedValue: base, key: "base")
+
+        // Initialise A with Kaiming‑uniform and B with zeros (the standard
+        // LoRA init so that the branch starts at zero).
+        let scale = sqrt(1.0 / Float(inDim))
+        let aData = (MLXRandom.uniform(low: 0.0, high: 1.0, [inDim, r]) * 2.0 - 1.0) * scale
+        self.loraA = aData
+        self.loraB = MLXArray.zeros([outDim, r])
+
+        super.init()
+    }
+
+    /// Convenience: wrap a Linear with an explicit LoRAConfig.
+    public convenience init(base: Linear, config: LoRAConfig) {
+        self.init(base: base, r: config.r, alpha: config.alpha)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let baseOut = base(x)
+        guard enabled else { return baseOut }
+
+        // LoRA path: x · A · Bᵀ  (not Aᵀ! MLX stores weight in (out, in) layout,
+        // matching matmul convention where x is (..., in))
+        let loraOut = x.matmul(loraA).matmul(loraB.T)
+        let scale = alpha / Float(r)
+        return baseOut + loraOut * scale
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM4.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM4.swift
@@ -1,3 +1,5 @@
+// Adapted from soniqo/speech-swift's VoxCPM2TTS module (Apache-2.0).
+
 import Foundation
 import MLX
 import MLXFast

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM4.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/MiniCPM4.swift
@@ -1,0 +1,748 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+// MARK: - VoxCPM2RMSNorm
+
+public final class VoxCPM2RMSNorm: Module {
+    @ParameterInfo public var weight: MLXArray
+    public let eps: Float
+
+    public init(dimensions: Int, eps: Float = 1e-6) {
+        voxCPM2InitLog("VoxCPM2RMSNorm start (\(dimensions))")
+        self._weight = ParameterInfo(
+            wrappedValue: MLXArray(Array(repeating: Float(1.0), count: dimensions), [dimensions])
+        )
+        self.eps = eps
+        super.init()
+        voxCPM2InitLog("VoxCPM2RMSNorm done (\(dimensions))")
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let originalDType = x.dtype
+        let xFloat = x.asType(.float32)
+        let variance = mean(xFloat * xFloat, axis: xFloat.ndim - 1, keepDims: true)
+        let normalized = (xFloat * rsqrt(variance + MLXArray(eps))).asType(originalDType)
+        return normalized * weight.asType(originalDType)
+    }
+}
+
+// MARK: - Rotary Embedding
+
+public final class MiniCPMLongRoPE: Module {
+    @ParameterInfo var invFreq: MLXArray
+    private let scalingFactor: Float
+    @ParameterInfo var shortFactor: MLXArray
+    @ParameterInfo var longFactor: MLXArray
+    private let originalMaxPositionEmbeddings: Int
+    private let useLongFactor: Bool
+
+    public init(config: LMConfig) {
+        let headDim = config.kvChannels ?? (config.hiddenSize / config.numAttentionHeads)
+        let halfDim = headDim / 2
+
+        let exponents = MLXArray(0..<Int32(halfDim)).asType(.float32)
+            / MLXArray(Float(halfDim))
+        self._invFreq = ParameterInfo(
+            wrappedValue: exp(exponents * (-log(MLXArray(Float(config.ropeTheta))))),
+            key: "inv_freq"
+        )
+
+        let ropeScaling = config.ropeScaling ?? RopeScalingConfig()
+        let short = ropeScaling.shortFactor.isEmpty
+            ? Array(repeating: 1.0, count: halfDim)
+            : ropeScaling.shortFactor
+        let long = ropeScaling.longFactor.isEmpty
+            ? Array(repeating: 1.0, count: halfDim)
+            : ropeScaling.longFactor
+        self._shortFactor = ParameterInfo(wrappedValue: MLXArray(short).asType(.float32), key: "short_factor")
+        self._longFactor = ParameterInfo(wrappedValue: MLXArray(long).asType(.float32), key: "long_factor")
+        self.originalMaxPositionEmbeddings = max(1, ropeScaling.originalMaxPositionEmbeddings)
+        self.useLongFactor = max(1, config.maxPositionEmbeddings) > self.originalMaxPositionEmbeddings
+
+        let scale = Double(max(config.maxPositionEmbeddings, 1))
+            / Double(max(config.originalMaxPositionEmbeddings, 1))
+        self.scalingFactor = Float(sqrt(1.0 + log(max(scale, 1.0))
+            / log(Double(max(config.originalMaxPositionEmbeddings, 2)))))
+        super.init()
+    }
+
+    public func callAsFunction(_ positionIds: MLXArray) -> (MLXArray, MLXArray) {
+        let seqLen = Int(positionIds.max().item(Int32.self)) + 1
+        // Upstream VoxCPM2 precomputes the RoPE cache once using the
+        // max_position_embeddings-backed factor choice, so the effective
+        // factor is fixed for a given checkpoint rather than varying per call.
+        let factors = useLongFactor ? longFactor : shortFactor
+
+        let t = MLXArray(0..<Int32(seqLen)).asType(.float32)
+        let freqs = (t.expandedDimensions(axis: 1)
+            * (1.0 / factors.expandedDimensions(axis: 0)))
+            * invFreq.expandedDimensions(axis: 0)
+        let emb = concatenated([freqs, freqs], axis: -1)
+
+        let cos = cos(emb) * MLXArray(scalingFactor)
+        let sin = sin(emb) * MLXArray(scalingFactor)
+        return (cos[positionIds], sin[positionIds])
+    }
+}
+
+@inline(__always)
+private func rotateHalf(_ x: MLXArray) -> MLXArray {
+    let half = x.shape.last! / 2
+    let parts = split(x, indices: [half], axis: x.ndim - 1)
+    return concatenated([parts[1] * -1, parts[0]], axis: x.ndim - 1)
+}
+
+@inline(__always)
+private func applyRotaryPosEmb(
+    q: MLXArray, k: MLXArray, cos: MLXArray, sin: MLXArray
+) -> (MLXArray, MLXArray) {
+    // q / k arrive as (B, L, H, D); cos / sin as (L, D). Expand to
+    // (1, L, 1, D) so they broadcast across batch and heads.
+    let cosExpanded = cos.expandedDimensions(axis: 0).expandedDimensions(axis: 2)
+    let sinExpanded = sin.expandedDimensions(axis: 0).expandedDimensions(axis: 2)
+    let originalDType = q.dtype
+    let q = q.asType(.float32)
+    let k = k.asType(.float32)
+    let qEmbed = (q * cosExpanded) + (rotateHalf(q) * sinExpanded)
+    let kEmbed = (k * cosExpanded) + (rotateHalf(k) * sinExpanded)
+    return (qEmbed.asType(originalDType), kEmbed.asType(originalDType))
+}
+
+@inline(__always)
+private func debugRange(_ label: String, _ x: MLXArray) {
+    let values = x.asArray(Float.self)
+    let minValue = values.min() ?? 0
+    let maxValue = values.max() ?? 0
+    let message = "  \(label) range: min=\(minValue), max=\(maxValue), count=\(values.count)\n"
+    if let data = message.data(using: .utf8) {
+        FileHandle.standardOutput.write(data)
+    }
+}
+
+@inline(__always)
+private func voxCPM2InitDebugEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_INIT"] == "1"
+}
+
+@inline(__always)
+private func voxCPM2InitLog(_ message: String) {
+    guard voxCPM2InitDebugEnabled() else { return }
+    let line = "  VoxCPM2 init: \(message)\n"
+    if let data = line.data(using: .utf8) {
+        FileHandle.standardOutput.write(data)
+    }
+}
+
+@inline(__always)
+func zeroLinear(_ inputDimensions: Int, _ outputDimensions: Int, bias: Bool = true) -> Linear {
+    // Use Linear's standard init (random weights) — the actual weights are
+    // overwritten by the safetensors load. Earlier we tried zero-initialising
+    // via the designated `init(weight:bias:)` to save memory, but update
+    // (parameters:) silently failed to overwrite those arrays, leaving every
+    // Linear at exactly zero post-load. The random-init path works because
+    // MLX correctly walks the items() reflection in that case.
+    return Linear(inputDimensions, outputDimensions, bias: bias)
+}
+
+@inline(__always)
+func makeUnifiedCFMTimeSpan(timesteps: Int, scheduler _: String, sigmaMin _: Float) -> [Float] {
+    // Match upstream VoxCPM2 inference:
+    //   t_span = linspace(1, 0, n_timesteps + 1)
+    //   t_span = t_span + sway_sampling_coef * (cos(pi/2 * t_span) - 1 + t_span)
+    // The upstream default sway_sampling_coef is 1.0.
+    let steps = max(timesteps, 1)
+    let swaySamplingCoef = Double(1.0)
+
+    return (0...steps).map { step in
+        let progress = Double(step) / Double(steps)
+        let t = 1.0 - progress
+        let shaped = t + swaySamplingCoef * (cos(Double.pi / 2.0 * t) - 1.0 + t)
+        return Float(shaped)
+    }
+}
+
+@inline(__always)
+private func clampUnitInterval(_ value: Double, epsilon: Double = 1e-7) -> Double {
+    min(max(value, epsilon), 1.0 - epsilon)
+}
+
+@inline(__always)
+private func inverseStandardNormalCDF(_ p: Double) -> Double {
+    precondition(p > 0.0 && p < 1.0)
+
+    // Peter J. Acklam's rational approximation.
+    let a1 = -3.969683028665376e+01
+    let a2 = 2.209460984245205e+02
+    let a3 = -2.759285104469687e+02
+    let a4 = 1.383577518672690e+02
+    let a5 = -3.066479806614716e+01
+    let a6 = 2.506628277459239e+00
+
+    let b1 = -5.447609879822406e+01
+    let b2 = 1.615858368580409e+02
+    let b3 = -1.556989798598866e+02
+    let b4 = 6.680131188771972e+01
+    let b5 = -1.328068155288572e+01
+
+    let c1 = -7.784894002430293e-03
+    let c2 = -3.223964580411365e-01
+    let c3 = -2.400758277161838e+00
+    let c4 = -2.549732539343734e+00
+    let c5 = 4.374664141464968e+00
+    let c6 = 2.938163982698783e+00
+
+    let d1 = 7.784695709041462e-03
+    let d2 = 3.224671290700398e-01
+    let d3 = 2.445134137142996e+00
+    let d4 = 3.754408661907416e+00
+
+    let plow = 0.02425
+    let phigh = 1.0 - plow
+
+    if p < plow {
+        let q = sqrt(-2.0 * log(p))
+        return (((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6) /
+            ((((d1 * q + d2) * q + d3) * q + d4) * q + 1.0)
+    }
+
+    if p > phigh {
+        let q = sqrt(-2.0 * log(1.0 - p))
+        return -(((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6) /
+            ((((d1 * q + d2) * q + d3) * q + d4) * q + 1.0)
+    }
+
+    let q = p - 0.5
+    let r = q * q
+    return (((((a1 * r + a2) * r + a3) * r + a4) * r + a5) * r + a6) * q /
+        (((((b1 * r + b2) * r + b3) * r + b4) * r + b5) * r + 1.0)
+}
+
+// MARK: - Attention / MLP
+
+public final class MiniCPMAttention: Module {
+    public let numHeads: Int
+    public let numKVHeads: Int
+    public let headDim: Int
+    public let scale: Float
+
+    @ModuleInfo(key: "q_proj") public var qProj: Linear
+    @ModuleInfo(key: "k_proj") public var kProj: Linear
+    @ModuleInfo(key: "v_proj") public var vProj: Linear
+    @ModuleInfo(key: "o_proj") public var oProj: Linear
+    public init(config: LMConfig) {
+        voxCPM2InitLog("Attention start")
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.kvChannels ?? (config.hiddenSize / config.numAttentionHeads)
+        self.scale = 1.0 / sqrt(Float(headDim))
+
+        let qDim = numHeads * headDim
+        let kvDim = numKVHeads * headDim
+
+        self._qProj = ModuleInfo(wrappedValue: zeroLinear(config.hiddenSize, qDim, bias: false), key: "q_proj")
+        voxCPM2InitLog("Attention q_proj")
+        self._kProj = ModuleInfo(wrappedValue: zeroLinear(config.hiddenSize, kvDim, bias: false), key: "k_proj")
+        voxCPM2InitLog("Attention k_proj")
+        self._vProj = ModuleInfo(wrappedValue: zeroLinear(config.hiddenSize, kvDim, bias: false), key: "v_proj")
+        voxCPM2InitLog("Attention v_proj")
+        self._oProj = ModuleInfo(wrappedValue: zeroLinear(qDim, config.hiddenSize, bias: false), key: "o_proj")
+        voxCPM2InitLog("Attention o_proj")
+
+        super.init()
+        voxCPM2InitLog("Attention done")
+    }
+
+    public func callAsFunction(
+        _ hiddenStates: MLXArray,
+        rope: MiniCPMLongRoPE?,
+        cache: (MLXArray, MLXArray)? = nil,
+        isCausal: Bool = true
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let batch = hiddenStates.dim(0)
+        let seqLen = hiddenStates.dim(1)
+
+        var queries = qProj(hiddenStates)
+        var keys = kProj(hiddenStates)
+        var values = vProj(hiddenStates)
+
+        queries = queries.reshaped(batch, seqLen, numHeads, headDim)
+        keys = keys.reshaped(batch, seqLen, numKVHeads, headDim)
+        values = values.reshaped(batch, seqLen, numKVHeads, headDim)
+
+        // RoPE is applied while q/k still have layout (B, L, H, D) — the cos/sin
+        // tables broadcast as (1, L, 1, D) and need the seq dim at axis 1, not
+        // axis 2. Apply the rotary embedding first, then transpose to head-first.
+        if let rope {
+            let offset = cache?.0.dim(2) ?? 0
+            let positionIds = MLXArray(0..<Int32(seqLen)) + Int32(offset)
+            let (cos, sin) = rope(positionIds)
+            (queries, keys) = applyRotaryPosEmb(q: queries, k: keys, cos: cos, sin: sin)
+        }
+
+        queries = queries.transposed(0, 2, 1, 3)
+        keys = keys.transposed(0, 2, 1, 3)
+        values = values.transposed(0, 2, 1, 3)
+
+        // Mirror the upstream MPS safeguard: SDPA behaves more reliably when
+        // q/k/v are materialized into contiguous buffers after the transpose.
+        queries = queries.contiguous()
+        keys = keys.contiguous()
+        values = values.contiguous()
+
+        var cachedKeys = keys
+        var cachedValues = values
+        if let (prevKeys, prevValues) = cache {
+            cachedKeys = concatenated([prevKeys, keys], axis: 2)
+            cachedValues = concatenated([prevValues, values], axis: 2)
+        }
+
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode
+        if !isCausal {
+            mask = .none
+        } else if seqLen <= 1 && cache == nil {
+            mask = .none
+        } else {
+            let kvLen = cachedKeys.dim(2)
+            let pastLen = kvLen - seqLen
+            let causal = MLXArray.tri(seqLen, m: kvLen, k: pastLen, type: Float.self)
+            let additiveMask = (1 - causal) * -Float.greatestFiniteMagnitude
+            mask = .array(additiveMask.reshaped(1, 1, seqLen, kvLen).asType(hiddenStates.dtype))
+        }
+
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: cachedKeys,
+            values: cachedValues,
+            scale: scale,
+            mask: mask
+        ).transposed(0, 2, 1, 3).reshaped(batch, seqLen, -1)
+        let output = oProj(attn)
+        return (output, (cachedKeys, cachedValues))
+    }
+}
+
+public final class MiniCPMMLP: Module {
+    @ModuleInfo(key: "gate_proj") public var gateProj: Linear
+    @ModuleInfo(key: "up_proj") public var upProj: Linear
+    @ModuleInfo(key: "down_proj") public var downProj: Linear
+
+    public init(config: LMConfig) {
+        self._gateProj = ModuleInfo(wrappedValue: zeroLinear(config.hiddenSize, config.intermediateSize, bias: false), key: "gate_proj")
+        self._upProj = ModuleInfo(wrappedValue: zeroLinear(config.hiddenSize, config.intermediateSize, bias: false), key: "up_proj")
+        self._downProj = ModuleInfo(wrappedValue: zeroLinear(config.intermediateSize, config.hiddenSize, bias: false), key: "down_proj")
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+public final class MiniCPMDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") public var selfAttn: MiniCPMAttention
+    @ModuleInfo public var mlp: MiniCPMMLP
+    @ModuleInfo(key: "input_layernorm") public var inputLayerNorm: VoxCPM2RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") public var postAttentionLayerNorm: VoxCPM2RMSNorm
+    public let scaleDepth: Float
+    public let useMup: Bool
+    public let numHiddenLayers: Int
+
+    public init(config: LMConfig) {
+        voxCPM2InitLog("DecoderLayer start")
+        self._selfAttn = ModuleInfo(wrappedValue: MiniCPMAttention(config: config), key: "self_attn")
+        voxCPM2InitLog("DecoderLayer self_attn")
+        self._mlp = ModuleInfo(wrappedValue: MiniCPMMLP(config: config))
+        voxCPM2InitLog("DecoderLayer mlp")
+        self._inputLayerNorm = ModuleInfo(wrappedValue: VoxCPM2RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps), key: "input_layernorm")
+        voxCPM2InitLog("DecoderLayer input_layernorm")
+        self._postAttentionLayerNorm = ModuleInfo(wrappedValue: VoxCPM2RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps), key: "post_attention_layernorm")
+        voxCPM2InitLog("DecoderLayer post_attention_layernorm")
+        self.scaleDepth = config.scaleDepth
+        self.useMup = config.useMup
+        self.numHiddenLayers = config.numHiddenLayers
+        super.init()
+        voxCPM2InitLog("DecoderLayer done")
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray,
+        rope: MiniCPMLongRoPE?,
+        cache: (MLXArray, MLXArray)? = nil,
+        isCausal: Bool = true,
+        debugLabel: String? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray)) {
+        let debugStatsEnabled = ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
+        if debugStatsEnabled, let debugLabel {
+            debugRange("\(debugLabel) input", x)
+        }
+
+        let residual = x
+        let normed = inputLayerNorm(x)
+        if debugStatsEnabled, let debugLabel {
+            debugRange("\(debugLabel) normed", normed)
+        }
+        let (attnOut, newCache) = selfAttn(normed, rope: rope, cache: cache, isCausal: isCausal)
+        if debugStatsEnabled, let debugLabel {
+            debugRange("\(debugLabel) attnOut", attnOut)
+        }
+        let residualScale = useMup ? (scaleDepth / sqrt(Float(numHiddenLayers))) : 1.0
+
+        var h = residual + (attnOut * MLXArray(residualScale))
+        let mlpOut = mlp(postAttentionLayerNorm(h)) * MLXArray(residualScale)
+        if debugStatsEnabled, let debugLabel {
+            debugRange("\(debugLabel) mlpOut", mlpOut)
+        }
+        h = h + mlpOut
+        if debugStatsEnabled, let debugLabel {
+            debugRange("\(debugLabel) output", h)
+        }
+        return (h, newCache)
+    }
+}
+
+public final class MiniCPMModel: Module {
+    public let config: LMConfig
+
+    @ModuleInfo(key: "embed_tokens") public var embedTokens: Embedding?
+    @ModuleInfo public var layers: [MiniCPMDecoderLayer]
+    @ModuleInfo public var norm: VoxCPM2RMSNorm
+    @ModuleInfo public var rope: MiniCPMLongRoPE?
+
+    public init(_ config: LMConfig) {
+        voxCPM2InitLog("MiniCPMModel start")
+        self.config = config
+        let embeddingCount = max(config.vocabSize, 1)
+        self._embedTokens = ModuleInfo(
+            wrappedValue: Embedding(embeddingCount: embeddingCount, dimensions: config.hiddenSize),
+            key: "embed_tokens"
+        )
+        voxCPM2InitLog("MiniCPMModel embed_tokens")
+        self._layers = ModuleInfo(wrappedValue: (0..<config.numHiddenLayers).map { _ in MiniCPMDecoderLayer(config: config) })
+        voxCPM2InitLog("MiniCPMModel layers")
+        self._norm = ModuleInfo(wrappedValue: VoxCPM2RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps))
+        voxCPM2InitLog("MiniCPMModel norm")
+        self._rope = ModuleInfo(wrappedValue: config.noRope ? nil : MiniCPMLongRoPE(config: config), key: "rope")
+        voxCPM2InitLog("MiniCPMModel rope")
+        super.init()
+        voxCPM2InitLog("MiniCPMModel done")
+    }
+
+    public func callAsFunction(
+        inputsEmbeds: MLXArray? = nil,
+        inputIds: MLXArray? = nil,
+        mask: MLXArray? = nil,
+        cache: [(MLXArray, MLXArray)]? = nil,
+        isCausal: Bool = true
+    ) -> (MLXArray, [(MLXArray, MLXArray)]) {
+        let hiddenStates: MLXArray
+        if let inputsEmbeds {
+            hiddenStates = inputsEmbeds
+        } else if let inputIds {
+            guard let embedTokens else {
+                fatalError("MiniCPMModel called with inputIds but no embed_tokens layer")
+            }
+            hiddenStates = embedTokens(inputIds)
+        } else {
+            fatalError("MiniCPMModel requires inputsEmbeds or inputIds")
+        }
+
+        let rope = self.rope
+
+        var h = hiddenStates
+        var newCaches: [(MLXArray, MLXArray)] = []
+        newCaches.reserveCapacity(layers.count)
+        let debugStatsEnabled = ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
+
+        for (idx, layer) in layers.enumerated() {
+            let layerCache = cache?[idx]
+            let debugLabel = debugStatsEnabled ? "MiniCPM layer \(idx)" : nil
+            let (nextH, nextCache) = layer(
+                h,
+                rope: rope,
+                cache: layerCache,
+                isCausal: isCausal,
+                debugLabel: debugLabel
+            )
+            h = nextH
+            newCaches.append(nextCache)
+        }
+
+        h = norm(h)
+        if debugStatsEnabled {
+            debugRange("MiniCPM final norm", h)
+        }
+        return (h, newCaches)
+    }
+}
+
+// MARK: - VoxCPM Local Encoder
+
+public final class VoxCPMLocEnc: Module {
+    public let config: LMConfig
+
+    @ParameterInfo(key: "special_token") public var specialToken: MLXArray
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo public var encoder: MiniCPMModel
+
+    public init(config: LMConfig, inputDim: Int = 64) {
+        self.config = config
+        self._specialToken = ParameterInfo(
+            wrappedValue: MLXArray(
+                Array(repeating: Float(0.0), count: config.hiddenSize),
+                [1, 1, 1, config.hiddenSize]
+            ),
+            key: "special_token"
+        )
+        self._inProj = ModuleInfo(wrappedValue: zeroLinear(inputDim, config.hiddenSize, bias: true), key: "in_proj")
+        self._encoder = ModuleInfo(wrappedValue: MiniCPMModel(config))
+        super.init()
+    }
+
+    public func loadSpecialToken(_ token: MLXArray) {
+        self.update(parameters: ModuleParameters(values: ["special_token": .value(token)]))
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let steps = x.dim(1)
+        let patches = x.dim(2)
+        let debugEnabled = voxCPM2InitDebugEnabled()
+        if debugEnabled {
+            voxCPM2InitLog("LocEnc input shape=\(x.shape) dtype=\(x.dtype)")
+        }
+
+        var h = inProj(x)
+        if debugEnabled {
+            voxCPM2InitLog("LocEnc inProj output shape=\(h.shape) dtype=\(h.dtype)")
+            voxCPM2InitLog("LocEnc specialToken shape=\(specialToken.shape) dtype=\(specialToken.dtype)")
+        }
+        let special = repeated(repeated(specialToken.asType(h.dtype), count: batch, axis: 0), count: steps, axis: 1)
+        if debugEnabled {
+            voxCPM2InitLog("LocEnc special repeated shape=\(special.shape) dtype=\(special.dtype)")
+        }
+        h = concatenated([special, h], axis: 2)
+        if debugEnabled {
+            voxCPM2InitLog("LocEnc concat shape=\(h.shape) dtype=\(h.dtype)")
+        }
+        h = h.reshaped(batch * steps, patches + 1, -1)
+        if debugEnabled {
+            voxCPM2InitLog("LocEnc reshaped shape=\(h.shape) dtype=\(h.dtype)")
+        }
+
+        let (outputs, _) = encoder(inputsEmbeds: h, isCausal: false)
+        if debugEnabled {
+            voxCPM2InitLog("LocEnc encoder output shape=\(outputs.shape) dtype=\(outputs.dtype)")
+        }
+        let cls = outputs[0..., 0..<1, 0...].squeezed(axis: 1)
+        return cls.reshaped(batch, steps, -1)
+    }
+}
+
+// MARK: - VoxCPM DiT
+
+public final class SinusoidalPosEmb: Module {
+    public let dim: Int
+
+    public init(dim: Int) {
+        precondition(dim % 2 == 0)
+        self.dim = dim
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, scale: Float = 1000) -> MLXArray {
+        let values = x.shape.isEmpty ? x.reshaped(1) : x.asType(.float32)
+        let half = dim / 2
+        let embScale = log(MLXArray(10000.0)) / MLXArray(Float(half - 1))
+        let freq = exp(MLXArray(0..<Int32(half)).asType(.float32) * (-embScale))
+        let emb = MLXArray(scale) * values.reshaped(-1, 1) * freq.reshaped(1, -1)
+        return concatenated([sin(emb), cos(emb)], axis: -1)
+    }
+}
+
+public final class TimestepEmbedding: Module {
+    @ModuleInfo(key: "linear_1") public var linear_1: Linear
+    @ModuleInfo(key: "linear_2") public var linear_2: Linear
+
+    public init(inChannels: Int, timeEmbedDim: Int, outDim: Int? = nil) {
+        self._linear_1 = ModuleInfo(wrappedValue: zeroLinear(inChannels, timeEmbedDim), key: "linear_1")
+        self._linear_2 = ModuleInfo(wrappedValue: zeroLinear(timeEmbedDim, outDim ?? timeEmbedDim), key: "linear_2")
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear_2(silu(linear_1(x)))
+    }
+}
+
+public final class VoxCPMLocDiTV2: Module {
+    public let config: LMConfig
+    public let inChannels: Int
+
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "cond_proj") var condProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+    @ModuleInfo var decoder: MiniCPMModel
+
+    public let timeEmbeddings: SinusoidalPosEmb
+    @ModuleInfo(key: "time_mlp") public var timeMlp: TimestepEmbedding
+    @ModuleInfo(key: "delta_time_mlp") public var deltaTimeMlp: TimestepEmbedding
+
+    public init(config: LMConfig, inChannels: Int = 64) {
+        self.config = config
+        self.inChannels = inChannels
+
+        self._inProj = ModuleInfo(wrappedValue: zeroLinear(inChannels, config.hiddenSize), key: "in_proj")
+        self._condProj = ModuleInfo(wrappedValue: zeroLinear(inChannels, config.hiddenSize), key: "cond_proj")
+        self._outProj = ModuleInfo(wrappedValue: zeroLinear(config.hiddenSize, inChannels), key: "out_proj")
+        self._decoder = ModuleInfo(wrappedValue: MiniCPMModel(config))
+        self.timeEmbeddings = SinusoidalPosEmb(dim: config.hiddenSize)
+        self._timeMlp = ModuleInfo(
+            wrappedValue: TimestepEmbedding(inChannels: config.hiddenSize, timeEmbedDim: config.hiddenSize),
+            key: "time_mlp"
+        )
+        self._deltaTimeMlp = ModuleInfo(
+            wrappedValue: TimestepEmbedding(inChannels: config.hiddenSize, timeEmbedDim: config.hiddenSize),
+            key: "delta_time_mlp"
+        )
+
+        super.init()
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray,
+        mu: MLXArray,
+        t: MLXArray,
+        cond: MLXArray,
+        dt: MLXArray
+    ) -> MLXArray {
+        let debugStatsEnabled = ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
+
+        let xProj = inProj(x.transposed(0, 2, 1).contiguous())
+        let condProj = condProj(cond.transposed(0, 2, 1).contiguous())
+        let prefix = condProj.dim(1)
+
+        let modelDType = xProj.dtype
+        let tEmb = timeMlp(timeEmbeddings(t).asType(modelDType)).asType(modelDType)
+        let dtEmb = deltaTimeMlp(timeEmbeddings(dt).asType(modelDType)).asType(modelDType)
+        let timeToken = (tEmb + dtEmb).expandedDimensions(axis: 1)
+
+        let hiddenDim = xProj.dim(2)
+        let muTokens = mu.asType(modelDType).reshaped(mu.dim(0), -1, hiddenDim)
+
+        let hidden = concatenated([muTokens, timeToken, condProj, xProj], axis: 1)
+        if debugStatsEnabled {
+            debugRange("LocDiT xProj", xProj)
+            debugRange("LocDiT condProj", condProj)
+            debugRange("LocDiT tEmb", tEmb)
+            debugRange("LocDiT dtEmb", dtEmb)
+            debugRange("LocDiT timeToken", timeToken)
+            debugRange("LocDiT muTokens", muTokens)
+            debugRange("LocDiT hidden", hidden)
+        }
+        let (decoded, _) = decoder(inputsEmbeds: hidden, isCausal: false)
+        let trimmed = decoded[0..., (muTokens.dim(1) + 1 + prefix)..., 0...]
+        let projected = outProj(trimmed)
+        if debugStatsEnabled {
+            debugRange("LocDiT decoded", decoded)
+            debugRange("LocDiT trimmed", trimmed)
+            debugRange("LocDiT projected", projected)
+        }
+        return projected.transposed(0, 2, 1).contiguous()
+    }
+}
+
+public final class UnifiedCFM: Module {
+    public let inChannels: Int
+    public let cfmParams: CFMConfig
+    public let meanMode: Bool
+
+    @ModuleInfo public var estimator: VoxCPMLocDiTV2
+
+    public init(
+        inChannels: Int,
+        cfmParams: CFMConfig,
+        estimator: VoxCPMLocDiTV2,
+        meanMode: Bool = false
+    ) {
+        self.inChannels = inChannels
+        self.cfmParams = cfmParams
+        self.meanMode = meanMode
+        self._estimator = ModuleInfo(wrappedValue: estimator)
+        super.init()
+    }
+
+    public func solveEuler(
+        _ x: MLXArray,
+        tSpan: [Float],
+        mu: MLXArray,
+        cond: MLXArray,
+        cfgValue: Float = 1.0,
+        useCfgZeroStar: Bool = true
+    ) -> MLXArray {
+        guard tSpan.count >= 2 else { return x }
+
+        var currentX = x
+        var t = tSpan[0]
+        var dt = tSpan[0] - tSpan[1]
+        let zeroInitSteps = max(1, Int(Double(tSpan.count) * 0.04))
+
+        for step in 1..<tSpan.count {
+            let dphiDt: MLXArray
+            if useCfgZeroStar && step <= zeroInitSteps {
+                dphiDt = MLXArray.zeros(currentX.shape, dtype: currentX.dtype, stream: .cpu)
+            } else {
+                let batch = currentX.dim(0)
+                let xIn = concatenated([currentX, currentX], axis: 0)
+                let muIn = concatenated([mu, MLXArray.zeros(mu.shape, dtype: mu.dtype, stream: .cpu)], axis: 0)
+                let tVal = MLXArray(Array(repeating: t, count: batch * 2)).reshaped(batch * 2)
+                let dtVal = meanMode
+                    ? MLXArray(Array(repeating: dt, count: batch * 2)).reshaped(batch * 2)
+                    : MLXArray.zeros([batch * 2], dtype: currentX.dtype, stream: .cpu)
+                let condIn = concatenated([cond, cond], axis: 0)
+
+                let out = estimator(xIn, mu: muIn, t: tVal, cond: condIn, dt: dtVal)
+                let positive = out[0..<batch, 0..., 0...]
+                let negative = out[batch..<(batch * 2), 0..., 0...]
+
+                if useCfgZeroStar {
+                    let positiveFlat = positive.reshaped(batch, -1)
+                    let negativeFlat = negative.reshaped(batch, -1)
+                    let dot = (positiveFlat * negativeFlat).sum(axis: 1).reshaped(batch, 1, 1)
+                    let sqNorm = ((negativeFlat * negativeFlat).sum(axis: 1) + MLXArray(1e-8)).reshaped(batch, 1, 1)
+                    let stStar = dot / sqNorm
+                    dphiDt = negative * stStar + MLXArray(cfgValue) * (positive - negative * stStar)
+                } else {
+                    dphiDt = negative + MLXArray(cfgValue) * (positive - negative)
+                }
+            }
+
+            currentX = currentX - MLXArray(dt) * dphiDt
+            t = tSpan[step]
+            if step < tSpan.count - 1 {
+                dt = tSpan[step] - tSpan[step + 1]
+            }
+        }
+
+        return currentX
+    }
+
+    public func sample(
+        mu: MLXArray,
+        nTimesteps: Int,
+        patchSize: Int,
+        cond: MLXArray,
+        temperature: Float = 1.0,
+        cfgValue: Float? = nil
+    ) -> MLXArray {
+        let batch = mu.dim(0)
+        let z = MLXRandom.normal([batch, inChannels, patchSize], dtype: mu.dtype) * MLXArray(temperature)
+        let tSpan = makeUnifiedCFMTimeSpan(
+            timesteps: nTimesteps,
+            scheduler: cfmParams.tScheduler,
+            sigmaMin: cfmParams.sigmaMin
+        )
+        return solveEuler(z, tSpan: tSpan, mu: mu, cond: cond, cfgValue: cfgValue ?? cfmParams.inferenceCfgRate)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
@@ -14,7 +14,7 @@ import MLXAudioCore
 import MLXAudioTTS
 
 let model = try await TTS.loadModel(
-    modelRepo: "aufklarer/VoxCPM2-MLX-bf16"
+    modelRepo: "mlx-community/VoxCPM2-8bit"
 )
 
 let audio = try await model.generate(

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
@@ -40,8 +40,64 @@ let model = try await TTS.loadModel(
 )
 ```
 
+## Advanced Features
+
+### Text Normalization
+
+Enable the `normalize` parameter to expand numbers, dates, currency amounts,
+and common abbreviations into spoken form before synthesis:
+
+```swift
+let audio = try await voxModel.generateVoxCPM2(
+    text: "It costs $50.25 — estimated delivery Feb 3rd.",
+    normalize: true
+)
+// Text becomes: "It costs fifty dollars and twenty-five cents — estimated delivery February third"
+```
+
+### Bad-case Retry
+
+The `retryBadcase` parameter automatically retries when the generated audio is
+abnormally short or long relative to the input text:
+
+```swift
+let audio = try await voxModel.generateVoxCPM2(
+    text: "Hello world.",
+    retryBadcase: true,
+    retryBadcaseMaxTimes: 3
+)
+```
+
+### LoRA Fine-Tuning
+
+Load a model with LoRA adapters for fine-tuned voice adaptation:
+
+```swift
+let config = LoRAConfig(enableLM: true, enableDiT: true, r: 8, alpha: 16)
+let model = try await VoxCPM2Model.fromModelDirectory(
+    modelDir,
+    loraConfig: config
+)
+try model.loadLoRA(weightsPath: "/path/to/lora_weights.safetensors")
+model.setLoRAEnabled(true)
+
+let audio = try await model.generateVoxCPM2(text: "Fine-tuned voice output.")
+```
+
+For training, the LoRA matrices (`loraA`, `loraB`) can be updated on each
+`LoRALinear` module. Use `getLoRAStateDict()` to export weights for saving:
+
+```swift
+let state = model.getLoRAStateDict()
+// Save `state` as a safetensors file for future inference
+```
+
 ## Notes
 
 - `voice` is passed as VoxCPM2 instruction text.
 - `refAudio` and `refText` are mapped to VoxCPM2 reference conditioning.
 - VoxCPM2 checkpoints are detected from `model_type`, `architecture`, or repository/path names containing `voxcpm2`.
+- LoRA requires injecting adapters at load time via `VoxCPM2Model.fromModelDirectory(_:loraConfig:)`.
+  The generic `TTS.loadModel()` path does not yet support LoRA configuration.
+- The ZipEnhancer denoiser (`denoise: true`) is not yet implemented in MLX.
+  Reference audio should be clean for best results.

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
@@ -2,6 +2,11 @@
 
 OpenBMB VoxCPM2 text-to-speech support for MLX Swift.
 
+The implementation is adapted from the VoxCPM2TTS module in
+[soniqo/speech-swift](https://github.com/soniqo/speech-swift), which is
+licensed under Apache-2.0, and integrated with this package's model loading
+and generation APIs.
+
 ## Usage
 
 ```swift

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/README.md
@@ -1,0 +1,42 @@
+# VoxCPM2
+
+OpenBMB VoxCPM2 text-to-speech support for MLX Swift.
+
+## Usage
+
+```swift
+import MLXAudioCore
+import MLXAudioTTS
+
+let model = try await TTS.loadModel(
+    modelRepo: "aufklarer/VoxCPM2-MLX-bf16"
+)
+
+let audio = try await model.generate(
+    text: "Hello from VoxCPM2.",
+    voice: nil,
+    refAudio: nil,
+    refText: nil,
+    language: nil
+)
+
+try AudioFileUtils.save(
+    audio: audio,
+    sampleRate: model.sampleRate,
+    fileURL: URL(fileURLWithPath: "/tmp/voxcpm2.wav")
+)
+```
+
+Local MLX checkpoints are supported as well:
+
+```swift
+let model = try await TTS.loadModel(
+    modelRepo: "/path/to/VoxCPM2-8bit"
+)
+```
+
+## Notes
+
+- `voice` is passed as VoxCPM2 instruction text.
+- `refAudio` and `refText` are mapped to VoxCPM2 reference conditioning.
+- VoxCPM2 checkpoints are detected from `model_type`, `architecture`, or repository/path names containing `voxcpm2`.

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
@@ -885,7 +885,7 @@ public final class VoxCPM2Model: Module {
     ) throws -> MLXArray {
         var mono = audio
         if sampleRate != audio_vae.sampleRate {
-            mono = VoxCPM2AudioResampler.resample(audio, from: sampleRate, to: audio_vae.sampleRate)
+            mono = try resampleAudio(audio, from: sampleRate, to: audio_vae.sampleRate)
         }
         guard !mono.isEmpty else {
             throw NSError(domain: "VoxCPM2Model", code: 2, userInfo: [
@@ -949,13 +949,18 @@ public final class VoxCPM2Model: Module {
         minTokens: Int = 2,
         refText: String? = nil,
         refAudio: [Float]? = nil,
+        refAudioSampleRate: Int? = nil,
         promptText: String? = nil,
         promptAudio: [Float]? = nil,
+        promptAudioSampleRate: Int? = nil,
         inferenceTimesteps: Int = 10,
         cfgValue: Float = 2.0,
         streamingPrefixLen: Int = 4,
         warmupPatches: Int = 0,
-        instruct: String? = nil
+        instruct: String? = nil,
+        streamingDecodeInterval: Int? = nil,
+        audioChunkHandler: (@Sendable ([Float]) -> Void)? = nil,
+        returnFullAudio: Bool = true
     ) async throws -> [Float] {
         guard tokenizer != nil else {
             throw NSError(domain: "VoxCPM2Model", code: 3, userInfo: [
@@ -998,12 +1003,12 @@ public final class VoxCPM2Model: Module {
 
             let refFeat = try encodeAudio(
                 refAudio ?? [],
-                sampleRate: audio_vae.sampleRate,
+                sampleRate: refAudioSampleRate ?? audio_vae.sampleRate,
                 paddingMode: "right"
             )
             let promptFeat = try encodeAudio(
                 promptAudio ?? [],
-                sampleRate: audio_vae.sampleRate,
+                sampleRate: promptAudioSampleRate ?? audio_vae.sampleRate,
                 paddingMode: "left"
             )
             let promptLen = promptFeat.dim(0)
@@ -1063,7 +1068,7 @@ public final class VoxCPM2Model: Module {
 
             let refFeat = try encodeAudio(
                 refAudio ?? [],
-                sampleRate: audio_vae.sampleRate,
+                sampleRate: refAudioSampleRate ?? audio_vae.sampleRate,
                 paddingMode: "right"
             )
             let refTokens = MLXArray(
@@ -1106,7 +1111,7 @@ public final class VoxCPM2Model: Module {
 
             let promptFeat = try encodeAudio(
                 promptAudio ?? [],
-                sampleRate: audio_vae.sampleRate,
+                sampleRate: promptAudioSampleRate ?? audio_vae.sampleRate,
                 paddingMode: "left"
             )
             let promptLen = promptFeat.dim(0)
@@ -1185,6 +1190,18 @@ public final class VoxCPM2Model: Module {
 
         let hasContinuation = hasPrompt
         var predFeatSeq: [MLXArray] = []
+        var pendingStreamFeats: [MLXArray] = []
+        let streamInterval = max(1, streamingDecodeInterval ?? Int.max)
+
+        func decodeAudio(_ feats: [MLXArray]) -> [Float] {
+            var allFeat = concatenated(feats, axis: 1)
+            allFeat = allFeat.reshaped([allFeat.dim(0), -1, args.featDim])
+            var audio = audio_vae.decode(allFeat.asType(.float32))
+            audio = audio.flattened()
+            eval(audio)
+            return audio.asArray(Float.self)
+        }
+
         if hasContinuation {
             let audioIndices = (0..<audioMaskB.dim(1)).filter { idx in
                 audioMaskB[0, idx].item(Float.self) > 0.5
@@ -1223,7 +1240,15 @@ public final class VoxCPM2Model: Module {
             predFeat = predFeat.transposed(0, 2, 1)
 
             if step >= warmupCount {
-                predFeatSeq.append(predFeat.expandedDimensions(axis: 1))
+                let generatedFeat = predFeat.expandedDimensions(axis: 1)
+                predFeatSeq.append(generatedFeat)
+                if audioChunkHandler != nil {
+                    pendingStreamFeats.append(generatedFeat)
+                    if pendingStreamFeats.count >= streamInterval {
+                        audioChunkHandler?(decodeAudio(pendingStreamFeats))
+                        pendingStreamFeats.removeAll(keepingCapacity: true)
+                    }
+                }
             }
 
             let currEmbed = enc_to_lm_proj(
@@ -1271,12 +1296,17 @@ public final class VoxCPM2Model: Module {
             ])
         }
 
-        logGen("decoding audio")
-        var allFeat = concatenated(predFeatSeq, axis: 1)
-        allFeat = allFeat.reshaped([allFeat.dim(0), -1, args.featDim])
+        if audioChunkHandler != nil, !pendingStreamFeats.isEmpty {
+            audioChunkHandler?(decodeAudio(pendingStreamFeats))
+            pendingStreamFeats.removeAll(keepingCapacity: true)
+        }
 
-        var audio = audio_vae.decode(allFeat.asType(.float32))
-        audio = audio.flattened()
+        if audioChunkHandler != nil && !returnFullAudio {
+            return []
+        }
+
+        logGen("decoding audio")
+        var audio = MLXArray(decodeAudio(predFeatSeq))
 
         if hasContinuation {
             let decodePatchLen = args.patchSize * audio_vae.decodeChunkSize
@@ -1341,7 +1371,7 @@ extension VoxCPM2Model: SpeechGenerationModel, @unchecked Sendable {
             }
 
             do {
-                let samples = try await self.generateVoxCPM2(
+                _ = try await self.generateVoxCPM2(
                     text: text,
                     language: language,
                     maxTokens: generationParameters.maxTokens ?? 2000,
@@ -1349,9 +1379,13 @@ extension VoxCPM2Model: SpeechGenerationModel, @unchecked Sendable {
                     refAudio: refAudioSamples,
                     inferenceTimesteps: 10,
                     cfgValue: 2.0,
-                    instruct: voice
+                    instruct: voice,
+                    streamingDecodeInterval: 4,
+                    audioChunkHandler: { chunk in
+                        continuation.yield(.audio(MLXArray(chunk)))
+                    },
+                    returnFullAudio: false
                 )
-                continuation.yield(.audio(MLXArray(samples)))
                 continuation.finish()
             } catch {
                 continuation.finish(throwing: error)

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
@@ -1,3 +1,5 @@
+// Adapted from soniqo/speech-swift's VoxCPM2TTS module (Apache-2.0).
+
 import Foundation
 import HuggingFace
 import MLX

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
@@ -1,0 +1,1361 @@
+import Foundation
+import HuggingFace
+import MLX
+import MLXAudioCore
+import MLXFast
+import MLXLMCommon
+import MLXNN
+import Tokenizers
+
+public final class ScalarQuantizationLayer: Module {
+    @ModuleInfo(key: "in_proj") public var in_proj: Linear
+    @ModuleInfo(key: "out_proj") public var out_proj: Linear
+    public let scale: Int
+
+    public init(inDim: Int, outDim: Int, latentDim: Int = 64, scale: Int = 9) {
+        self.scale = scale
+        self._in_proj = ModuleInfo(wrappedValue: zeroLinear(inDim, latentDim), key: "in_proj")
+        self._out_proj = ModuleInfo(wrappedValue: zeroLinear(latentDim, outDim), key: "out_proj")
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let h = in_proj(x)
+        let quantized = round(tanh(h) * MLXArray(Float(scale))) / MLXArray(Float(scale))
+        return out_proj(quantized)
+    }
+}
+
+public final class VoxCPM2Model: Module {
+    public let args: ModelArgs
+    public let outputSampleRate: Int
+
+    @ModuleInfo public var base_lm: MiniCPMModel
+    @ModuleInfo public var residual_lm: MiniCPMModel
+    @ModuleInfo public var feat_encoder: VoxCPMLocEnc
+    @ModuleInfo public var feat_decoder: UnifiedCFM
+    @ModuleInfo public var fsq_layer: ScalarQuantizationLayer
+    @ModuleInfo public var enc_to_lm_proj: Linear
+    @ModuleInfo public var lm_to_dit_proj: Linear
+    @ModuleInfo public var res_to_dit_proj: Linear
+    @ModuleInfo public var fusion_concat_proj: Linear
+    @ModuleInfo public var stop_proj: Linear
+    @ModuleInfo public var stop_head: Linear
+    @ModuleInfo public var audio_vae: AudioVAE
+
+    private var tokenizer: Tokenizers.Tokenizer?
+    private var voxCPM2TokenizerSplitMap: [Int: [Int]] = [:]
+    private var _isLoaded: Bool = true
+    private static var debugVerboseEnabled: Bool {
+        ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
+    }
+
+    public init(args: ModelArgs) {
+        self.args = args
+        self.outputSampleRate = args.audioVAEConfig.outSampleRate
+        let debugInitEnabled = ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_INIT"] == "1"
+        @inline(__always)
+        func logInit(_ message: String) {
+            guard debugInitEnabled else { return }
+            let line = "  VoxCPM2 init: \(message)\n"
+            if let data = line.data(using: .utf8) {
+                FileHandle.standardOutput.write(data)
+            }
+        }
+
+        let lmConfig = args.lmConfig
+        logInit("base_lm")
+        self._base_lm = ModuleInfo(wrappedValue: MiniCPMModel(lmConfig))
+
+        var residualConfig = lmConfig
+        residualConfig.numHiddenLayers = args.residualLMNumLayers
+        residualConfig.vocabSize = 0
+        residualConfig.noRope = args.residualLMNoRope
+        logInit("residual_lm")
+        self._residual_lm = ModuleInfo(wrappedValue: MiniCPMModel(residualConfig))
+
+        var encoderConfig = lmConfig
+        encoderConfig.hiddenSize = args.encoderConfig.hiddenDim
+        encoderConfig.intermediateSize = args.encoderConfig.ffnDim
+        encoderConfig.numAttentionHeads = args.encoderConfig.numHeads
+        encoderConfig.numHiddenLayers = args.encoderConfig.numLayers
+        encoderConfig.kvChannels = args.encoderConfig.kvChannels
+        encoderConfig.vocabSize = 0
+        logInit("feat_encoder")
+        self._feat_encoder = ModuleInfo(wrappedValue: VoxCPMLocEnc(config: encoderConfig, inputDim: args.featDim))
+
+        var ditConfig = lmConfig
+        ditConfig.hiddenSize = args.ditConfig.hiddenDim
+        ditConfig.intermediateSize = args.ditConfig.ffnDim
+        ditConfig.numAttentionHeads = args.ditConfig.numHeads
+        ditConfig.numHiddenLayers = args.ditConfig.numLayers
+        ditConfig.kvChannels = args.ditConfig.kvChannels
+        ditConfig.vocabSize = 0
+        logInit("feat_decoder")
+        let estimator = VoxCPMLocDiTV2(config: ditConfig, inChannels: args.featDim)
+        self._feat_decoder = ModuleInfo(wrappedValue: UnifiedCFM(
+            inChannels: args.featDim,
+            cfmParams: args.ditConfig.cfmConfig,
+            estimator: estimator,
+            meanMode: args.ditConfig.ditMeanMode
+        ))
+
+        logInit("fsq_layer")
+        self._fsq_layer = ModuleInfo(wrappedValue: ScalarQuantizationLayer(
+            inDim: args.lmConfig.hiddenSize,
+            outDim: args.lmConfig.hiddenSize,
+            latentDim: args.scalarQuantizationLatentDim,
+            scale: args.scalarQuantizationScale
+        ))
+
+        logInit("projection heads")
+        self._enc_to_lm_proj = ModuleInfo(wrappedValue: zeroLinear(args.encoderConfig.hiddenDim, args.lmConfig.hiddenSize))
+        self._lm_to_dit_proj = ModuleInfo(wrappedValue: zeroLinear(args.lmConfig.hiddenSize, args.ditConfig.hiddenDim))
+        self._res_to_dit_proj = ModuleInfo(wrappedValue: zeroLinear(args.lmConfig.hiddenSize, args.ditConfig.hiddenDim))
+        self._fusion_concat_proj = ModuleInfo(wrappedValue: zeroLinear(args.lmConfig.hiddenSize * 2, args.lmConfig.hiddenSize))
+        self._stop_proj = ModuleInfo(wrappedValue: zeroLinear(args.lmConfig.hiddenSize, args.lmConfig.hiddenSize))
+        self._stop_head = ModuleInfo(wrappedValue: zeroLinear(args.lmConfig.hiddenSize, 2, bias: false))
+        logInit("audio_vae")
+        self._audio_vae = ModuleInfo(wrappedValue: AudioVAE(args.audioVAEConfig))
+
+        super.init()
+    }
+
+    private static var shouldPromoteRuntimeParametersToFloat32: Bool {
+        GPU.deviceInfo().architecture.lowercased().contains("apple")
+    }
+
+    private func promoteRuntimeParametersToFloat32() {
+        _ = apply(filter: { module, _, _ in
+            !(module is Quantized)
+        }) { array in
+            array.asType(.float32)
+        }
+    }
+
+    // MARK: - Loading
+
+    public static func fromPretrained(
+        _ modelRepo: String = "aufklarer/VoxCPM2-MLX-bf16",
+        cache: HubCache = .default
+    ) async throws -> VoxCPM2Model {
+        guard let repoID = Repo.ID(rawValue: modelRepo) else {
+            throw AudioGenerationError.modelNotInitialized("Invalid repository ID: \(modelRepo)")
+        }
+
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            additionalMatchingPatterns: ["*.py"],
+            cache: cache
+        )
+        return try await fromModelDirectory(modelDir)
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) async throws -> VoxCPM2Model {
+        let args = try ModelArgs.load(from: modelDir)
+        let model = VoxCPM2Model(args: args)
+
+        let tokenizer = try await Self.loadTokenizer(from: modelDir)
+        model.setTokenizer(tokenizer)
+
+        try model.loadWithDiagnostics("loadWeights(from:)") {
+            try model.loadWeights(from: modelDir)
+        }
+        if ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_WLOAD"] == "1" {
+            let q = model.base_lm.layers[0].selfAttn.qProj.weight
+            let mAbs = q.abs().mean().item(Float.self)
+            print("[VoxCPM2 WLOAD pre-promote] base_lm L0 q_proj mean_abs=\(mAbs) dtype=\(q.dtype)")
+        }
+        // Upstream promotes low-precision VoxCPM2 runtime dtypes to float32 on
+        // Apple Silicon because bf16/fp16 can glitch the diffusion loop.
+        if Self.shouldPromoteRuntimeParametersToFloat32 {
+            model.promoteRuntimeParametersToFloat32()
+        } else {
+            model.audio_vae.castParametersToFloat32()
+        }
+        if ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_WLOAD"] == "1" {
+            let q = model.base_lm.layers[0].selfAttn.qProj.weight
+            let mAbs = q.abs().mean().item(Float.self)
+            print("[VoxCPM2 WLOAD post-promote] base_lm L0 q_proj mean_abs=\(mAbs) dtype=\(q.dtype)")
+        }
+
+        // NOTE: MLX can trip over some parameter views during eager evaluation
+        // even when the model loads cleanly. We defer evaluation until first use.
+
+        return model
+    }
+
+    private func swapQuantizedLinears(from weights: [String: MLXArray]) throws {
+        let quantizedPaths = Set(weights.keys.flatMap { key -> [String] in
+            guard key.hasSuffix(".scales") else { return [] }
+            let base = String(key.dropLast(".scales".count))
+            return Self.quantizedPathVariants(for: base)
+        })
+        guard !quantizedPaths.isEmpty else { return }
+
+        let bits: Int
+        if let cfg = args.quantization, cfg.isQuantized {
+            bits = cfg.bits
+        } else {
+            bits = inferQuantizationBits(from: weights) ?? 4
+        }
+        let groupSize = args.quantization?.groupSize ?? 64
+        guard bits == 4 || bits == 8 else {
+            throw NSError(domain: "VoxCPM2Model", code: 6, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported quantization bits: \(bits) (expected 4 or 8)"
+            ])
+        }
+
+        // Walk every leaf module; convert each Linear whose path appears in the
+        // safetensors as a quantized weight. `quantize(model:filter:)` from MLXNN
+        // does the Linear → QuantizedLinear swap in place via update(modules:).
+        // The placeholder quantized parameters are overwritten by the subsequent
+        // update(parameters:) calls in loadWeights().
+        quantize(
+            model: self,
+            groupSize: groupSize,
+            bits: bits,
+            filter: { path, _ in quantizedPaths.contains(path) }
+        )
+    }
+
+    private static func quantizedPathVariants(for path: String) -> [String] {
+        let components = path.split(separator: ".").map(String.init)
+        guard let last = components.last else { return [path] }
+
+        var variants = [path]
+        let camelLast = camelCaseKey(last)
+        if camelLast != last {
+            let camelPath = (components.dropLast() + [camelLast]).joined(separator: ".")
+            variants.append(camelPath)
+        }
+        return variants
+    }
+
+    private static func camelCaseKey(_ key: String) -> String {
+        let parts = key.split(separator: "_").map(String.init)
+        guard parts.count > 1 else { return key }
+
+        let head = parts[0]
+        let tail = parts.dropFirst().map { component in
+            guard let first = component.first else { return component }
+            return first.uppercased() + component.dropFirst()
+        }
+        return ([head] + tail).joined()
+    }
+
+    private func inferQuantizationBits(from weights: [String: MLXArray]) -> Int? {
+        for key in weights.keys where key.hasSuffix(".scales") {
+            let prefix = String(key.dropLast(".scales".count))
+            guard let weight = weights["\(prefix).weight"],
+                  let scales = weights["\(prefix).scales"],
+                  weight.ndim == 2, scales.ndim == 2 else { continue }
+            let packedCols = weight.dim(1)
+            let numGroups = scales.dim(1)
+            guard numGroups > 0 else { continue }
+            let ratio = packedCols / numGroups
+            if ratio == 8 { return 4 }
+            if ratio == 16 { return 8 }
+        }
+        return nil
+    }
+
+    private static func loadTokenizer(from directory: URL) async throws -> Tokenizers.Tokenizer {
+        try await AutoTokenizer.from(modelFolder: directory, strict: false)
+    }
+
+    private func loadWeights(from directory: URL) throws {
+        let allWeights = try VoxCPM2WeightLoader.loadAllSafetensors(from: directory)
+        let sanitized = audio_vae.sanitize(allWeights)
+        try swapQuantizedLinears(from: sanitized)
+        try loadWeights(into: base_lm, prefix: "base_lm", from: sanitized)
+        try loadWeights(into: residual_lm, prefix: "residual_lm", from: sanitized)
+        if let specialToken = sanitized["feat_encoder.special_token"] {
+            try loadWithDiagnostics("feat_encoder.special_token") {
+                feat_encoder.loadSpecialToken(specialToken)
+            }
+        }
+        try loadWithDiagnostics("feat_encoder.in_proj") {
+            try loadLinearWeights(to: feat_encoder.inProj, prefix: "feat_encoder.in_proj", from: sanitized)
+        }
+        try loadWeights(into: feat_encoder.encoder, prefix: "feat_encoder.encoder", from: sanitized)
+        try loadWithDiagnostics("feat_decoder") {
+            try loadLinearWeights(
+                to: feat_decoder.estimator.inProj,
+                prefix: "feat_decoder.estimator.in_proj",
+                from: sanitized
+            )
+            try loadLinearWeights(
+                to: feat_decoder.estimator.condProj,
+                prefix: "feat_decoder.estimator.cond_proj",
+                from: sanitized
+            )
+            try loadLinearWeights(
+                to: feat_decoder.estimator.outProj,
+                prefix: "feat_decoder.estimator.out_proj",
+                from: sanitized
+            )
+            try loadWeights(
+                into: feat_decoder.estimator.timeMlp,
+                prefix: "feat_decoder.estimator.time_mlp",
+                from: sanitized
+            )
+            try loadWeights(
+                into: feat_decoder.estimator.deltaTimeMlp,
+                prefix: "feat_decoder.estimator.delta_time_mlp",
+                from: sanitized
+            )
+            // Use the generic recursive loader (same path as base_lm). The
+            // explicit loadMiniCPMModel below only loaded .weight per Linear
+            // and silently skipped .scales / .biases — which left every
+            // quantized Linear in the DiT decoder at random init in the
+            // int8 / int4 bundles, producing near-no-op layers.
+            try loadWeights(
+                into: feat_decoder.estimator.decoder,
+                prefix: "feat_decoder.estimator.decoder",
+                from: sanitized
+            )
+        }
+        try loadWithDiagnostics("fsq_layer") {
+            try loadWeights(into: fsq_layer, prefix: "fsq_layer", from: sanitized)
+        }
+        try loadWithDiagnostics("enc_to_lm_proj") {
+            try loadLinearWeights(to: enc_to_lm_proj, prefix: "enc_to_lm_proj", from: sanitized)
+        }
+        try loadWithDiagnostics("lm_to_dit_proj") {
+            try loadLinearWeights(to: lm_to_dit_proj, prefix: "lm_to_dit_proj", from: sanitized)
+        }
+        try loadWithDiagnostics("res_to_dit_proj") {
+            try loadLinearWeights(to: res_to_dit_proj, prefix: "res_to_dit_proj", from: sanitized)
+        }
+        try loadWithDiagnostics("fusion_concat_proj") {
+            try loadLinearWeights(to: fusion_concat_proj, prefix: "fusion_concat_proj", from: sanitized)
+        }
+        try loadWithDiagnostics("stop_proj") {
+            try loadLinearWeights(to: stop_proj, prefix: "stop_proj", from: sanitized)
+        }
+        try loadWithDiagnostics("stop_head") {
+            try loadLinearWeights(to: stop_head, prefix: "stop_head", from: sanitized)
+        }
+        try loadWithDiagnostics("audio_vae.encoder") {
+            try loadWeights(into: audio_vae.encoder, prefix: "audio_vae.encoder", from: sanitized)
+        }
+        try loadWithDiagnostics("audio_vae.encoder.conv_in") {
+            if let weight = sanitized["audio_vae.encoder.conv_in.weight"] {
+                try ensureShape(weight, matches: audio_vae.encoder.conv_in.weight.shape, label: "audio_vae.encoder.conv_in.weight")
+                audio_vae.encoder.conv_in.weight = weight
+            }
+            if let bias = sanitized["audio_vae.encoder.conv_in.bias"] {
+                if let currentBias = audio_vae.encoder.conv_in.bias {
+                    try ensureShape(bias, matches: currentBias.shape, label: "audio_vae.encoder.conv_in.bias")
+                }
+                audio_vae.encoder.conv_in.bias = bias
+            }
+        }
+        try loadWithDiagnostics("audio_vae.decoder.conv_in") {
+            try loadDecoderConvStack(audio_vae.decoder.conv_in, prefix: "audio_vae.decoder.conv_in", from: sanitized)
+        }
+        for (index, block) in audio_vae.decoder.blocks.layers.enumerated() {
+            try loadWithDiagnostics("audio_vae.decoder.blocks.layers.\(index)") {
+                try loadDecoderBlock(block, prefix: "audio_vae.decoder.blocks.layers.\(index)", from: sanitized)
+            }
+        }
+        try loadWithDiagnostics("audio_vae.decoder.sr_cond_layers") {
+            try loadSampleRateConditionLayerStack(
+                audio_vae.decoder.srCondLayers,
+                prefix: "audio_vae.decoder.sr_cond_layers",
+                from: sanitized
+            )
+        }
+        if let snakeOut = sanitized["audio_vae.decoder.snake_out.alpha"] {
+            try loadWithDiagnostics("audio_vae.decoder.snake_out.alpha") {
+                try ensureShape(
+                    snakeOut,
+                    matches: audio_vae.decoder.snake_out.alpha.shape,
+                    label: "audio_vae.decoder.snake_out.alpha"
+                )
+                audio_vae.decoder.snake_out.loadAlpha(snakeOut)
+            }
+        }
+        if let convOutWeight = sanitized["audio_vae.decoder.conv_out.weight"] {
+            try loadWithDiagnostics("audio_vae.decoder.conv_out.weight") {
+                try ensureShape(
+                    convOutWeight,
+                    matches: audio_vae.decoder.conv_out.weight.shape,
+                    label: "audio_vae.decoder.conv_out.weight"
+                )
+                audio_vae.decoder.conv_out.weight = convOutWeight
+            }
+        }
+        if let convOutBias = sanitized["audio_vae.decoder.conv_out.bias"] {
+            try loadWithDiagnostics("audio_vae.decoder.conv_out.bias") {
+                if let currentBias = audio_vae.decoder.conv_out.bias {
+                    try ensureShape(
+                        convOutBias,
+                        matches: currentBias.shape,
+                        label: "audio_vae.decoder.conv_out.bias"
+                    )
+                }
+                audio_vae.decoder.conv_out.bias = convOutBias
+            }
+        }
+        if ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_STATS"] == "1" {
+            let baseQ = base_lm.layers[0].selfAttn.qProj.weight.asArray(Float.self)
+            let baseGate = base_lm.layers[0].mlp.gateProj.weight.asArray(Float.self)
+            let residualQ = residual_lm.layers[0].selfAttn.qProj.weight.asArray(Float.self)
+            let encoderQ = feat_encoder.encoder.layers[0].selfAttn.qProj.weight.asArray(Float.self)
+            let encoderGate = feat_encoder.encoder.layers[0].mlp.gateProj.weight.asArray(Float.self)
+            let featIn = feat_encoder.inProj.weight.asArray(Float.self)
+            let featDecoderIn = feat_decoder.estimator.inProj.weight.asArray(Float.self)
+            let featDecoderCond = feat_decoder.estimator.condProj.weight.asArray(Float.self)
+            let featDecoderOut = feat_decoder.estimator.outProj.weight.asArray(Float.self)
+            if let data = "  VoxCPM2 loaded weights: base_q[min=\(baseQ.min() ?? 0), max=\(baseQ.max() ?? 0)], base_gate[min=\(baseGate.min() ?? 0), max=\(baseGate.max() ?? 0)], residual_q[min=\(residualQ.min() ?? 0), max=\(residualQ.max() ?? 0)], encoder_q[min=\(encoderQ.min() ?? 0), max=\(encoderQ.max() ?? 0)], encoder_gate[min=\(encoderGate.min() ?? 0), max=\(encoderGate.max() ?? 0)], feat_in[min=\(featIn.min() ?? 0), max=\(featIn.max() ?? 0)]\n".data(using: .utf8) {
+                FileHandle.standardOutput.write(data)
+            }
+            if let data = "  VoxCPM2 loaded feat_decoder weights: in_proj[min=\(featDecoderIn.min() ?? 0), max=\(featDecoderIn.max() ?? 0)], cond_proj[min=\(featDecoderCond.min() ?? 0), max=\(featDecoderCond.max() ?? 0)], out_proj[min=\(featDecoderOut.min() ?? 0), max=\(featDecoderOut.max() ?? 0)]\n".data(using: .utf8) {
+                FileHandle.standardOutput.write(data)
+            }
+        }
+    }
+
+    private func loadMiniCPMModel(
+        _ model: MiniCPMModel,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        if let embedTokens = weights["\(prefix).embed_tokens.weight"] {
+            try loadWithDiagnostics("\(prefix).embed_tokens") {
+                model.update(
+                    modules: ModuleChildren.unflattened([
+                        ("embed_tokens", Embedding(weight: embedTokens))
+                    ])
+                )
+            }
+        }
+
+        if let rope = model.rope {
+            try loadMiniCPMRope(rope, prefix: "\(prefix).rope", from: weights)
+        }
+
+        if let normWeight = weights["\(prefix).norm.weight"] {
+            try loadWithDiagnostics("\(prefix).norm") {
+                try ensureShape(normWeight, matches: model.norm.weight.shape, label: "\(prefix).norm.weight")
+                try model.norm.update(parameters: ModuleParameters.unflattened(["weight": normWeight]), verify: .shapeMismatch)
+            }
+        }
+
+        for (index, layer) in model.layers.enumerated() {
+            try loadMiniCPMDecoderLayer(layer, prefix: "\(prefix).layers.\(index)", from: weights)
+        }
+    }
+
+    private func loadMiniCPMRope(
+        _ rope: MiniCPMLongRoPE,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        if let invFreq = weights["\(prefix).inv_freq"] {
+            try loadWithDiagnostics("\(prefix).inv_freq") {
+                try ensureShape(invFreq, matches: rope.invFreq.shape, label: "\(prefix).inv_freq")
+                try rope.update(parameters: ModuleParameters.unflattened(["inv_freq": invFreq]), verify: .shapeMismatch)
+            }
+        }
+        if let shortFactor = weights["\(prefix).short_factor"] {
+            try loadWithDiagnostics("\(prefix).short_factor") {
+                try ensureShape(shortFactor, matches: rope.shortFactor.shape, label: "\(prefix).short_factor")
+                try rope.update(parameters: ModuleParameters.unflattened(["short_factor": shortFactor]), verify: .shapeMismatch)
+            }
+        }
+        if let longFactor = weights["\(prefix).long_factor"] {
+            try loadWithDiagnostics("\(prefix).long_factor") {
+                try ensureShape(longFactor, matches: rope.longFactor.shape, label: "\(prefix).long_factor")
+                try rope.update(parameters: ModuleParameters.unflattened(["long_factor": longFactor]), verify: .shapeMismatch)
+            }
+        }
+    }
+
+    private func loadMiniCPMDecoderLayer(
+        _ layer: MiniCPMDecoderLayer,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        if let inputLayerNorm = weights["\(prefix).input_layernorm.weight"] {
+            try loadWithDiagnostics("\(prefix).input_layernorm") {
+                try ensureShape(inputLayerNorm, matches: layer.inputLayerNorm.weight.shape, label: "\(prefix).input_layernorm.weight")
+                try layer.inputLayerNorm.update(parameters: ModuleParameters.unflattened(["weight": inputLayerNorm]), verify: .shapeMismatch)
+            }
+        }
+
+        if let qWeight = weights["\(prefix).self_attn.q_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).self_attn.q_proj") {
+                try ensureShape(qWeight, matches: layer.selfAttn.qProj.weight.shape, label: "\(prefix).self_attn.q_proj.weight")
+                try layer.selfAttn.qProj.update(parameters: ModuleParameters.unflattened(["weight": qWeight]), verify: .shapeMismatch)
+            }
+        }
+        if let kWeight = weights["\(prefix).self_attn.k_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).self_attn.k_proj") {
+                try ensureShape(kWeight, matches: layer.selfAttn.kProj.weight.shape, label: "\(prefix).self_attn.k_proj.weight")
+                try layer.selfAttn.kProj.update(parameters: ModuleParameters.unflattened(["weight": kWeight]), verify: .shapeMismatch)
+            }
+        }
+        if let vWeight = weights["\(prefix).self_attn.v_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).self_attn.v_proj") {
+                try ensureShape(vWeight, matches: layer.selfAttn.vProj.weight.shape, label: "\(prefix).self_attn.v_proj.weight")
+                try layer.selfAttn.vProj.update(parameters: ModuleParameters.unflattened(["weight": vWeight]), verify: .shapeMismatch)
+            }
+        }
+        if let oWeight = weights["\(prefix).self_attn.o_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).self_attn.o_proj") {
+                try ensureShape(oWeight, matches: layer.selfAttn.oProj.weight.shape, label: "\(prefix).self_attn.o_proj.weight")
+                try layer.selfAttn.oProj.update(parameters: ModuleParameters.unflattened(["weight": oWeight]), verify: .shapeMismatch)
+            }
+        }
+        if let gateWeight = weights["\(prefix).mlp.gate_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).mlp.gate_proj") {
+                try ensureShape(gateWeight, matches: layer.mlp.gateProj.weight.shape, label: "\(prefix).mlp.gate_proj.weight")
+                try layer.mlp.gateProj.update(parameters: ModuleParameters.unflattened(["weight": gateWeight]), verify: .shapeMismatch)
+            }
+        }
+        if let upWeight = weights["\(prefix).mlp.up_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).mlp.up_proj") {
+                try ensureShape(upWeight, matches: layer.mlp.upProj.weight.shape, label: "\(prefix).mlp.up_proj.weight")
+                try layer.mlp.upProj.update(parameters: ModuleParameters.unflattened(["weight": upWeight]), verify: .shapeMismatch)
+            }
+        }
+        if let downWeight = weights["\(prefix).mlp.down_proj.weight"] {
+            try loadWithDiagnostics("\(prefix).mlp.down_proj") {
+                try ensureShape(downWeight, matches: layer.mlp.downProj.weight.shape, label: "\(prefix).mlp.down_proj.weight")
+                try layer.mlp.downProj.update(parameters: ModuleParameters.unflattened(["weight": downWeight]), verify: .shapeMismatch)
+            }
+        }
+
+        if let postAttentionLayerNorm = weights["\(prefix).post_attention_layernorm.weight"] {
+            try loadWithDiagnostics("\(prefix).post_attention_layernorm") {
+                try ensureShape(postAttentionLayerNorm, matches: layer.postAttentionLayerNorm.weight.shape, label: "\(prefix).post_attention_layernorm.weight")
+                try layer.postAttentionLayerNorm.update(parameters: ModuleParameters.unflattened(["weight": postAttentionLayerNorm]), verify: .shapeMismatch)
+            }
+        }
+    }
+
+    @discardableResult
+    private func loadWithDiagnostics<T>(_ label: String, _ body: () throws -> T) throws -> T {
+        do {
+            return try withErrorHandler({ message in
+                if let data = "[VoxCPM2] MLX error in \(label): \(message)\n".data(using: .utf8) {
+                    FileHandle.standardOutput.write(data)
+                }
+            }) {
+                try withError { error in
+                    let value = try body()
+                    try error.check()
+                    return value
+                }
+            }
+        } catch {
+            if let data = "[VoxCPM2] Swift error in \(label): \(error)\n".data(using: .utf8) {
+                FileHandle.standardOutput.write(data)
+            }
+            throw error
+        }
+    }
+
+    private func loadLinearWeights(
+        to linear: Linear,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        var params: [String: NestedItem<String, MLXArray>] = [:]
+        if let weight = weights["\(prefix).weight"] {
+            params["weight"] = .value(weight)
+        }
+        if let bias = weights["\(prefix).bias"] {
+            params["bias"] = .value(bias)
+        }
+        // QuantizedLinear also has `scales` and `biases` parameters. Without
+        // loading these the dequantised matmul gets random values from
+        // `quantize()`'s placeholder init and the layer becomes a near-no-op.
+        if let scales = weights["\(prefix).scales"] {
+            params["scales"] = .value(scales)
+        }
+        if let qBiases = weights["\(prefix).biases"] {
+            params["biases"] = .value(qBiases)
+        }
+        guard !params.isEmpty else { return }
+        try linear.update(parameters: ModuleParameters(values: params), verify: .shapeMismatch)
+    }
+
+    private func loadWeights<T: Module>(
+        into module: T,
+        prefix: String,
+        from weights: [String: MLXArray],
+        stripPrefix: String? = nil
+    ) throws {
+        let prefixWithDot = prefix + "."
+        let stripPrefix = stripPrefix ?? prefixWithDot
+        let filtered = weights.reduce(into: [String: MLXArray]()) { result, entry in
+            if entry.key == prefix {
+                result[""] = entry.value
+            } else if entry.key.hasPrefix(prefixWithDot) {
+                result[String(entry.key.dropFirst(stripPrefix.count))] = entry.value
+            }
+        }
+
+        guard !filtered.isEmpty else {
+            return
+        }
+
+        if let snake = module as? Snake1d {
+            if let alpha = filtered["alpha"] ?? filtered[""] {
+                try loadWithDiagnostics(prefix) {
+                    if Self.debugVerboseEnabled {
+                        if let data = "  snake current alpha shape: \(snake.alpha.shape)\n".data(using: .utf8) {
+                            FileHandle.standardOutput.write(data)
+                        }
+                        if let data = "  snake loaded alpha shape: \(alpha.shape)\n".data(using: .utf8) {
+                            FileHandle.standardOutput.write(data)
+                        }
+                    }
+                    snake.loadAlpha(alpha)
+                }
+                return
+            }
+        }
+
+        if Self.debugVerboseEnabled, let data = "Loading \(prefix)...\n".data(using: .utf8) {
+            FileHandle.standardOutput.write(data)
+        }
+        let params = ModuleParameters.unflattened(filtered)
+        _ = try loadWithDiagnostics(prefix) {
+            try module.update(parameters: params, verify: .shapeMismatch)
+        }
+    }
+
+    private func loadDecoderConvStack(
+        _ stack: ConvStack1d,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        for (index, layer) in stack.layers.enumerated() {
+            let layerPrefix = "\(prefix).layers.\(index)"
+            if let weight = weights["\(layerPrefix).weight"] {
+                try ensureShape(weight, matches: layer.weight.shape, label: "\(layerPrefix).weight")
+                layer.weight = weight
+            }
+            if let bias = weights["\(layerPrefix).bias"] {
+                if let currentBias = layer.bias {
+                    try ensureShape(bias, matches: currentBias.shape, label: "\(layerPrefix).bias")
+                }
+                layer.bias = bias
+            }
+        }
+    }
+
+    private func loadResidualUnit(
+        _ unit: CausalResidualUnit,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        if let alpha = weights["\(prefix).snake1.alpha"] {
+            try ensureShape(alpha, matches: unit.snake1.alpha.shape, label: "\(prefix).snake1.alpha")
+            unit.snake1.loadAlpha(alpha)
+        }
+        if let weight = weights["\(prefix).conv1.weight"] {
+            try ensureShape(weight, matches: unit.conv1.weight.shape, label: "\(prefix).conv1.weight")
+            unit.conv1.weight = weight
+        }
+        if let bias = weights["\(prefix).conv1.bias"] {
+            if let currentBias = unit.conv1.bias {
+                try ensureShape(bias, matches: currentBias.shape, label: "\(prefix).conv1.bias")
+            }
+            unit.conv1.bias = bias
+        }
+        if let alpha = weights["\(prefix).snake2.alpha"] {
+            try ensureShape(alpha, matches: unit.snake2.alpha.shape, label: "\(prefix).snake2.alpha")
+            unit.snake2.loadAlpha(alpha)
+        }
+        if let weight = weights["\(prefix).conv2.weight"] {
+            try ensureShape(weight, matches: unit.conv2.weight.shape, label: "\(prefix).conv2.weight")
+            unit.conv2.weight = weight
+        }
+        if let bias = weights["\(prefix).conv2.bias"] {
+            if let currentBias = unit.conv2.bias {
+                try ensureShape(bias, matches: currentBias.shape, label: "\(prefix).conv2.bias")
+            }
+            unit.conv2.bias = bias
+        }
+    }
+
+    private func loadDecoderBlock(
+        _ block: CausalDecoderBlock,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        if let alpha = weights["\(prefix).snake.alpha"] {
+            try ensureShape(alpha, matches: block.snake.alpha.shape, label: "\(prefix).snake.alpha")
+            block.snake.loadAlpha(alpha)
+        }
+        if let weight = weights["\(prefix).conv_t.weight"] {
+            try ensureShape(weight, matches: block.conv_t.weight.shape, label: "\(prefix).conv_t.weight")
+            block.conv_t.weight = weight
+        }
+        if let bias = weights["\(prefix).conv_t.bias"] {
+            if let currentBias = block.conv_t.bias {
+                try ensureShape(bias, matches: currentBias.shape, label: "\(prefix).conv_t.bias")
+            }
+            block.conv_t.bias = bias
+        }
+        try loadResidualUnit(block.res1, prefix: "\(prefix).res1", from: weights)
+        try loadResidualUnit(block.res2, prefix: "\(prefix).res2", from: weights)
+        try loadResidualUnit(block.res3, prefix: "\(prefix).res3", from: weights)
+    }
+
+    private func loadSampleRateConditionLayerStack(
+        _ stack: SampleRateConditionLayerStack,
+        prefix: String,
+        from weights: [String: MLXArray]
+    ) throws {
+        for (index, layer) in stack.layers.enumerated() {
+            let layerPrefix = "\(prefix).\(index)"
+            if let scaleWeight = weights["\(layerPrefix).scale_embed.weight"] {
+                try loadWithDiagnostics("\(layerPrefix).scale_embed") {
+                    try ensureTableEmbeddingShape(
+                        scaleWeight,
+                        matches: layer.scale_embed.weight.shape,
+                        label: "\(layerPrefix).scale_embed.weight"
+                    )
+                    layer.loadScaleWeight(scaleWeight)
+                }
+            }
+            if let biasWeight = weights["\(layerPrefix).bias_embed.weight"] {
+                try loadWithDiagnostics("\(layerPrefix).bias_embed") {
+                    try ensureTableEmbeddingShape(
+                        biasWeight,
+                        matches: layer.bias_embed.weight.shape,
+                        label: "\(layerPrefix).bias_embed.weight"
+                    )
+                    layer.loadBiasWeight(biasWeight)
+                }
+            }
+        }
+    }
+
+    private func ensureTableEmbeddingShape(
+        _ array: MLXArray,
+        matches expectedShape: [Int],
+        label: String
+    ) throws {
+        if array.shape == expectedShape {
+            return
+        }
+        guard expectedShape.count == 3, array.shape.count == 2 else {
+            throw NSError(
+                domain: "VoxCPM2Model",
+                code: 6,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "\(label) shape mismatch: expected \(expectedShape), got \(array.shape)"
+                ]
+            )
+        }
+        guard array.shape[0] == expectedShape[0],
+              array.shape[1] == expectedShape[1] * expectedShape[2]
+        else {
+            throw NSError(
+                domain: "VoxCPM2Model",
+                code: 6,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "\(label) shape mismatch: expected \(expectedShape), got \(array.shape)"
+                ]
+            )
+        }
+    }
+
+    private func ensureShape(
+        _ array: MLXArray,
+        matches expectedShape: [Int],
+        label: String
+    ) throws {
+        guard array.shape == expectedShape else {
+            throw NSError(
+                domain: "VoxCPM2Model",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "\(label) shape mismatch: expected \(expectedShape), got \(array.shape)"
+                ]
+            )
+        }
+    }
+
+    public func setTokenizer(_ tokenizer: Tokenizers.Tokenizer) {
+        self.tokenizer = tokenizer
+        self.voxCPM2TokenizerSplitMap = Self.buildVoxCPM2TokenizerSplitMap(
+            tokenizer: tokenizer,
+            vocabSize: args.lmConfig.vocabSize
+        )
+    }
+
+    // MARK: - Shape Helpers
+
+    func tokenize(_ text: String) throws -> [Int32] {
+        guard let tokenizer else {
+            throw NSError(domain: "VoxCPM2Model", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Tokenizer not loaded"
+            ])
+        }
+        let tokens = tokenizer.tokenize(text: text)
+        var ids: [Int] = []
+        ids.reserveCapacity(tokens.count)
+        for token in tokens {
+            if let expansion = Self.expandVoxCPM2TokenizerToken(token, tokenizer: tokenizer) {
+                ids.append(contentsOf: expansion)
+            } else if let id = tokenizer.convertTokenToId(token) {
+                ids.append(id)
+            }
+        }
+        return ids.map(Int32.init)
+    }
+
+    static func buildVoxCPM2TokenizerSplitMap(
+        tokenizer: Tokenizers.Tokenizer,
+        vocabSize: Int
+    ) -> [Int: [Int]] {
+        guard vocabSize > 0 else { return [:] }
+
+        var splitMap: [Int: [Int]] = [:]
+        splitMap.reserveCapacity(max(vocabSize / 256, 1))
+
+        for id in 0..<vocabSize {
+            guard let token = tokenizer.convertIdToToken(id) else { continue }
+            guard let expansion = expandVoxCPM2TokenizerToken(token, tokenizer: tokenizer) else { continue }
+            splitMap[id] = expansion
+        }
+
+        return splitMap
+    }
+
+    static func expandVoxCPM2TokenizerIds(
+        _ ids: [Int],
+        using splitMap: [Int: [Int]]
+    ) -> [Int] {
+        guard !splitMap.isEmpty else { return ids }
+
+        var expanded: [Int] = []
+        expanded.reserveCapacity(ids.count)
+        for id in ids {
+            if let expansion = splitMap[id] {
+                expanded.append(contentsOf: expansion)
+            } else {
+                expanded.append(id)
+            }
+        }
+        return expanded
+    }
+
+    static func expandVoxCPM2TokenizerToken(
+        _ token: String,
+        tokenizer: Tokenizers.Tokenizer
+    ) -> [Int]? {
+        let clean = token.replacingOccurrences(of: "▁", with: "")
+        guard clean.count >= 2 else { return nil }
+        guard clean.unicodeScalars.allSatisfy({ Self.isVoxCPM2CJKScalar($0) }) else { return nil }
+
+        let charIds = clean.compactMap { tokenizer.convertTokenToId(String($0)) }
+        guard charIds.count == clean.count else { return nil }
+        return charIds
+    }
+
+    static func isVoxCPM2CJKScalar(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x4E00...0x9FFF,
+             0x3400...0x4DBF,
+             0xF900...0xFAFF,
+             0x20000...0x2A6DF:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func encodeAudio(
+        _ audio: [Float],
+        sampleRate: Int,
+        paddingMode: String = "right"
+    ) throws -> MLXArray {
+        var mono = audio
+        if sampleRate != audio_vae.sampleRate {
+            mono = VoxCPM2AudioResampler.resample(audio, from: sampleRate, to: audio_vae.sampleRate)
+        }
+        guard !mono.isEmpty else {
+            throw NSError(domain: "VoxCPM2Model", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Reference/prompt audio is empty"
+            ])
+        }
+
+        let patchLen = args.patchSize * audio_vae.chunkSize
+        let remainder = mono.count % patchLen
+        if remainder != 0 {
+            let pad = patchLen - remainder
+            if paddingMode == "left" {
+                mono = [Float](repeating: 0, count: pad) + mono
+            } else {
+                mono += [Float](repeating: 0, count: pad)
+            }
+        }
+
+        let input = MLXArray(mono).reshaped([1, mono.count, 1])
+        let feat = audio_vae.encode(input, sampleRate: audio_vae.sampleRate).squeezed(axis: 0)
+        let audioLength = feat.dim(0) / args.patchSize
+        let trimmed = feat[
+            0..<(audioLength * args.patchSize),
+            0...
+        ]
+        return trimmed.reshaped([audioLength, args.patchSize, audio_vae.latentDim])
+    }
+
+    private func makeTimeSpan(_ timesteps: Int) -> [Float] {
+        return makeUnifiedCFMTimeSpan(
+            timesteps: timesteps,
+            scheduler: args.ditConfig.cfmConfig.tScheduler,
+            sigmaMin: args.ditConfig.cfmConfig.sigmaMin
+        )
+    }
+
+    // MARK: - Generation
+
+    public func generate(text: String, language: String? = nil) async throws -> [Float] {
+        try await generateVoxCPM2(
+            text: text,
+            language: language,
+            maxTokens: 2000,
+            minTokens: 2,
+            refText: nil,
+            refAudio: nil,
+            promptText: nil,
+            promptAudio: nil,
+            inferenceTimesteps: 10,
+            cfgValue: 2.0,
+            streamingPrefixLen: 4,
+            warmupPatches: 0,
+            instruct: nil
+        )
+    }
+
+    public func generateVoxCPM2(
+        text: String,
+        language: String? = nil,
+        maxTokens: Int = 2000,
+        minTokens: Int = 2,
+        refText: String? = nil,
+        refAudio: [Float]? = nil,
+        promptText: String? = nil,
+        promptAudio: [Float]? = nil,
+        inferenceTimesteps: Int = 10,
+        cfgValue: Float = 2.0,
+        streamingPrefixLen: Int = 4,
+        warmupPatches: Int = 0,
+        instruct: String? = nil
+    ) async throws -> [Float] {
+        guard tokenizer != nil else {
+            throw NSError(domain: "VoxCPM2Model", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Tokenizer not loaded"
+            ])
+        }
+        _ = language
+        let debugVerboseEnabled = ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
+        @inline(__always)
+        func logGen(_ message: String) {
+            guard debugVerboseEnabled else { return }
+            if let data = "[VoxCPM2] \(message)\n".data(using: .utf8) {
+                FileHandle.standardOutput.write(data)
+            }
+        }
+
+        var workingText = text
+        var effectiveWarmup = warmupPatches
+        if let instruct, !instruct.isEmpty {
+            workingText = "(\(instruct))\(workingText)"
+            effectiveWarmup = min(effectiveWarmup, 1)
+        }
+
+        let scaleEmb = args.lmConfig.useMup ? Float(args.lmConfig.scaleEmb) : 1.0
+        let latentDim = audio_vae.latentDim
+        let hasRef = refAudio != nil
+        let hasPrompt = promptAudio != nil && promptText != nil
+
+        let textIds: [Int32]
+        var textToken: MLXArray
+        var audioFeat: MLXArray
+        var textMask: MLXArray
+        var audioMask: MLXArray
+
+        if hasRef && hasPrompt {
+            let combinedText = (promptText ?? "") + workingText
+            textIds = try tokenize(combinedText)
+            let textLength = textIds.count + 1
+            textToken = MLXArray(textIds + [Int32(101)]).reshaped([1, textLength])
+
+            let refFeat = try encodeAudio(
+                refAudio ?? [],
+                sampleRate: audio_vae.sampleRate,
+                paddingMode: "right"
+            )
+            let promptFeat = try encodeAudio(
+                promptAudio ?? [],
+                sampleRate: audio_vae.sampleRate,
+                paddingMode: "left"
+            )
+            let promptLen = promptFeat.dim(0)
+
+            let refTokens = MLXArray(
+                [Int32(103)]
+                + Array(repeating: Int32(0), count: refFeat.dim(0))
+                + [Int32(104)]
+            )
+            let refFeats = concatenated(
+                [
+                    MLXArray.zeros([1, args.patchSize, latentDim]),
+                    refFeat,
+                    MLXArray.zeros([1, args.patchSize, latentDim])
+                ],
+                axis: 0
+            )
+            let refTMask = MLXArray(
+                [Float(1.0)]
+                + Array(repeating: Float(0.0), count: refFeat.dim(0))
+                + [Float(1.0)]
+            )
+            let refAMask = MLXArray(
+                [Float(0.0)]
+                + Array(repeating: Float(1.0), count: refFeat.dim(0))
+                + [Float(0.0)]
+            )
+
+            let textPadFeat = MLXArray.zeros([textLength, args.patchSize, latentDim])
+            let promptPadToken = MLXArray.zeros([promptLen], dtype: .int32)
+
+            let fullText = concatenated([refTokens, textToken.squeezed(axis: 0), promptPadToken], axis: 0)
+            let fullAudio = concatenated([refFeats, textPadFeat, promptFeat], axis: 0)
+            textMask = concatenated(
+                [
+                    refTMask,
+                    MLXArray.ones([textLength], dtype: .float32),
+                    MLXArray.zeros([promptLen], dtype: .float32)
+                ],
+                axis: 0
+            )
+            audioMask = concatenated(
+                [
+                    refAMask,
+                    MLXArray.zeros([textLength], dtype: .float32),
+                    MLXArray.ones([promptLen], dtype: .float32)
+                ],
+                axis: 0
+            )
+
+            textToken = fullText.reshaped([1, fullText.dim(0)])
+            audioFeat = fullAudio.reshaped([1, fullAudio.dim(0), args.patchSize, latentDim])
+        } else if hasRef {
+            textIds = try tokenize(workingText)
+            let textLength = textIds.count + 1
+            textToken = MLXArray(textIds + [Int32(101)]).reshaped([1, textLength])
+
+            let refFeat = try encodeAudio(
+                refAudio ?? [],
+                sampleRate: audio_vae.sampleRate,
+                paddingMode: "right"
+            )
+            let refTokens = MLXArray(
+                [Int32(103)]
+                + Array(repeating: Int32(0), count: refFeat.dim(0))
+                + [Int32(104)]
+            )
+            let refFeats = concatenated(
+                [
+                    MLXArray.zeros([1, args.patchSize, latentDim]),
+                    refFeat,
+                    MLXArray.zeros([1, args.patchSize, latentDim])
+                ],
+                axis: 0
+            )
+            let refTMask = MLXArray(
+                [Float(1.0)]
+                + Array(repeating: Float(0.0), count: refFeat.dim(0))
+                + [Float(1.0)]
+            )
+            let refAMask = MLXArray(
+                [Float(0.0)]
+                + Array(repeating: Float(1.0), count: refFeat.dim(0))
+                + [Float(0.0)]
+            )
+
+            let textPadFeat = MLXArray.zeros([textLength, args.patchSize, latentDim])
+            let fullText = concatenated([refTokens, textToken.squeezed(axis: 0)], axis: 0)
+            let fullAudio = concatenated([refFeats, textPadFeat], axis: 0)
+            textMask = concatenated([refTMask, MLXArray.ones([textLength], dtype: .float32)], axis: 0)
+            audioMask = concatenated([refAMask, MLXArray.zeros([textLength], dtype: .float32)], axis: 0)
+
+            textToken = fullText.reshaped([1, fullText.dim(0)])
+            audioFeat = fullAudio.reshaped([1, fullAudio.dim(0), args.patchSize, latentDim])
+        } else if hasPrompt {
+            let combinedText = (promptText ?? "") + workingText
+            textIds = try tokenize(combinedText)
+            let textLength = textIds.count + 1
+            textToken = MLXArray(textIds + [Int32(101)]).reshaped([1, textLength])
+
+            let promptFeat = try encodeAudio(
+                promptAudio ?? [],
+                sampleRate: audio_vae.sampleRate,
+                paddingMode: "left"
+            )
+            let promptLen = promptFeat.dim(0)
+
+            let textPadFeat = MLXArray.zeros([textLength, args.patchSize, latentDim])
+            let promptPadToken = MLXArray.zeros([promptLen], dtype: .int32)
+
+            let fullText = concatenated([textToken.squeezed(axis: 0), promptPadToken], axis: 0)
+            let fullAudio = concatenated([textPadFeat, promptFeat], axis: 0)
+            textMask = concatenated(
+                [
+                    MLXArray.ones([textLength], dtype: .float32),
+                    MLXArray.zeros([promptLen], dtype: .float32)
+                ],
+                axis: 0
+            )
+            audioMask = concatenated(
+                [
+                    MLXArray.zeros([textLength], dtype: .float32),
+                    MLXArray.ones([promptLen], dtype: .float32)
+                ],
+                axis: 0
+            )
+
+            textToken = fullText.reshaped([1, fullText.dim(0)])
+            audioFeat = fullAudio.reshaped([1, fullAudio.dim(0), args.patchSize, latentDim])
+        } else {
+            textIds = try tokenize(workingText)
+            let textLength = textIds.count + 1
+            textToken = MLXArray(textIds + [Int32(101)]).reshaped([1, textLength])
+            audioFeat = MLXArray.zeros([1, textLength, args.patchSize, latentDim])
+            textMask = MLXArray.ones([1, textLength], dtype: .float32)
+            audioMask = MLXArray.zeros([1, textLength], dtype: .float32)
+        }
+
+        let textTokenB = textToken
+        let audioFeatB = audioFeat
+        let textMaskB = textMask.shape.count == 1 ? textMask.reshaped([1, textMask.dim(0)]) : textMask
+        let audioMaskB = audioMask.shape.count == 1 ? audioMask.reshaped([1, audioMask.dim(0)]) : audioMask
+        let textMask3 = textMaskB.expandedDimensions(axis: 2)
+        let audioMask3 = audioMaskB.expandedDimensions(axis: 2)
+
+        logGen("building embeddings")
+        let featEmbed = enc_to_lm_proj(feat_encoder(audioFeatB))
+        let textEmbed = base_lm.embedTokens!(textTokenB) * MLXArray(scaleEmb)
+        let combinedEmbed = textMask3 * textEmbed + audioMask3 * featEmbed
+
+        let lastFeatIndex = audioFeatB.dim(1) - 1
+        var prefixFeatCond = audioFeatB[
+            0...,
+            lastFeatIndex...(lastFeatIndex),
+            0...,
+            0...
+        ].squeezed(axis: 1)
+
+        let (encOutputs, initialLmCache) = base_lm(inputsEmbeds: combinedEmbed)
+        var lmCache = initialLmCache
+        let encOutputsFSQ = fsq_layer(encOutputs)
+        let maskedEnc = encOutputsFSQ * audioMask3 + encOutputs * textMask3
+        var lmHidden = maskedEnc[
+            0...,
+            (maskedEnc.dim(1) - 1)...(maskedEnc.dim(1) - 1),
+            0...
+        ].squeezed(axis: 1)
+
+        let residualInput = fusion_concat_proj(
+            concatenated([maskedEnc, audioMask3 * featEmbed], axis: -1)
+        )
+        let (resOutputs, initialResCache) = residual_lm(inputsEmbeds: residualInput)
+        var resCache = initialResCache
+        var residualHidden = resOutputs[
+            0...,
+            (resOutputs.dim(1) - 1)...(resOutputs.dim(1) - 1),
+            0...
+        ].squeezed(axis: 1)
+
+        let hasContinuation = hasPrompt
+        var predFeatSeq: [MLXArray] = []
+        if hasContinuation {
+            let audioIndices = (0..<audioMaskB.dim(1)).filter { idx in
+                audioMaskB[0, idx].item(Float.self) > 0.5
+            }
+            let contextLen = min(streamingPrefixLen - 1, audioIndices.count)
+            for idx in audioIndices.suffix(contextLen) {
+                let slice = audioFeatB[
+                    0...,
+                    idx..<(idx + 1),
+                    0...,
+                    0...
+                ]
+                predFeatSeq.append(slice)
+            }
+        }
+
+        let warmupCount = hasContinuation ? 0 : effectiveWarmup
+        for step in 0..<(maxTokens + warmupCount) {
+            if step == 0 {
+                logGen("sampling first audio patch")
+            }
+            let ditMu = concatenated([
+                lm_to_dit_proj(lmHidden),
+                res_to_dit_proj(residualHidden)
+            ], axis: -1)
+            let condIn = prefixFeatCond.transposed(0, 2, 1)
+
+            var predFeat = feat_decoder.sample(
+                mu: ditMu,
+                nTimesteps: inferenceTimesteps,
+                patchSize: args.patchSize,
+                cond: condIn,
+                cfgValue: cfgValue
+            )
+
+            predFeat = predFeat.transposed(0, 2, 1)
+
+            if step >= warmupCount {
+                predFeatSeq.append(predFeat.expandedDimensions(axis: 1))
+            }
+
+            let currEmbed = enc_to_lm_proj(
+                feat_encoder(predFeat.expandedDimensions(axis: 1))
+            )
+
+            let stopLogits = stop_head(silu(stop_proj(lmHidden)))
+            let stopFlag = argMax(stopLogits, axis: -1).squeezed().item(Int32.self)
+            let realSteps = step - warmupCount
+            if realSteps > minTokens && stopFlag == 1 {
+                break
+            }
+
+            let (newLmOut, nextLmCache) = base_lm(
+                inputsEmbeds: currEmbed,
+                cache: lmCache
+            )
+            lmCache = nextLmCache
+            lmHidden = fsq_layer(newLmOut[
+                0...,
+                (newLmOut.dim(1) - 1)...(newLmOut.dim(1) - 1),
+                0...
+            ].squeezed(axis: 1))
+
+            let currResidualInput = fusion_concat_proj(
+                concatenated([lmHidden.expandedDimensions(axis: 1), currEmbed], axis: -1)
+            )
+            let (newResOut, nextResCache) = residual_lm(
+                inputsEmbeds: currResidualInput,
+                cache: resCache
+            )
+            resCache = nextResCache
+            residualHidden = newResOut[
+                0...,
+                (newResOut.dim(1) - 1)...(newResOut.dim(1) - 1),
+                0...
+            ].squeezed(axis: 1)
+
+            prefixFeatCond = predFeat
+        }
+
+        guard !predFeatSeq.isEmpty else {
+            throw NSError(domain: "VoxCPM2Model", code: 4, userInfo: [
+                NSLocalizedDescriptionKey: "No audio patches were generated"
+            ])
+        }
+
+        logGen("decoding audio")
+        var allFeat = concatenated(predFeatSeq, axis: 1)
+        allFeat = allFeat.reshaped([allFeat.dim(0), -1, args.featDim])
+
+        var audio = audio_vae.decode(allFeat.asType(.float32))
+        audio = audio.flattened()
+
+        if hasContinuation {
+            let decodePatchLen = args.patchSize * audio_vae.decodeChunkSize
+            let trimAudioSamples = decodePatchLen * (streamingPrefixLen - 1)
+            if trimAudioSamples < audio.count {
+                audio = audio[trimAudioSamples...]
+            }
+        }
+
+        eval(audio)
+        return audio.asArray(Float.self)
+    }
+}
+
+extension VoxCPM2Model: SpeechGenerationModel, @unchecked Sendable {
+    public var sampleRate: Int { outputSampleRate }
+
+    public var defaultGenerationParameters: GenerateParameters {
+        GenerateParameters(
+            maxTokens: 2000,
+            temperature: 1.0,
+            topP: 1.0,
+            repetitionPenalty: 1.0
+        )
+    }
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        let samples = try await generateVoxCPM2(
+            text: text,
+            language: language,
+            maxTokens: generationParameters.maxTokens ?? 2000,
+            refText: refText,
+            refAudio: refAudio?.asArray(Float.self),
+            inferenceTimesteps: 10,
+            cfgValue: 2.0,
+            instruct: voice
+        )
+        return MLXArray(samples)
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+        let refAudioSamples = refAudio?.asArray(Float.self)
+        let task = Task { @Sendable [weak self, refAudioSamples] in
+            guard let self else {
+                continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
+                return
+            }
+
+            do {
+                let samples = try await self.generateVoxCPM2(
+                    text: text,
+                    language: language,
+                    maxTokens: generationParameters.maxTokens ?? 2000,
+                    refText: refText,
+                    refAudio: refAudioSamples,
+                    inferenceTimesteps: 10,
+                    cfgValue: 2.0,
+                    instruct: voice
+                )
+                continuation.yield(.audio(MLXArray(samples)))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
+        return stream
+    }
+}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift
@@ -48,6 +48,10 @@ public final class VoxCPM2Model: Module {
     private var tokenizer: Tokenizers.Tokenizer?
     private var voxCPM2TokenizerSplitMap: [Int: [Int]] = [:]
     private var _isLoaded: Bool = true
+
+    // MARK: - LoRA state
+    private var loraConfig: LoRAConfig?
+    private var loraModules: [String: LoRALinear] = [:]
     private static var debugVerboseEnabled: Bool {
         ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
     }
@@ -139,6 +143,7 @@ public final class VoxCPM2Model: Module {
 
     public static func fromPretrained(
         _ modelRepo: String = "aufklarer/VoxCPM2-MLX-bf16",
+        loraConfig: LoRAConfig? = nil,
         cache: HubCache = .default
     ) async throws -> VoxCPM2Model {
         guard let repoID = Repo.ID(rawValue: modelRepo) else {
@@ -151,10 +156,13 @@ public final class VoxCPM2Model: Module {
             additionalMatchingPatterns: ["*.py"],
             cache: cache
         )
-        return try await fromModelDirectory(modelDir)
+        return try await fromModelDirectory(modelDir, loraConfig: loraConfig)
     }
 
-    public static func fromModelDirectory(_ modelDir: URL) async throws -> VoxCPM2Model {
+    public static func fromModelDirectory(
+        _ modelDir: URL,
+        loraConfig: LoRAConfig? = nil
+    ) async throws -> VoxCPM2Model {
         let args = try ModelArgs.load(from: modelDir)
         let model = VoxCPM2Model(args: args)
 
@@ -184,6 +192,12 @@ public final class VoxCPM2Model: Module {
 
         // NOTE: MLX can trip over some parameter views during eager evaluation
         // even when the model loads cleanly. We defer evaluation until first use.
+
+        // If a LoRA configuration was provided, inject LoRA wrappers
+        // around the target linear layers.
+        if let loraConfig {
+            try model.injectLoRA(config: loraConfig)
+        }
 
         return model
     }
@@ -960,7 +974,15 @@ public final class VoxCPM2Model: Module {
         instruct: String? = nil,
         streamingDecodeInterval: Int? = nil,
         audioChunkHandler: (@Sendable ([Float]) -> Void)? = nil,
-        returnFullAudio: Bool = true
+        returnFullAudio: Bool = true,
+        // Normalization and retry (matching the official Python API)
+        normalize: Bool = false,
+        /// Denoise prompt/reference audio before generation.
+        /// Requires a loaded ZipEnhancer denoiser (not yet implemented in MLX).
+        denoise: Bool = false,
+        retryBadcase: Bool = false,
+        retryBadcaseMaxTimes: Int = 3,
+        retryBadcaseRatioThreshold: Float = 6.0
     ) async throws -> [Float] {
         guard tokenizer != nil else {
             throw NSError(domain: "VoxCPM2Model", code: 3, userInfo: [
@@ -969,6 +991,117 @@ public final class VoxCPM2Model: Module {
         }
         _ = language
         let debugVerboseEnabled = ProcessInfo.processInfo.environment["VOXCPM2_DEBUG_VERBOSE"] == "1"
+
+        // Apply text normalization before tokenization
+        let normalizedText = normalize ? TextNormalizer.normalize(text) : text
+
+        // Denoiser (ZipEnhancer) is not yet implemented in MLX.
+        // Reference: https://github.com/OpenBMB/VoxCPM
+        if denoise {
+            if debugVerboseEnabled, let data = "[VoxCPM2] denoise=true is not yet implemented in MLX — skipping denoising\n".data(using: .utf8) {
+                FileHandle.standardOutput.write(data)
+            }
+        }
+
+        // Define the actual generation step as a local function so we can
+        // retry it with different text (normalized vs original).
+        func runGeneration(text: String) async throws -> [Float] {
+            try await _runGenerationImpl(
+                text: text,
+                language: language,
+                maxTokens: maxTokens,
+                minTokens: minTokens,
+                refText: refText,
+                refAudio: refAudio,
+                refAudioSampleRate: refAudioSampleRate,
+                promptText: promptText,
+                promptAudio: promptAudio,
+                promptAudioSampleRate: promptAudioSampleRate,
+                inferenceTimesteps: inferenceTimesteps,
+                cfgValue: cfgValue,
+                streamingPrefixLen: streamingPrefixLen,
+                warmupPatches: warmupPatches,
+                instruct: instruct,
+                streamingDecodeInterval: streamingDecodeInterval,
+                audioChunkHandler: audioChunkHandler,
+                returnFullAudio: returnFullAudio,
+                debugVerboseEnabled: debugVerboseEnabled
+            )
+        }
+
+        // Retry wrapper for bad-case detection
+        let maxAttempts = retryBadcase ? max(1, retryBadcaseMaxTimes) : 1
+
+        var lastError: Error?
+        for attempt in 1...maxAttempts {
+            do {
+                let inputText = attempt == 1 ? normalizedText : text
+                let audio = try await runGeneration(text: inputText)
+
+                // Check for bad case (too short or too long relative to text)
+                if retryBadcase && isBadCase(
+                    audio: audio, text: normalizedText,
+                    ratioThreshold: retryBadcaseRatioThreshold
+                ) {
+                    lastError = nil
+                    if attempt < maxAttempts {
+                        if debugVerboseEnabled, let data = "[VoxCPM2] bad case detected (attempt \(attempt)/\(maxAttempts)), retrying...\n".data(using: .utf8) {
+                            FileHandle.standardOutput.write(data)
+                        }
+                    }
+                    continue
+                }
+                return audio
+            } catch {
+                lastError = error
+                if attempt < maxAttempts {
+                    if debugVerboseEnabled, let data = "[VoxCPM2] generation failed (attempt \(attempt)/\(maxAttempts)): \(error), retrying...\n".data(using: .utf8) {
+                        FileHandle.standardOutput.write(data)
+                    }
+                }
+            }
+        }
+
+        if let lastError { throw lastError }
+        // Fallback: should not reach here
+        throw NSError(domain: "VoxCPM2Model", code: 5, userInfo: [
+            NSLocalizedDescriptionKey: "Generation failed after \(maxAttempts) attempts"
+        ])
+    }
+
+    /// Determine whether generated audio is abnormally short or long.
+    private func isBadCase(audio: [Float], text: String, ratioThreshold: Float) -> Bool {
+        guard !audio.isEmpty else { return true }
+        let audioDuration = Float(audio.count) / Float(outputSampleRate)
+        let estimatedTextDuration = Float(text.count) / 5.0  // ~5 chars/sec average
+        guard estimatedTextDuration > 0 else { return false }
+        let ratio = audioDuration / estimatedTextDuration
+        return ratio > ratioThreshold || ratio < 1.0 / ratioThreshold
+    }
+
+    /// Core generation implementation extracted so that `generateVoxCPM2`
+    /// can wrap it with normalisation and retry logic.
+    private func _runGenerationImpl(
+        text: String,
+        language: String?,
+        maxTokens: Int,
+        minTokens: Int,
+        refText: String?,
+        refAudio: [Float]?,
+        refAudioSampleRate: Int?,
+        promptText: String?,
+        promptAudio: [Float]?,
+        promptAudioSampleRate: Int?,
+        inferenceTimesteps: Int,
+        cfgValue: Float,
+        streamingPrefixLen: Int,
+        warmupPatches: Int,
+        instruct: String?,
+        streamingDecodeInterval: Int?,
+        audioChunkHandler: (@Sendable ([Float]) -> Void)?,
+        returnFullAudio: Bool,
+        debugVerboseEnabled: Bool
+    ) async throws -> [Float] {
         @inline(__always)
         func logGen(_ message: String) {
             guard debugVerboseEnabled else { return }
@@ -1318,6 +1451,176 @@ public final class VoxCPM2Model: Module {
 
         eval(audio)
         return audio.asArray(Float.self)
+    }
+}
+
+// MARK: - LoRA injection and management
+
+extension VoxCPM2Model {
+    /// Collect the set of flattened path strings that should receive a LoRA
+    /// wrapper based on `config`.
+    private func collectLoRATargetPaths(config: LoRAConfig) -> Set<String> {
+        var targets = Set<String>()
+        let projNames = ["qProj", "kProj", "vProj", "oProj"]
+
+        if config.enableLM {
+            for i in base_lm.layers.indices {
+                for name in projNames {
+                    targets.insert("base_lm.layers.\(i).selfAttn.\(name)")
+                }
+            }
+            for i in residual_lm.layers.indices {
+                for name in projNames {
+                    targets.insert("residual_lm.layers.\(i).selfAttn.\(name)")
+                }
+            }
+        }
+
+        if config.enableDiT {
+            for i in feat_decoder.estimator.decoder.layers.indices {
+                for name in projNames {
+                    targets.insert("feat_decoder.estimator.decoder.layers.\(i).selfAttn.\(name)")
+                }
+            }
+        }
+
+        if config.enableProj {
+            targets.insert("enc_to_lm_proj")
+            targets.insert("lm_to_dit_proj")
+            targets.insert("res_to_dit_proj")
+            targets.insert("fusion_concat_proj")
+            targets.insert("stop_proj")
+            targets.insert("stop_head")
+        }
+
+        return targets
+    }
+
+    /// Wrap the target ``Linear`` layers in ``LoRALinear`` adapters
+    /// according to `config`.  Called during model loading.
+    private func injectLoRA(config: LoRAConfig) throws {
+        let targets = collectLoRATargetPaths(config: config)
+        let updates = leafModules().flattened().compactMap { (path, module) -> (String, Module)? in
+            guard targets.contains(path), let linear = module as? Linear else { return nil }
+            let lora = LoRALinear(base: linear, r: config.r, alpha: config.alpha)
+            loraModules[path] = lora
+            return (path, lora)
+        }
+        guard !updates.isEmpty else {
+            throw AudioGenerationError.modelNotInitialized(
+                "LoRA: no target Linear layers found — model structure may have changed"
+            )
+        }
+        loraConfig = config
+        update(modules: ModuleChildren.unflattened(updates))
+    }
+
+    // MARK: - Public LoRA API
+
+    /// Load LoRA weights from a safetensors file and apply them to the
+    /// injected LoRA adapters.
+    ///
+    /// The expected key format is:
+    /// ```
+    /// base_lm.layers.0.selfAttn.qProj.loraA
+    /// base_lm.layers.0.selfAttn.qProj.loraB
+    /// ```
+    ///
+    /// A `base_model.model.` prefix (common in PEFT exports) is stripped
+    /// automatically.
+    ///
+    /// - Parameters:
+    ///   - weightsPath: Path to a `.safetensors` file.
+    /// - Returns: `(loaded, skipped)` — keys that were loaded and keys that
+    ///   were skipped because no matching adapter was found.
+    @discardableResult
+    public func loadLoRA(weightsPath: String) throws -> (loaded: [String], skipped: [String]) {
+        guard !loraModules.isEmpty else {
+            throw AudioGenerationError.modelNotInitialized(
+                "No LoRA adapters injected — call fromModelDirectory(with: loraConfig:) first"
+            )
+        }
+
+        let url = URL(fileURLWithPath: weightsPath)
+        let allWeights = try MLX.loadArrays(url: url)
+
+        var loaded: [String] = []
+        var skipped: [String] = []
+
+        for (key, array) in allWeights {
+            // Strip common PEFT prefix
+            let cleanKey = key
+                .replacingOccurrences(of: "base_model.model.", with: "")
+                // Convert PEFT underscore convention to camelCase
+                .replacingOccurrences(of: "lora_A.weight", with: "loraA")
+                .replacingOccurrences(of: "lora_B.weight", with: "loraB")
+
+            // Find the parent path (e.g. "base_lm.layers.0.selfAttn.qProj")
+            // and the param name ("loraA" or "loraB")
+            guard let dot = cleanKey.lastIndex(of: ".") else {
+                skipped.append(key)
+                continue
+            }
+            let parentPath = String(cleanKey[..<dot])
+            let paramName = String(cleanKey[cleanKey.index(after: dot)...])
+
+            guard let module = loraModules[parentPath] else {
+                skipped.append(key)
+                continue
+            }
+
+            switch paramName {
+            case "loraA":
+                module.loraA = array.asType(.float32)
+                loaded.append(key)
+            case "loraB":
+                module.loraB = array.asType(.float32)
+                loaded.append(key)
+            default:
+                skipped.append(key)
+            }
+        }
+
+        return (loaded, skipped)
+    }
+
+    /// Unload LoRA weights by zeroing out all A/B matrices.
+    ///
+    /// The adapters remain in the model but have no effect until new weights
+    /// are loaded via ``loadLoRA(weightsPath:)``.
+    public func unloadLoRA() {
+        for (_, module) in loraModules {
+            let inDim = module.loraA.shape[0]
+            let r = module.loraA.shape[1]
+            let outDim = module.loraB.shape[0]
+            module.loraA = MLXArray.zeros([inDim, r])
+            module.loraB = MLXArray.zeros([outDim, r])
+        }
+    }
+
+    /// Enable or disable the LoRA branch on all injected adapters.
+    ///
+    /// When disabled the model behaves as the original base model.
+    public func setLoRAEnabled(_ enabled: Bool) {
+        for (_, module) in loraModules {
+            module.enabled = enabled
+        }
+    }
+
+    /// Export the current LoRA weights as a dictionary keyed by
+    /// flattened path (suitable for saving to safetensors).
+    public func getLoRAStateDict() -> [String: MLXArray] {
+        var state: [String: MLXArray] = [:]
+        for (path, module) in loraModules {
+            state["\(path).loraA"] = module.loraA
+            state["\(path).loraB"] = module.loraB
+        }
+        return state
+    }
+
+    /// Whether LoRA adapters are currently loaded and enabled.
+    public var isLoRAEnabled: Bool {
+        loraModules.values.contains { $0.enabled }
     }
 }
 

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Support.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Support.swift
@@ -21,25 +21,3 @@ enum VoxCPM2WeightLoader {
         return weights
     }
 }
-
-enum VoxCPM2AudioResampler {
-    static func resample(_ input: [Float], from sourceRate: Int, to targetRate: Int) -> [Float] {
-        guard !input.isEmpty, sourceRate > 0, targetRate > 0, sourceRate != targetRate else {
-            return input
-        }
-
-        let outputCount = max(1, Int((Double(input.count) * Double(targetRate) / Double(sourceRate)).rounded()))
-        guard outputCount > 1, input.count > 1 else {
-            return Array(repeating: input.first ?? 0, count: outputCount)
-        }
-
-        let ratio = Double(sourceRate) / Double(targetRate)
-        return (0..<outputCount).map { index in
-            let position = Double(index) * ratio
-            let left = min(Int(position), input.count - 1)
-            let right = min(left + 1, input.count - 1)
-            let fraction = Float(position - Double(left))
-            return input[left] * (1 - fraction) + input[right] * fraction
-        }
-    }
-}

--- a/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Support.swift
+++ b/Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2Support.swift
@@ -1,0 +1,45 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+enum VoxCPM2WeightLoader {
+    static func loadAllSafetensors(from directory: URL) throws -> [String: MLXArray] {
+        let files = try FileManager.default
+            .contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        guard !files.isEmpty else {
+            throw AudioGenerationError.modelNotInitialized("No safetensors files found in \(directory.path)")
+        }
+
+        var weights: [String: MLXArray] = [:]
+        for file in files {
+            let arrays = try MLX.loadArrays(url: file)
+            weights.merge(arrays) { _, new in new }
+        }
+        return weights
+    }
+}
+
+enum VoxCPM2AudioResampler {
+    static func resample(_ input: [Float], from sourceRate: Int, to targetRate: Int) -> [Float] {
+        guard !input.isEmpty, sourceRate > 0, targetRate > 0, sourceRate != targetRate else {
+            return input
+        }
+
+        let outputCount = max(1, Int((Double(input.count) * Double(targetRate) / Double(sourceRate)).rounded()))
+        guard outputCount > 1, input.count > 1 else {
+            return Array(repeating: input.first ?? 0, count: outputCount)
+        }
+
+        let ratio = Double(sourceRate) / Double(targetRate)
+        return (0..<outputCount).map { index in
+            let position = Double(index) * ratio
+            let left = min(Int(position), input.count - 1)
+            let right = min(left + 1, input.count - 1)
+            let fraction = Float(position - Double(left))
+            return input[left] * (1 - fraction) + input[right] * fraction
+        }
+    }
+}

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -102,6 +102,13 @@ public enum TTS {
         }
 
         switch resolvedType {
+        case "voxcpm2", "voxcpm":
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await VoxCPM2Model.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await VoxCPM2Model.fromModelDirectory(modelDir) }
+            )
         case "moss_tts_nano":
             return try await load(
                 source,
@@ -252,6 +259,9 @@ public enum TTS {
 
     private static func inferModelType(from modelRepo: String) -> String? {
         let lower = modelRepo.lowercased()
+        if lower.contains("voxcpm2") || lower.contains("voxcpm") {
+            return "voxcpm2"
+        }
         if lower.contains("qwen3_tts") {
             return "qwen3_tts"
         }

--- a/Sources/MLXAudioTTS/TextNormalizer.swift
+++ b/Sources/MLXAudioTTS/TextNormalizer.swift
@@ -1,0 +1,262 @@
+// Text normalization for TTS input.
+//
+// Expands numbers, dates, currency amounts, and common abbreviations
+// into their spoken form so the TTS model produces more natural output.
+//
+// Currently supports English number expansion with basic international
+// coverage for common patterns.
+
+import Foundation
+
+/// Normalise text before TTS generation to improve pronunciation of
+/// numbers, dates, currency, and abbreviations.
+///
+/// Usage:
+/// ```swift
+/// let clean = TextNormalizer.normalize("It costs $50.25")
+/// // "It costs fifty dollars and twenty-five cents"
+/// ```
+public enum TextNormalizer {
+    // MARK: - Public API
+
+    /// Run all normalisation passes on `text`.
+    ///
+    /// - Parameter text: Raw input text.
+    /// - Returns: Text with numbers, dates, etc. expanded in‑place.
+    public static func normalize(_ text: String) -> String {
+        var result = text
+
+        // Order matters — run broad patterns before narrow ones.
+        result = expandCurrency(result)
+        result = expandOrdinalIndicators(result)
+        result = expandCardinalNumbers(result)
+        result = expandCommonAbbreviations(result)
+
+        return result
+    }
+
+    // MARK: - Currency
+
+    /// Replace `$3.50`, `€12`, `£1.99` etc. with spoken forms.
+    private static let currencyPattern =
+        try! NSRegularExpression(pattern: #"([£$€¥])(\d{1,6}(?:\.\d{1,2})?)"#)
+
+    private static let currencyNames: [Character: (unit: String, sub: String)] = [
+        "$": ("dollars", "cents"),
+        "£": ("pounds", "pence"),
+        "€": ("euros", "cents"),
+        "¥": ("yuan", "fen"),
+    ]
+
+    private static func expandCurrency(_ text: String) -> String {
+        let ns = text as NSString
+        var result = text
+
+        for match in currencyPattern.matches(in: text, range: NSRange(location: 0, length: ns.length))
+            .reversed()
+        {
+            let fullRange = NSRange(location: match.range.location, length: match.range.length)
+            let symbol = ns.substring(with: match.range(at: 1))
+            let amount = ns.substring(with: match.range(at: 2))
+
+            guard let sym = symbol.first, let names = currencyNames[sym],
+                  let value = Double(amount)
+            else { continue }
+
+            let spoken: String
+            if amount.contains(".") {
+                let parts = amount.split(separator: ".")
+                let major = Int(parts[0]) ?? 0
+                let minor = Int(parts[1].padding(toLength: 2, withPad: "0", startingAt: 0)) ?? 0
+                if major == 0 {
+                    spoken = "\(minor) \(names.sub)"
+                } else if minor == 0 {
+                    spoken = "\(numberToWords(major)) \(names.unit)"
+                } else {
+                    spoken =
+                        "\(numberToWords(major)) \(names.unit) and \(numberToWords(minor)) \(names.sub)"
+                }
+            } else {
+                let intVal = Int(value)
+                spoken = "\(numberToWords(intVal)) \(names.unit)"
+            }
+
+            result = (result as NSString).replacingCharacters(in: fullRange, with: spoken)
+        }
+        return result
+    }
+
+    // MARK: - Ordinal indicators
+
+    private static let ordinalPattern =
+        try! NSRegularExpression(pattern: #"\b(\d{1,6})(st|nd|rd|th)\b"#)
+
+    private static func expandOrdinalIndicators(_ text: String) -> String {
+        let ns = text as NSString
+        var result = text
+
+        for match in ordinalPattern.matches(in: text, range: NSRange(location: 0, length: ns.length))
+            .reversed()
+        {
+            let fullRange = NSRange(location: match.range.location, length: match.range.length)
+            let numStr = ns.substring(with: match.range(at: 1))
+            guard let num = Int(numStr) else { continue }
+            let spoken = ordinalToWords(num)
+            result = (result as NSString).replacingCharacters(in: fullRange, with: spoken)
+        }
+        return result
+    }
+
+    // MARK: - Cardinal numbers
+
+    private static let cardinalPattern =
+        try! NSRegularExpression(pattern: #"(?<![a-zA-Z])(\d{1,9})(?![a-zA-Z])"#)
+
+    private static func expandCardinalNumbers(_ text: String) -> String {
+        let ns = text as NSString
+        var result = text
+
+        for match in cardinalPattern.matches(in: text, range: NSRange(location: 0, length: ns.length))
+            .reversed()
+        {
+            let fullRange = NSRange(location: match.range.location, length: match.range.length)
+            let numStr = ns.substring(with: match.range(at: 1))
+            guard let num = Int(numStr) else { continue }
+            // Skip years (4 digits) — handled by context, not a simple rule
+            if numStr.count == 4 && num >= 1000 && num <= 2099 { continue }
+            let spoken = numberToWords(num)
+            result = (result as NSString).replacingCharacters(in: fullRange, with: spoken)
+        }
+        return result
+    }
+
+    // MARK: - Common abbreviations
+
+    private static let abbreviationMap: [String: String] = [
+        "e.g.": "for example",
+        "i.e.": "that is",
+        "etc.": "etcetera",
+        "vs.": "versus",
+        "Dr.": "doctor",
+        "Mr.": "mister",
+        "Mrs.": "missus",
+        "Ms.": "miss",
+        "Prof.": "professor",
+        "St.": "saint",
+        "Ave.": "avenue",
+        "Blvd.": "boulevard",
+        "Dept.": "department",
+        "Est.": "established",
+        "Inc.": "incorporated",
+        "Ltd.": "limited",
+        "Corp.": "corporation",
+        "Co.": "company",
+        "Mt.": "mount",
+        "Ft.": "fort",
+        "Jan.": "January",
+        "Feb.": "February",
+        "Mar.": "March",
+        "Apr.": "April",
+        "Jun.": "June",
+        "Jul.": "July",
+        "Aug.": "August",
+        "Sep.": "September",
+        "Oct.": "October",
+        "Nov.": "November",
+        "Dec.": "December",
+    ]
+
+    private static func expandCommonAbbreviations(_ text: String) -> String {
+        var result = text
+        for (abbr, expansion) in abbreviationMap {
+            result = result.replacingOccurrences(of: abbr, with: expansion)
+        }
+        return result
+    }
+
+    // MARK: - Number to words
+
+    private static let ones = [
+        "", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+        "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
+        "seventeen", "eighteen", "nineteen",
+    ]
+
+    private static let tens = [
+        "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty",
+        "ninety",
+    ]
+
+    private static func numberToWords(_ n: Int) -> String {
+        guard n >= 0 else { return "minus \(numberToWords(-n))" }
+        if n >= 1_000_000_000 {
+            let b = n / 1_000_000_000; let r = n % 1_000_000_000
+            let base = b == 1 ? "one billion" : "\(numberToWords(b)) billion"
+            return r == 0 ? base : "\(base) \(numberToWords(r))"
+        }
+        if n >= 1_000_000 {
+            let m = n / 1_000_000; let r = n % 1_000_000
+            let base = m == 1 ? "one million" : "\(numberToWords(m)) million"
+            return r == 0 ? base : "\(base) \(numberToWords(r))"
+        }
+        if n >= 1_000 {
+            let th = n / 1_000; let r = n % 1_000
+            let base = th == 1 ? "one thousand" : "\(numberToWords(th)) thousand"
+            return r == 0 ? base : "\(base) \(numberToWords(r))"
+        }
+        if n >= 100 {
+            let h = n / 100; let r = n % 100
+            let base = h == 1 ? "one hundred" : "\(ones[h]) hundred"
+            return r == 0 ? base : "\(base) and \(numberToWords(r))"
+        }
+        if n >= 20 {
+            let t = n / 10; let o = n % 10
+            return o == 0 ? tens[t] : "\(tens[t])-\(ones[o])"
+        }
+        return ones[n]
+    }
+
+    private static func ordinalToWords(_ n: Int) -> String {
+        let card = numberToWords(n)
+        // Simple ordinal suffix mapping
+        let suffix: String
+        let mod100 = n % 100
+        let mod10 = n % 10
+        if mod100 >= 11 && mod100 <= 13 {
+            suffix = "th"
+        } else {
+            switch mod10 {
+            case 1: suffix = "st"
+            case 2: suffix = "nd"
+            case 3: suffix = "rd"
+            default: suffix = "th"
+            }
+        }
+
+        // Special ordinal words for 1-20
+        if n == 1 { return "first" }
+        if n == 2 { return "second" }
+        if n == 3 { return "third" }
+        if n == 4 { return "fourth" }
+        if n == 5 { return "fifth" }
+        if n == 6 { return "sixth" }
+        if n == 7 { return "seventh" }
+        if n == 8 { return "eighth" }
+        if n == 9 { return "ninth" }
+        if n == 10 { return "tenth" }
+        if n == 11 { return "eleventh" }
+        if n == 12 { return "twelfth" }
+        if n == 13 { return "thirteenth" }
+
+        return "\(card)\(suffix)"
+    }
+}
+
+// MARK: - Foundation helpers
+
+extension String {
+    /// Simple‑minded lowercase ASCII detection — enough for abbreviation matching.
+    fileprivate var lowercasedASCII: String {
+        lowercased()
+    }
+}

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -371,6 +371,12 @@ struct MossTTSNanoTests {
         #expect(TTS.resolveModelType(modelRepo: "mlx-community/MOSS-TTS-Nano") == "moss_tts_nano")
         #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "moss_tts_nano") == "moss_tts_nano")
     }
+
+    @Test func ttsModelResolutionIncludesVoxCPM2() {
+        #expect(TTS.resolveModelType(modelRepo: "aufklarer/VoxCPM2-MLX-bf16") == "voxcpm2")
+        #expect(TTS.resolveModelType(modelRepo: "/tmp/VoxCPM2-8bit") == "voxcpm2")
+        #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "voxcpm2") == "voxcpm2")
+    }
 }
 
 @Suite("MOSS TTS Full Tests")


### PR DESCRIPTION
## Summary

This PR fills the gap between VoxCPM2's official Python API and the existing MLX Swift implementation by adding three major feature groups:

### LoRA Fine-Tuning
- **`LoRAConfig`** — matches the official `lora` config schema (`enable_lm`, `enable_diT`, `enable_proj`, `r`, `alpha`, `dropout`)
- **`LoRALinear`** — wraps a frozen `Linear` with trainable low-rank matrices A/B, toggled via `enabled`
- **`VoxCPM2Model.loadLoRA(weightsPath:)`** — loads safetensors with automatic PEFT prefix stripping
- **`unloadLoRA()`**, **`setLoRAEnabled()`**, **`getLoRAStateDict()`** — full lifecycle management
- Injected at load time via `VoxCPM2Model.fromModelDirectory(_:loraConfig:)`

### Text Normalization
- **`TextNormalizer`** — expands numbers, currency, ordinal indicators, and common abbreviations
- Enabled via `generateVoxCPM2(..., normalize: true)`

### Bad-case Retry
- **`retryBadcase`**, `retryBadcaseMaxTimes`, `retryBadcaseRatioThreshold` — automatically retries when generated audio is abnormally short or long

### Denoiser (placeholder)
- `denoise: Bool` parameter added to the API signature, emits diagnostic warning — ZipEnhancer integration is left as future work

## Files

| File | Change |
|------|--------|
| `Sources/MLXAudioTTS/Models/VoxCPM2/LoRAConfig.swift` | new |
| `Sources/MLXAudioTTS/Models/VoxCPM2/LoRALinear.swift` | new |
| `Sources/MLXAudioTTS/TextNormalizer.swift` | new |
| `Sources/MLXAudioTTS/Models/VoxCPM2/VoxCPM2.swift` | modified |
| `Sources/MLXAudioTTS/Models/VoxCPM2/README.md` | modified |

All existing APIs remain backward-compatible — new parameters default to `false`/`nil`, and the generic `TTS.loadModel()` path is unaffected.
