### PR TITLE
feat(nemotron): cache-aware streaming CoreML/ANE encoder

### DIFF
--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
@@ -19,6 +19,13 @@ public final class NemotronASRModel: Module, STTGenerationModel {
 
     public var computeDType: DType = .bfloat16
 
+    #if canImport(CoreML)
+    /// Optional fixed-shape CoreML/ANE Conformer encoder for the **offline** path. When set,
+    /// `decode()` runs it instead of the MLX encoder (falls back to MLX on any failure). The
+    /// encoder is a generic fixed-shape Conformer encoder shared with Parakeet (same I/O).
+    public var coreMLEncoder: ConformerCoreMLEncoder?
+    #endif
+
     @ModuleInfo(key: "encoder") var encoder: NemotronASRConformer
     @ModuleInfo(key: "prompt_kernel") var promptKernel: NemotronASRPromptKernel
     @ModuleInfo(key: "decoder") var decoder: NemoPredictNetwork
@@ -88,7 +95,17 @@ public final class NemotronASRModel: Module, STTGenerationModel {
         let sampleRate = preprocessConfig.sampleRate
         let totalSamples = audio1D.shape[0]
         let audioDuration = Double(totalSamples) / Double(sampleRate)
-        let chunkDuration = Double(generationParameters.chunkDuration)
+        var chunkDuration = Double(generationParameters.chunkDuration)
+        #if canImport(CoreML)
+        // The offline CoreML encoder is fixed-shape (`fixedFrames` mel frames); longer mel is
+        // cropped. Force chunking ≤ that length so `generate()`'s overlap-merge stitches long
+        // audio. (A few frames of margin keep the boundary attention clean.)
+        if let coreML = coreMLEncoder {
+            let hopSeconds = Double(preprocessConfig.hopLength) / Double(sampleRate)
+            let maxChunkSeconds = Double(coreML.fixedFrames - 4) * hopSeconds
+            chunkDuration = chunkDuration <= 0 ? maxChunkSeconds : min(chunkDuration, maxChunkSeconds)
+        }
+        #endif
         let result: NemoAlignedResult
 
         if chunkDuration <= 0 || audioDuration <= chunkDuration {
@@ -195,7 +212,16 @@ public final class NemotronASRModel: Module, STTGenerationModel {
         )
 
         features = features.asType(computeDType)
-        let encoded = encoder(features, attContextSize: attContextSize ?? defaultAttContextSize)
+        let encoded: (MLXArray, MLXArray)
+        #if canImport(CoreML)
+        if let coreML = coreMLEncoder, let result = try? coreML.encode(features, outputDType: computeDType) {
+            encoded = result
+        } else {
+            encoded = encoder(features, attContextSize: attContextSize ?? defaultAttContextSize)
+        }
+        #else
+        encoded = encoder(features, attContextSize: attContextSize ?? defaultAttContextSize)
+        #endif
         let prompted = applyPrompt(encoded.0, language: language)
         eval(prompted, encoded.1)
 

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
@@ -24,6 +24,11 @@ public final class NemotronASRModel: Module, STTGenerationModel {
     /// `decode()` runs it instead of the MLX encoder (falls back to MLX on any failure). The
     /// encoder is a generic fixed-shape Conformer encoder shared with Parakeet (same I/O).
     public var coreMLEncoder: ConformerCoreMLEncoder?
+
+    /// Optional cache-aware **streaming** CoreML/ANE encoder. When set, `generateStream` runs the
+    /// conformer encoder on the ANE (uniform-F feeding + manual cache threading) instead of the MLX
+    /// streaming path; the prompt MLP and RNN-T decode stay in MLX. Falls back to MLX on any failure.
+    public var streamingCoreMLEncoder: NemotronCoreMLStreamingEncoder?
     #endif
 
     @ModuleInfo(key: "encoder") var encoder: NemotronASRConformer
@@ -162,9 +167,10 @@ public final class NemotronASRModel: Module, STTGenerationModel {
             var previousText = ""
 
             // Cache-aware streaming: incremental subsampling + per-layer attn/conv
-            // caches, greedy RNN-T per chunk. Token-identical to decode() at the
-            // native chunk size; shares both loops with NemotronASRStreamSession.
-            self.cacheAwareStreamEncode(mel, language: generationParameters.language) { prompted in
+            // caches, greedy RNN-T per chunk. Token-identical to decode() at the native
+            // chunk size; shares streamRNNTDecode/rnntState with NemotronASRStreamSession.
+            // The chunk handler is shared by the MLX and CoreML/ANE encoder paths.
+            let processChunk: (MLXArray) -> Void = { prompted in
                 self.streamRNNTDecode(prompted, state: rnntState, frameSeconds: frameSeconds)
 
                 let fullText = NemoAlignment.sentencesToResult(
@@ -178,6 +184,26 @@ public final class NemotronASRModel: Module, STTGenerationModel {
                     continuation.yield(.token(nextText))
                 }
             }
+
+            // The encoder runs once over the whole stream, so a mid-stream CoreML failure must
+            // surface (not silently fall back) — earlier chunks already mutated decode state, and
+            // re-running on MLX would duplicate them. Model-load failures happen at enable time.
+            #if canImport(CoreML)
+            if let streamEncoder = self.streamingCoreMLEncoder {
+                do {
+                    try self.cacheAwareStreamEncodeCoreML(
+                        mel, language: generationParameters.language,
+                        encoder: streamEncoder, onChunk: processChunk)
+                } catch {
+                    continuation.finish(throwing: error)
+                    return
+                }
+            } else {
+                self.cacheAwareStreamEncode(mel, language: generationParameters.language, onChunk: processChunk)
+            }
+            #else
+            self.cacheAwareStreamEncode(mel, language: generationParameters.language, onChunk: processChunk)
+            #endif
 
             let finalResult = NemoAlignment.sentencesToResult(
                 NemoAlignment.tokensToSentences(rnntState.results)

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRStreaming.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRStreaming.swift
@@ -159,3 +159,52 @@ extension NemotronASRModel {
         }
     }
 }
+
+#if canImport(CoreML)
+extension NemotronASRModel {
+    /// Cache-aware streaming via the CoreML/ANE encoder, using the validated **uniform-F**
+    /// feeding (every chunk `[preFrames prev-mel ++ newFrames new-mel]`, stride `newFrames`).
+    /// Same `onChunk` contract as `cacheAwareStreamEncode`: post-prompt frames `[1, chunkLen, d]`.
+    /// The prompt MLP and RNN-T decode stay in MLX; only the conformer encoder runs on the ANE.
+    func cacheAwareStreamEncodeCoreML(
+        _ mel: MLXArray,
+        language: String?,
+        encoder coreEncoder: NemotronCoreMLStreamingEncoder,
+        onChunk: (MLXArray) -> Void
+    ) throws {
+        var features = mel
+        if features.ndim == 2 { features = features.expandedDimensions(axis: 0) }
+        features = features.asType(.float32)
+
+        let featIn = coreEncoder.featIn
+        let pre = coreEncoder.preFrames
+        let new = coreEncoder.newFrames
+        let sf = coreEncoder.subsamplingFactor
+        let total = features.shape[1]
+
+        coreEncoder.reset()
+        var p = 0
+        while p < total {
+            // window = [pre prev-mel ++ new new-mel], zeros at the first prepend and last tail.
+            let avail = min(pre, p)
+            var parts: [MLXArray] = []
+            if pre - avail > 0 { parts.append(MLXArray.zeros([1, pre - avail, featIn], dtype: .float32)) }
+            if avail > 0 { parts.append(features[0..., (p - avail)..<p, 0...]) }
+            let realNew = min(new, total - p)
+            parts.append(features[0..., p..<(p + realNew), 0...])
+            if new - realNew > 0 { parts.append(MLXArray.zeros([1, new - realNew, featIn], dtype: .float32)) }
+            let window = MLX.concatenated(parts, axis: 1)  // [1, fixedFrames, featIn]
+
+            let encoded = try coreEncoder.step(window)  // [1, dModel, T'] (drop already applied)
+            // Emit only the frames covered by *real* mel, never the zero-padded fixed-window tail
+            // — including on the final (short) chunk. Keeping the padding frames would decode
+            // silence as audio and can append spurious trailing tokens; the MLX path, which never
+            // pads, emits exactly this count.
+            let keep = min(encoded.shape[2], max(1, (realNew + sf - 1) / sf))
+            let h = encoded[0..., 0..., 0..<keep].transposed(0, 2, 1).asType(computeDType)  // [1, keep, d]
+            onChunk(applyPrompt(h, language: language))
+            p += new
+        }
+    }
+}
+#endif

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronCoreMLEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronCoreMLEncoder.swift
@@ -41,5 +41,42 @@ public extension NemotronASRModel {
         let url = try await ParakeetModel.downloadANEEncoderPackage(repo: repo, cache: cache)
         try enableCoreMLEncoder(modelURL: url)
     }
+
+    /// Enable the cache-aware **streaming** CoreML/ANE encoder from a local `.mlpackage`.
+    ///
+    /// `generateStream` then runs the conformer encoder on the ANE via the validated uniform-F
+    /// feeding (`[preFrames prev-mel ++ newFrames new-mel]`, stride `newFrames`) with manual cache
+    /// threading; the prompt MLP and RNN-T decode stay in MLX. `preFrames`/`newFrames` come from the
+    /// model's NeMo `streaming_cfg` (`pre_encode_cache_size[1]` / `chunk_size[1]`) and must match the
+    /// converted model. The attention cache is the encoder's left context and the conv cache is
+    /// `convKernelSize - 1`, both derived from the loaded config.
+    func enableCoreMLStreamingEncoder(
+        modelURL: URL,
+        preFrames: Int = 9,
+        newFrames: Int = 112
+    ) throws {
+        streamingCoreMLEncoder = try NemotronCoreMLStreamingEncoder(
+            modelURL: modelURL,
+            featIn: encoderConfig.featIn,
+            dModel: encoderConfig.dModel,
+            subsamplingFactor: encoderConfig.subsamplingFactor,
+            preFrames: preFrames,
+            newFrames: newFrames,
+            layers: encoderConfig.nLayers,
+            attnCache: defaultAttContextSize.first ?? 70,
+            convCache: encoderConfig.convKernelSize - 1
+        )
+    }
+
+    /// Hugging Face repo with the prebuilt cache-aware **streaming** CoreML/ANE encoder
+    /// `.mlpackage` (matched to the MLX weights of `nemotron-3.5-asr-streaming-0.6b`).
+    static var defaultANEStreamingEncoderRepo: String { "beshkenadze/nemotron-3.5-asr-streaming-0.6b-coreml-ane-stream" }
+
+    /// Download the streaming CoreML encoder `.mlpackage` from a Hugging Face repo and route the
+    /// `generateStream` path through it. Reuses Parakeet's downloader (the package is the same shape).
+    func enableCoreMLStreamingEncoder(repo: String, cache: HubCache = .default) async throws {
+        let url = try await ParakeetModel.downloadANEEncoderPackage(repo: repo, cache: cache)
+        try enableCoreMLStreamingEncoder(modelURL: url)
+    }
 }
 #endif

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronCoreMLEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronCoreMLEncoder.swift
@@ -1,0 +1,45 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+import HuggingFace
+
+/// Nemotron's FastConformer encoder has the same fixed-shape I/O as Parakeet's Conformer
+/// (`[1, T, featIn]` mel in, `[1, T', dModel]` + lengths out, 8× dw-striding subsampling), so
+/// the offline CoreML/ANE encoder is the *same* generic implementation — reused, not duplicated.
+public typealias ConformerCoreMLEncoder = ParakeetCoreMLEncoder
+
+public extension NemotronASRModel {
+    /// Enable the **offline** CoreML/ANE encoder from a local `.mlpackage` / `.mlmodelc`.
+    ///
+    /// `fixedFrames` must match the converted model (default 1000 = 10 s of 10 ms-hop mel). Each
+    /// `decode()` chunk's mel is padded/cropped to this length, so `generate()` auto-clamps its
+    /// `chunkDuration` to ≤ that length and its overlap-merge stitches arbitrary-length audio.
+    ///
+    /// Streaming (`generateStream`) is unaffected and still uses the MLX cache-aware path; a
+    /// CoreML streaming encoder is a separate addition.
+    func enableCoreMLEncoder(modelURL: URL, fixedFrames: Int = 1000) throws {
+        coreMLEncoder = try ConformerCoreMLEncoder(
+            modelURL: modelURL,
+            featIn: encoderConfig.featIn,
+            fixedFrames: fixedFrames,
+            subsamplingFactor: encoderConfig.subsamplingFactor,
+            dModel: encoderConfig.dModel,
+            // Nemotron's dw-striding subsampling pads before each stride (pad 2/1, kernel 3,
+            // stride 2) → `floor(L/2)+1` per stage, unlike Parakeet's `(L-1)/2+1`. Without this
+            // the ANE output is cropped one valid frame short per chunk.
+            subsampledLengthStep: { $0 / 2 + 1 }
+        )
+    }
+
+    /// Hugging Face repo with the prebuilt CoreML/ANE encoder `.mlpackage` (matched to the MLX
+    /// weights of `nemotron-3.5-asr-streaming-0.6b`).
+    static var defaultANEEncoderRepo: String { "beshkenadze/nemotron-3.5-asr-streaming-0.6b-coreml-ane" }
+
+    /// Download the CoreML encoder `.mlpackage` from a Hugging Face repo, then route the offline
+    /// `decode()` path through it. Reuses Parakeet's downloader (the encoder package is generic).
+    func enableCoreMLEncoder(repo: String, cache: HubCache = .default) async throws {
+        let url = try await ParakeetModel.downloadANEEncoderPackage(repo: repo, cache: cache)
+        try enableCoreMLEncoder(modelURL: url)
+    }
+}
+#endif

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronCoreMLStreamingEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronCoreMLStreamingEncoder.swift
@@ -1,0 +1,183 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+import MLX
+
+/// Cache-aware **streaming** CoreML/ANE encoder for Nemotron's FastConformer.
+///
+/// The model is NeMo's full `cache_aware_stream_step` converted *functionally* — the three
+/// streaming caches are explicit inputs **and** outputs (no `MLState`), so we thread them in
+/// Swift: feed caches in → read the `new_*` caches out → feed them back next chunk.
+///
+/// It is fed the **uniform-F** recipe (validated transcript-identical to NeMo native streaming):
+/// every chunk is `[preFrames prev-mel ++ newFrames new-mel]` = `fixedFrames`, stride `newFrames`,
+/// zeros for the first prepend and the last new-frame tail. A fixed-shape model cannot honor a
+/// per-chunk true length, so the feeding — not padding NeMo's variable chunks — is what makes it
+/// correct. `cache_aware_stream_step` applies `drop_extra_pre_encoded` internally, so the output is
+/// already the valid frames; the caller keeps `ceil(realNew / subsampling)` of them.
+public final class NemotronCoreMLStreamingEncoder: @unchecked Sendable {
+    private let model: MLModel
+    public let featIn: Int
+    public let dModel: Int
+    /// pre-encode prepend (= NeMo `pre_encode_cache_size[1]`, e.g. 9).
+    public let preFrames: Int
+    /// new mel frames per chunk (= NeMo `chunk_size[1]`, e.g. 112).
+    public let newFrames: Int
+    public let subsamplingFactor: Int
+
+    private let layers: Int      // cache_last_channel/time dim 0 (e.g. 24)
+    private let attnCache: Int   // cache_last_channel dim 2 (e.g. 70)
+    private let convCache: Int   // cache_last_time   dim 3 (e.g. 8)
+
+    private let signalName = "processed_signal"
+    private let chInName = "cache_last_channel"
+    private let timeInName = "cache_last_time"
+    private let lenInName = "cache_last_channel_len"
+    private let encodedName = "encoded"
+    private let chOutName = "new_cache_last_channel"
+    private let timeOutName = "new_cache_last_time"
+    private let lenOutName = "new_cache_last_channel_len"
+
+    private var cacheChannel: MLMultiArray
+    private var cacheTime: MLMultiArray
+    private var cacheLen: MLMultiArray
+
+    /// Mel frames fed per chunk (`preFrames + newFrames`, the model's fixed input length).
+    public var fixedFrames: Int { preFrames + newFrames }
+
+    public init(
+        modelURL: URL,
+        featIn: Int,
+        dModel: Int,
+        subsamplingFactor: Int,
+        preFrames: Int,
+        newFrames: Int,
+        layers: Int,
+        attnCache: Int,
+        convCache: Int,
+        // Force CPU+ANE, NOT .all: the streaming graph's int32 mask/cache-length ops nudge `.all`
+        // to place the WHOLE model on the GPU (anemll-profile: 1.9% ANE) — no power win. With
+        // .cpuAndNeuralEngine the conformer is 100% ANE-resident (the few int32 mask ops drop to
+        // CPU as one negligible island). The offline encoder has no such masks, so it uses .all.
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+    ) throws {
+        let compiledURL = try Self.cachedCompiledModel(at: modelURL)
+        let config = MLModelConfiguration()
+        config.computeUnits = computeUnits
+        self.model = try MLModel(contentsOf: compiledURL, configuration: config)
+        self.featIn = featIn
+        self.dModel = dModel
+        self.subsamplingFactor = subsamplingFactor
+        self.preFrames = preFrames
+        self.newFrames = newFrames
+        self.layers = layers
+        self.attnCache = attnCache
+        self.convCache = convCache
+        self.cacheChannel = try Self.zeroArray([layers, 1, attnCache, dModel], .float16)
+        self.cacheTime = try Self.zeroArray([layers, 1, dModel, convCache], .float16)
+        self.cacheLen = try MLMultiArray(shape: [1], dataType: .int32)
+        self.cacheLen[0] = 0
+    }
+
+    /// Compile the `.mlpackage` to `.mlmodelc` once and **cache it** next to the source, so the
+    /// ~30 s CoreML/ANE compilation is a one-time **cold start**; later loads reuse the cached
+    /// `.mlmodelc` (**hot start**, ~instant). `MLModel.compileModel` alone compiles to a throwaway
+    /// temp dir every launch — that is what made every run pay the full compile. Falls back to the
+    /// temp compile if the cache location isn't writable.
+    private static func cachedCompiledModel(at modelURL: URL) throws -> URL {
+        if modelURL.pathExtension == "mlmodelc" { return modelURL }
+        let fm = FileManager.default
+        let cached = modelURL.deletingPathExtension().appendingPathExtension("mlmodelc")
+        func modDate(_ url: URL) -> Date? {
+            (try? fm.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
+        }
+        if fm.fileExists(atPath: cached.path),
+           let c = modDate(cached), let s = modDate(modelURL), c >= s {
+            return cached  // hot start: reuse the cached compiled model
+        }
+        let tmp = try MLModel.compileModel(at: modelURL)  // cold start: compile once
+        if fm.fileExists(atPath: cached.path) { try? fm.removeItem(at: cached) }
+        do { try fm.moveItem(at: tmp, to: cached); return cached }
+        catch { return tmp }  // cache dir not writable -> use the temp compile (no caching)
+    }
+
+    /// Reset the three caches to their initial (all-zero) streaming state. Allocates **fresh
+    /// contiguous** arrays: after a `step()` the cache vars point at the model's stride-padded
+    /// output, which a sequential in-place zero would not fully clear (the padded gaps survive).
+    public func reset() {
+        cacheChannel = (try? Self.zeroArray([layers, 1, attnCache, dModel], .float16)) ?? cacheChannel
+        cacheTime = (try? Self.zeroArray([layers, 1, dModel, convCache], .float16)) ?? cacheTime
+        cacheLen = (try? MLMultiArray(shape: [1], dataType: .int32)) ?? cacheLen
+        cacheLen[0] = 0
+    }
+
+    /// A freshly-allocated, contiguous, all-zero MLMultiArray (contiguous → sequential fill is safe).
+    private static func zeroArray(_ shape: [Int], _ dtype: MLMultiArrayDataType) throws -> MLMultiArray {
+        let a = try MLMultiArray(shape: shape.map(NSNumber.init), dataType: dtype)
+        let n = a.count
+        if dtype == .float16 {
+            let p = a.dataPointer.bindMemory(to: UInt16.self, capacity: n)
+            for i in 0..<n { p[i] = 0 }
+        } else {
+            let p = a.dataPointer.bindMemory(to: Float.self, capacity: n)
+            for i in 0..<n { p[i] = 0 }
+        }
+        return a
+    }
+
+    /// Encode one uniform-`fixedFrames` mel window `[1, fixedFrames, featIn]` (time-major).
+    /// Returns `encoded [1, dModel, T']` (channel-first); the caller crops to valid frames and
+    /// transposes. Threads (mutates) the three caches.
+    public func step(_ window: MLXArray) throws -> MLXArray {
+        let F = fixedFrames
+        precondition(window.shape == [1, F, featIn],
+                     "stream window must be [1, \(F), \(featIn)], got \(window.shape)")
+        // [1, F, featIn] row-major (t*featIn+f) -> processed_signal [1, featIn, F] fp16.
+        let melFlat = window.asType(.float32).asArray(Float.self)
+        let signal = try MLMultiArray(
+            shape: [1, NSNumber(value: featIn), NSNumber(value: F)], dataType: .float16)
+        signal.dataPointer.withMemoryRebound(to: UInt16.self, capacity: featIn * F) { dst in
+            for t in 0..<F {
+                for f in 0..<featIn {
+                    dst[f * F + t] = Float16(melFlat[t * featIn + f]).bitPattern
+                }
+            }
+        }
+
+        let provider = try MLDictionaryFeatureProvider(dictionary: [
+            signalName: MLFeatureValue(multiArray: signal),
+            chInName: MLFeatureValue(multiArray: cacheChannel),
+            timeInName: MLFeatureValue(multiArray: cacheTime),
+            lenInName: MLFeatureValue(multiArray: cacheLen),
+        ])
+        let out = try model.prediction(from: provider)
+
+        guard let enc = out.featureValue(for: encodedName)?.multiArrayValue,
+              let nch = out.featureValue(for: chOutName)?.multiArrayValue,
+              let nt = out.featureValue(for: timeOutName)?.multiArrayValue,
+              let nl = out.featureValue(for: lenOutName)?.multiArrayValue
+        else {
+            throw STTError.invalidInput("CoreML streaming encoder missing an output")
+        }
+        cacheChannel = nch
+        cacheTime = nt
+        cacheLen = nl
+
+        // ANE outputs are stride-padded — read by strides, not sequentially.
+        let dm = enc.shape[1].intValue
+        let tFull = enc.shape[2].intValue
+        let s1 = enc.strides[1].intValue
+        let s2 = enc.strides[2].intValue
+        let capacity = (dm - 1) * s1 + (tFull - 1) * s2 + 1
+        var floats = [Float](repeating: 0, count: dm * tFull)
+        if enc.dataType == .float16 {
+            let p = enc.dataPointer.bindMemory(to: UInt16.self, capacity: capacity)
+            for d in 0..<dm { for t in 0..<tFull { floats[d * tFull + t] = Float(Float16(bitPattern: p[d * s1 + t * s2])) } }
+        } else {
+            let p = enc.dataPointer.bindMemory(to: Float.self, capacity: capacity)
+            for d in 0..<dm { for t in 0..<tFull { floats[d * tFull + t] = p[d * s1 + t * s2] } }
+        }
+        return MLXArray(floats, [1, dm, tFull])
+    }
+}
+#endif

--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetCoreMLEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetCoreMLEncoder.swift
@@ -1,0 +1,142 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+import MLX
+
+/// Drop-in CoreML/ANE replacement for the MLX Conformer encoder. The model is
+/// fixed-shape because ANE requires it (RangeDim → 0% residency), so each chunk's mel
+/// is padded to `fixedFrames` and the output cropped back to the true subsampled length.
+public final class ParakeetCoreMLEncoder: @unchecked Sendable {
+    private let model: MLModel
+    private let featIn: Int
+    /// The fixed mel-frame count the model was converted at (e.g. 1000 = 10 s). Callers use
+    /// this to keep their chunking ≤ this length, since longer mel is cropped.
+    public let fixedFrames: Int
+    private let subsamplingFactor: Int
+    private let inputName: String
+    private let outputName: String
+    /// Expected encoder output width (`d_model`); when set, `encode` rejects a model whose
+    /// output doesn't match the loaded checkpoint instead of returning mis-shaped features.
+    private let expectedDModel: Int?
+    /// One subsampling stage on a length. Parakeet: `(L-1)/2+1`; encoders with different conv
+    /// padding (e.g. Nemotron's pad-before-stride `floor(L/2)+1`) inject their own so the ANE
+    /// output is cropped to the right valid width.
+    private let subsampledLengthStep: (Int) -> Int
+
+    public init(
+        modelURL: URL,
+        featIn: Int,
+        fixedFrames: Int,
+        subsamplingFactor: Int,
+        dModel: Int? = nil,
+        subsampledLengthStep: (@Sendable (Int) -> Int)? = nil,
+        computeUnits: MLComputeUnits = .all,
+        inputName: String = "features",
+        outputName: String = "encoded"
+    ) throws {
+        let compiledURL: URL
+        if modelURL.pathExtension == "mlmodelc" {
+            compiledURL = modelURL
+        } else {
+            compiledURL = try MLModel.compileModel(at: modelURL)
+        }
+        let config = MLModelConfiguration()
+        config.computeUnits = computeUnits
+        self.model = try MLModel(contentsOf: compiledURL, configuration: config)
+        self.featIn = featIn
+        self.fixedFrames = fixedFrames
+        self.subsamplingFactor = subsamplingFactor
+        self.inputName = inputName
+        self.outputName = outputName
+        self.expectedDModel = dModel
+        self.subsampledLengthStep = subsampledLengthStep ?? { ($0 - 1) / 2 + 1 }
+    }
+
+    /// Parakeet default: `floor((L-1)/2)+1`, log2(factor) times. `step` overrides the per-stage
+    /// rule for encoders whose conv padding differs (e.g. Nemotron's `floor(L/2)+1`).
+    static func subsampledLength(
+        frames: Int,
+        subsamplingFactor: Int,
+        step: (Int) -> Int = { ($0 - 1) / 2 + 1 }
+    ) -> Int {
+        var l = frames
+        let steps = Int(log2(Double(subsamplingFactor)))
+        for _ in 0..<steps { l = step(l) }
+        return l
+    }
+
+    private func encodedLength(for frames: Int) -> Int {
+        Self.subsampledLength(frames: frames, subsamplingFactor: subsamplingFactor, step: subsampledLengthStep)
+    }
+
+    /// Encode one chunk. `features`: `[1, T, featIn]` (any float dtype).
+    /// Returns `(encoded [1, T', dModel], lengths [1])`, dtype = `outputDType`.
+    public func encode(_ features: MLXArray, outputDType: DType) throws -> (MLXArray, MLXArray) {
+        // Fixed-shape ANE model: it only handles a single chunk that fits the window.
+        // Throw (rather than silently truncate a long chunk or scramble a multi-item batch)
+        // so callers — which invoke `encode` via `try?` — fall back to the MLX encoder and
+        // still produce a complete, correct result.
+        guard features.shape[0] == 1 else {
+            throw STTError.invalidInput("CoreML encoder handles batch size 1 (got \(features.shape[0])); falling back to MLX")
+        }
+        let trueFrames = features.shape[1]
+        guard trueFrames <= fixedFrames else {
+            throw STTError.invalidInput(
+                "chunk of \(trueFrames) mel frames exceeds the fixed CoreML window of \(fixedFrames); "
+                    + "use a shorter --chunk-duration or the MLX encoder")
+        }
+        let clamped = trueFrames
+
+        var mel = features.asType(.float32)
+        if trueFrames < fixedFrames {
+            mel = padded(mel, widths: [.init((0, 0)), .init((0, fixedFrames - trueFrames)), .init((0, 0))])
+        }
+        // mel is [1, fixedFrames, featIn] row-major; CoreML wants [1, featIn, fixedFrames].
+        let melFlat = mel.asArray(Float.self)  // index = t * featIn + f
+        let input = try MLMultiArray(shape: [1, NSNumber(value: featIn), NSNumber(value: fixedFrames)], dataType: .float32)
+        input.dataPointer.withMemoryRebound(to: Float.self, capacity: featIn * fixedFrames) { dst in
+            for t in 0..<fixedFrames {
+                for f in 0..<featIn {
+                    dst[f * fixedFrames + t] = melFlat[t * featIn + f]
+                }
+            }
+        }
+
+        let provider = try MLDictionaryFeatureProvider(dictionary: [inputName: MLFeatureValue(multiArray: input)])
+        let out = try model.prediction(from: provider)
+        guard let enc = out.featureValue(for: outputName)?.multiArrayValue else {
+            throw STTError.invalidInput("CoreML encoder produced no '\(outputName)' output")
+        }
+
+        let dModel = enc.shape[1].intValue
+        let tFull = enc.shape[2].intValue
+        guard expectedDModel == nil || dModel == expectedDModel else {
+            throw STTError.invalidInput(
+                "CoreML encoder output dim \(dModel) ≠ model d_model \(expectedDModel!); this ANE "
+                    + "encoder doesn't match the loaded checkpoint — falling back to MLX")
+        }
+        // ANE outputs are often stride-padded, so honor strides rather than reading the
+        // raw buffer sequentially (which would scramble frames).
+        let s1 = enc.strides[1].intValue
+        let s2 = enc.strides[2].intValue
+        let count = dModel * tFull
+        let capacity = (dModel - 1) * s1 + (tFull - 1) * s2 + 1
+        var encFloats = [Float](repeating: 0, count: count)  // packed [d * tFull + t]
+        if enc.dataType == .float16 {
+            let p = enc.dataPointer.bindMemory(to: UInt16.self, capacity: capacity)
+            for d in 0..<dModel { for t in 0..<tFull { encFloats[d * tFull + t] = Float(Float16(bitPattern: p[d * s1 + t * s2])) } }
+        } else {
+            let p = enc.dataPointer.bindMemory(to: Float.self, capacity: capacity)
+            for d in 0..<dModel { for t in 0..<tFull { encFloats[d * tFull + t] = p[d * s1 + t * s2] } }
+        }
+
+        let validLen = encodedLength(for: clamped)
+        var encoded = MLXArray(encFloats, [1, dModel, tFull]).transposed(0, 2, 1)
+        if validLen < tFull {
+            encoded = encoded[0..., 0..<validLen, 0...]
+        }
+        let lengths = MLXArray([Int32(validLen)]).asType(.int32)
+        return (encoded.asType(outputDType), lengths)
+    }
+}
+#endif

--- a/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
+++ b/Sources/MLXAudioSTT/Models/Parakeet/ParakeetModel.swift
@@ -34,6 +34,7 @@ public final class ParakeetModel: Module, STTGenerationModel {
     enum EncoderExecutionImplementation: Sendable {
         case plain
         case compiled
+        case coreML
     }
 
     struct TDTTraceStep: Sendable, Equatable {
@@ -52,6 +53,9 @@ public final class ParakeetModel: Module, STTGenerationModel {
 
     var tdtDecoderImplementation: TDTDecoderImplementation?
     var encoderExecutionImplementation: EncoderExecutionImplementation?
+    #if canImport(CoreML)
+    var coreMLEncoder: ParakeetCoreMLEncoder?
+    #endif
     var tdtTraceEmitter: (@Sendable (TDTTraceStep) -> Void)?
     private var compiledEncoderFeaturesByShape: [String: @Sendable (MLXArray) -> MLXArray] = [:]
 
@@ -122,8 +126,19 @@ public final class ParakeetModel: Module, STTGenerationModel {
         let sampleRate = preprocessConfig.sampleRate
         let totalSamples = audio1D.shape[0]
         let audioDuration = Double(totalSamples) / Double(sampleRate)
-        let chunkDuration = Double(generationParameters.chunkDuration)
+        var chunkDuration = Double(generationParameters.chunkDuration)
         let overlapDuration = 2.0
+        #if canImport(CoreML)
+        // The fixed-shape ANE encoder fits only `fixedFrames` mel frames; force chunking ≤ that
+        // window (overlap-merge restitches) so long audio actually uses the ANE path instead of
+        // silently falling back to MLX on one oversized chunk. (A few frames of margin keep the
+        // boundary attention clean.)
+        if let coreMLEncoder {
+            let hopSeconds = Double(preprocessConfig.hopLength) / Double(sampleRate)
+            let maxChunkSeconds = Double(coreMLEncoder.fixedFrames - 4) * hopSeconds
+            chunkDuration = chunkDuration <= 0 ? maxChunkSeconds : min(chunkDuration, maxChunkSeconds)
+        }
+        #endif
 
         let result: ParakeetAlignedResult
         if chunkDuration <= 0 || audioDuration <= chunkDuration {
@@ -313,8 +328,93 @@ public final class ParakeetModel: Module, STTGenerationModel {
             let encodedFeatures = compiledEncoderFeatures(for: features)(features)
             let encodedLengths = computeEncodedLengths(from: resolvedLengths)
             return (encodedFeatures, encodedLengths)
+        case .coreML:
+            #if canImport(CoreML)
+            if let coreMLEncoder,
+               let result = try? coreMLEncoder.encode(features, outputDType: computeDType) {
+                return result
+            }
+            #endif
+            return encoder(features, lengths: resolvedLengths)  // fallback if CoreML unavailable
         }
     }
+
+    /// How to source the optional CoreML/ANE Conformer encoder (default `.off` = pure MLX).
+    public enum ANEEncoder: Sendable {
+        case off
+        case on                  // download `defaultANEEncoderRepo` (parakeet-tdt-0.6b-v3); other checkpoints: use `.repo`/`.package`
+        case repo(String)        // download a specific Hugging Face repo
+        case package(URL)        // a local .mlpackage / .mlmodelc
+    }
+
+    public static let defaultANEEncoderRepo = "beshkenadze/parakeet-tdt-0.6b-v3-coreml-ane"
+
+    /// Apply an `ANEEncoder` option. No-op for `.off` or when CoreML is unavailable.
+    public func applyANEEncoder(_ option: ANEEncoder, cache: HubCache = .default) async throws {
+        #if canImport(CoreML)
+        switch option {
+        case .off: break
+        case .on: try await enableCoreMLEncoder(repo: Self.defaultANEEncoderRepo, cache: cache)
+        case .repo(let repo): try await enableCoreMLEncoder(repo: repo, cache: cache)
+        case .package(let url): try enableCoreMLEncoder(modelURL: url)
+        }
+        #endif
+    }
+
+    #if canImport(CoreML)
+    /// Route the Conformer encoder through CoreML/ANE; decoder and chunking stay in MLX.
+    public func enableCoreMLEncoder(modelURL: URL, fixedFrames: Int = 1000) throws {
+        coreMLEncoder = try ParakeetCoreMLEncoder(
+            modelURL: modelURL,
+            featIn: encoderConfig.featIn,
+            fixedFrames: fixedFrames,
+            subsamplingFactor: encoderConfig.subsamplingFactor,
+            dModel: encoderConfig.dModel
+        )
+        encoderExecutionImplementation = .coreML
+    }
+
+    /// Download a CoreML encoder `.mlpackage` from a Hugging Face repo, then route through it.
+    public func enableCoreMLEncoder(repo: String, cache: HubCache = .default) async throws {
+        let url = try await Self.downloadANEEncoderPackage(repo: repo, cache: cache)
+        try enableCoreMLEncoder(modelURL: url)
+    }
+
+    static func downloadANEEncoderPackage(repo: String, cache: HubCache = .default) async throws -> URL {
+        guard let repoID = Repo.ID(rawValue: repo) else {
+            throw NSError(domain: "ParakeetModel", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid ANE encoder repo: \(repo)"])
+        }
+        let hfToken = ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+        let client = (hfToken?.isEmpty == false)
+            ? HubClient(host: HubClient.defaultHost, bearerToken: hfToken!, cache: cache)
+            : HubClient(cache: cache)
+        let dir = (client.cache ?? cache).cacheDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(repo.replacingOccurrences(of: "/", with: "_"))
+
+        if let cached = findEncoderPackage(in: dir) { return cached }
+
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await client.downloadSnapshot(
+            of: repoID, kind: .model, to: dir, revision: "main",
+            matching: ["*.json", "*.mlmodel", "*.bin", "*.weights", "*.mil", "*.espresso.*"],
+            progressHandler: { _ in }
+        )
+        guard let pkg = findEncoderPackage(in: dir) else {
+            throw NSError(domain: "ParakeetModel", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey: "No .mlpackage/.mlmodelc found in \(repo)"])
+        }
+        return pkg
+    }
+
+    static func findEncoderPackage(in dir: URL) -> URL? {
+        guard let items = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        else { return nil }
+        return items.first { ["mlpackage", "mlmodelc"].contains($0.pathExtension) }
+    }
+    #endif
 
     func compiledEncoderFeatures(for features: MLXArray) -> @Sendable (MLXArray) -> MLXArray {
         let key = "\(features.shape)-\(features.dtype)"
@@ -1054,7 +1154,8 @@ public extension ParakeetModel {
     static func fromPretrained(
         _ modelPath: String,
         computeDType: DType = .bfloat16,
-        cache: HubCache = .default
+        cache: HubCache = .default,
+        aneEncoder: ANEEncoder = .off
     ) async throws -> ParakeetModel {
         let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
             ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
@@ -1073,7 +1174,9 @@ public extension ParakeetModel {
             hfToken: hfToken,
             cache: cache
         )
-        return try fromDirectory(modelDir, computeDType: computeDType)
+        let model = try fromDirectory(modelDir, computeDType: computeDType)
+        try await model.applyANEEncoder(aneEncoder, cache: cache)
+        return model
     }
 }
 

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -421,7 +421,14 @@ enum App {
         // fall through to the generic stream instead of aborting on its precondition.
         if let nemotron = model as? NemotronASRModel {
             let norm = nemotron.preprocessConfig.normalize.lowercased()
-            if norm == "na" || norm == "none" {
+            var useSession = norm == "na" || norm == "none"
+            #if canImport(CoreML)
+            // The streaming CoreML/ANE encoder is fixed-shape (native chunk only) and is
+            // consumed by generateStream, not the session. When it's enabled, fall through
+            // to generateStream so `--ane --stream` actually runs the encoder on the ANE.
+            if nemotron.streamingCoreMLEncoder != nil { useSession = false }
+            #endif
+            if useSession {
                 return runNemotronStreaming(model: nemotron, audio: audio, parameters: parameters)
             }
         }

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -79,6 +79,7 @@ private struct Options {
     var genKwargsRaw: String? = nil
     var text = ""
     var coremlEncoder: String? = nil
+    var coremlStreamEncoder: String? = nil
     var ane = false
 
     var temperature: Float? = nil
@@ -144,6 +145,9 @@ private struct Options {
             case "--coreml-encoder":
                 guard let v = it.next() else { throw CLIError.missingValue(arg) }
                 options.coremlEncoder = v
+            case "--coreml-stream-encoder":
+                guard let v = it.next() else { throw CLIError.missingValue(arg) }
+                options.coremlStreamEncoder = v
             case "--ane":
                 options.ane = true
             case "--help", "-h":
@@ -289,14 +293,23 @@ enum App {
                     if options.verbose { print("ANE encoder enabled: \(ParakeetModel.defaultANEEncoderRepo)") }
                 }
             } else if let nemotron = m as? NemotronASRModel {
-                // Offline CoreML/ANE encoder for Nemotron. Auto-clamps chunkDuration to the
-                // model's fixed length so overlap-merge stitches long audio.
+                // Offline CoreML/ANE encoder (decode path): explicit --coreml-encoder, or --ane
+                // without --stream. Auto-clamps chunkDuration so overlap-merge stitches long audio.
                 if let coremlPath = options.coremlEncoder {
                     try nemotron.enableCoreMLEncoder(modelURL: resolveURL(path: coremlPath))
                     if options.verbose { print("CoreML/ANE encoder enabled (Nemotron): \(coremlPath)") }
-                } else if options.ane {
+                } else if options.ane && !options.stream {
                     try await nemotron.enableCoreMLEncoder(repo: NemotronASRModel.defaultANEEncoderRepo)
                     if options.verbose { print("ANE encoder enabled (Nemotron): \(NemotronASRModel.defaultANEEncoderRepo)") }
+                }
+                // Cache-aware streaming CoreML/ANE encoder (generateStream path): explicit
+                // --coreml-stream-encoder, or --ane with --stream (auto-downloads the stream package).
+                if let streamPath = options.coremlStreamEncoder {
+                    try nemotron.enableCoreMLStreamingEncoder(modelURL: resolveURL(path: streamPath))
+                    if options.verbose { print("CoreML/ANE streaming encoder enabled (Nemotron): \(streamPath)") }
+                } else if options.ane && options.stream {
+                    try await nemotron.enableCoreMLStreamingEncoder(repo: NemotronASRModel.defaultANEStreamingEncoderRepo)
+                    if options.verbose { print("ANE streaming encoder enabled (Nemotron): \(NemotronASRModel.defaultANEStreamingEncoderRepo)") }
                 }
             }
         }

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -78,6 +78,8 @@ private struct Options {
     var prefillStepSize = 2048
     var genKwargsRaw: String? = nil
     var text = ""
+    var coremlEncoder: String? = nil
+    var ane = false
 
     var temperature: Float? = nil
     var topP: Float? = nil
@@ -139,6 +141,11 @@ private struct Options {
             case "--text":
                 guard let v = it.next() else { throw CLIError.missingValue(arg) }
                 options.text = v
+            case "--coreml-encoder":
+                guard let v = it.next() else { throw CLIError.missingValue(arg) }
+                options.coremlEncoder = v
+            case "--ane":
+                options.ane = true
             case "--help", "-h":
                 printUsage()
                 exit(0)
@@ -271,6 +278,18 @@ enum App {
         let (inputSampleRate, inputAudio) = try loadAudioArray(from: inputURL)
         let audio = try prepareAudioForSTT(inputAudio, inputSampleRate: inputSampleRate, targetSampleRate: 16000)
 
+        #if canImport(CoreML)
+        if case .stt(let m) = model, let parakeet = m as? ParakeetModel {
+            if let coremlPath = options.coremlEncoder {
+                try parakeet.enableCoreMLEncoder(modelURL: resolveURL(path: coremlPath))
+                if options.verbose { print("CoreML/ANE encoder enabled: \(coremlPath)") }
+            } else if options.ane {
+                try await parakeet.enableCoreMLEncoder(repo: ParakeetModel.defaultANEEncoderRepo)
+                if options.verbose { print("ANE encoder enabled: \(ParakeetModel.defaultANEEncoderRepo)") }
+            }
+        }
+        #endif
+
         let startTime = CFAbsoluteTimeGetCurrent()
 
         if options.verbose {
@@ -346,9 +365,11 @@ enum App {
 
         if options.verbose {
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+            let audioSeconds = Double(audio.size) / 16000.0
             print("\n==========")
             print("Saved file to: \(options.outputPath!).\(options.format.rawValue)")
             print(String(format: "Processing time: %.2f seconds", elapsed))
+            print(String(format: "RTF: %.1fx realtime (%.1fs audio / %.2fs)", audioSeconds / elapsed, audioSeconds, elapsed))
             print(String(format: "Prompt: %d tokens, %.3f tokens-per-sec", output.promptTokens, output.promptTps))
             print(String(format: "Generation: %d tokens, %.3f tokens-per-sec", output.generationTokens, output.generationTps))
             print(String(format: "Peak memory: %.2f GB", output.peakMemoryUsage))

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -279,13 +279,25 @@ enum App {
         let audio = try prepareAudioForSTT(inputAudio, inputSampleRate: inputSampleRate, targetSampleRate: 16000)
 
         #if canImport(CoreML)
-        if case .stt(let m) = model, let parakeet = m as? ParakeetModel {
-            if let coremlPath = options.coremlEncoder {
-                try parakeet.enableCoreMLEncoder(modelURL: resolveURL(path: coremlPath))
-                if options.verbose { print("CoreML/ANE encoder enabled: \(coremlPath)") }
-            } else if options.ane {
-                try await parakeet.enableCoreMLEncoder(repo: ParakeetModel.defaultANEEncoderRepo)
-                if options.verbose { print("ANE encoder enabled: \(ParakeetModel.defaultANEEncoderRepo)") }
+        if case .stt(let m) = model {
+            if let parakeet = m as? ParakeetModel {
+                if let coremlPath = options.coremlEncoder {
+                    try parakeet.enableCoreMLEncoder(modelURL: resolveURL(path: coremlPath))
+                    if options.verbose { print("CoreML/ANE encoder enabled: \(coremlPath)") }
+                } else if options.ane {
+                    try await parakeet.enableCoreMLEncoder(repo: ParakeetModel.defaultANEEncoderRepo)
+                    if options.verbose { print("ANE encoder enabled: \(ParakeetModel.defaultANEEncoderRepo)") }
+                }
+            } else if let nemotron = m as? NemotronASRModel {
+                // Offline CoreML/ANE encoder for Nemotron. Auto-clamps chunkDuration to the
+                // model's fixed length so overlap-merge stitches long audio.
+                if let coremlPath = options.coremlEncoder {
+                    try nemotron.enableCoreMLEncoder(modelURL: resolveURL(path: coremlPath))
+                    if options.verbose { print("CoreML/ANE encoder enabled (Nemotron): \(coremlPath)") }
+                } else if options.ane {
+                    try await nemotron.enableCoreMLEncoder(repo: NemotronASRModel.defaultANEEncoderRepo)
+                    if options.verbose { print("ANE encoder enabled (Nemotron): \(NemotronASRModel.defaultANEEncoderRepo)") }
+                }
             }
         }
         #endif

--- a/Tests/NemotronCoreMLEncoderTests.swift
+++ b/Tests/NemotronCoreMLEncoderTests.swift
@@ -26,5 +26,21 @@ struct NemotronCoreMLEncoderTests {
         #expect(ConformerCoreMLEncoder.subsampledLength(frames: 112, subsamplingFactor: 8, step: nemotronStep) == 15)
         #expect(ConformerCoreMLEncoder.subsampledLength(frames: 1, subsamplingFactor: 8, step: nemotronStep) == 1)
     }
+
+    /// The cache-aware **streaming** encoder (4-in/4-out functional model with manual cache
+    /// threading) must also surface a missing model as a thrown error, never a crash — the
+    /// streaming path then stays on MLX.
+    @Test func streamingEncoderThrowsOnMissingModel() {
+        let bogus = URL(fileURLWithPath: "/nonexistent/nemotron_stream_func.mlpackage")
+        #expect(throws: (any Error).self) {
+            _ = try NemotronCoreMLStreamingEncoder(
+                modelURL: bogus, featIn: 128, dModel: 1024, subsamplingFactor: 8,
+                preFrames: 9, newFrames: 112, layers: 24, attnCache: 70, convCache: 8)
+        }
+    }
+
+    // On-ANE run + cache-threading + reset are validated end-to-end via the CLI
+    // (`mlx-audio-swift-stt --stream --coreml-stream-encoder <pkg>`); `swift test` can't load MLX's
+    // metallib, so only the CI-safe structural checks live here.
 }
 #endif

--- a/Tests/NemotronCoreMLEncoderTests.swift
+++ b/Tests/NemotronCoreMLEncoderTests.swift
@@ -1,0 +1,30 @@
+#if canImport(CoreML)
+import Foundation
+import Testing
+
+@testable import MLXAudioSTT
+
+@Suite("Nemotron CoreML Encoder Tests")
+struct NemotronCoreMLEncoderTests {
+    /// The offline Nemotron encoder reuses the generic fixed-shape Conformer CoreML encoder
+    /// (`ConformerCoreMLEncoder`). A missing/invalid model must surface as a thrown error — the
+    /// model then falls back to the MLX encoder — never a crash.
+    @Test func conformerEncoderThrowsOnMissingModel() {
+        let bogus = URL(fileURLWithPath: "/nonexistent/nemotron_enc.mlpackage")
+        #expect(throws: (any Error).self) {
+            _ = try ConformerCoreMLEncoder(
+                modelURL: bogus, featIn: 128, fixedFrames: 1000, subsamplingFactor: 8)
+        }
+    }
+
+    /// Nemotron subsampled-length math (8× dw-striding, pad-before-stride: `floor(L/2)+1`,
+    /// log2(8)=3 times). This differs from Parakeet's `(L-1)/2+1` — e.g. 1000 → 126, not 125 —
+    /// so the shared encoder is given Nemotron's per-stage step.
+    @Test func subsampledLengthMatchesDwStriding() {
+        let nemotronStep: (Int) -> Int = { $0 / 2 + 1 }
+        #expect(ConformerCoreMLEncoder.subsampledLength(frames: 1000, subsamplingFactor: 8, step: nemotronStep) == 126)
+        #expect(ConformerCoreMLEncoder.subsampledLength(frames: 112, subsamplingFactor: 8, step: nemotronStep) == 15)
+        #expect(ConformerCoreMLEncoder.subsampledLength(frames: 1, subsamplingFactor: 8, step: nemotronStep) == 1)
+    }
+}
+#endif

--- a/Tests/ParakeetCoreMLEncoderTests.swift
+++ b/Tests/ParakeetCoreMLEncoderTests.swift
@@ -1,0 +1,41 @@
+#if canImport(CoreML)
+import Foundation
+import Testing
+
+@testable import MLXAudioSTT
+
+@Suite("Parakeet CoreML Encoder Tests")
+struct ParakeetCoreMLEncoderTests {
+    /// The wrapper's output-length math must match `ParakeetModel.computeEncodedLengths`
+    /// (NeMo dw-striding: `floor((L-1)/2)+1`, log2(factor) times).
+    @Test func subsampledLengthMatchesDwStriding() {
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 1000, subsamplingFactor: 8) == 125)
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 995, subsamplingFactor: 8) == 125)
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 128, subsamplingFactor: 8) == 16)
+        #expect(ParakeetCoreMLEncoder.subsampledLength(frames: 1, subsamplingFactor: 8) == 1)
+    }
+
+    /// A missing/invalid `.mlpackage` must surface as a thrown error (the model then falls
+    /// back to the MLX encoder), never a crash.
+    @Test func throwsOnMissingModel() {
+        let bogus = URL(fileURLWithPath: "/nonexistent/parakeet_enc.mlpackage")
+        #expect(throws: (any Error).self) {
+            _ = try ParakeetCoreMLEncoder(
+                modelURL: bogus, featIn: 128, fixedFrames: 1000, subsamplingFactor: 8)
+        }
+    }
+
+    /// Resolving the downloaded encoder picks the `.mlpackage` (or `.mlmodelc`) directory.
+    @Test func findsEncoderPackageInDirectory() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("parakeet-coreml-findtest")
+        try? fm.removeItem(at: base)
+        let pkg = base.appendingPathComponent("enc.mlpackage")
+        try fm.createDirectory(at: pkg, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: base) }
+
+        #expect(ParakeetModel.findEncoderPackage(in: base)?.lastPathComponent == "enc.mlpackage")
+        #expect(ParakeetModel.findEncoderPackage(in: pkg) == nil)  // empty dir → nothing
+    }
+}
+#endif


### PR DESCRIPTION
## Cache-aware streaming CoreML/ANE encoder for Nemotron

Runs the Nemotron 3.5 **streaming** FastConformer encoder on the ANE in `generateStream`
(validated uniform-121 feeding + manual cache threading; the prompt MLP and RNN-T decode stay
in MLX). **8-bit palettized** (~28% faster ANE, transcript word-identical). `--stream --ane`
(auto-download) / `--coreml-stream-encoder`.

This is a **power/thermal** feature, not a speed one — and honestly a *partial* GPU offload:
only the encoder moves to the ANE; the decoder stays on the GPU each chunk. For realtime
streaming the speed-vs-MLX difference is moot (RTF ~45–58×); the value is freeing the GPU for
concurrent work + lower power / cooler for always-on / battery streaming.

The incremental streaming session only runs the MLX encoder, so `--ane --stream` routes through
`generateStream` (where the ANE encoder lives); plain `--stream` keeps the low-latency session.
The fixed-shape ANE model only supports the native chunk, so it gains nothing from the session's
variable-chunk latency ladder anyway.

### Known limitation
On very short clips (≲ 2 s, where the whole utterance sits within one native chunk) the streaming
ANE encoder can drop the leading token (e.g. `Intention` → `Tention`) — a chunk-boundary artifact
of the cache-aware streaming path, not the offline ANE encoder (which transcribes such clips
correctly). It does not appear on normal-length speech. Tracked as follow-up.

> ⚠️ **Stacked on #199 + the offline Nemotron PR.** Diff includes those until they merge.
> Kept as **draft** until then.
