### PR TITLE
Kokoro: fix French nasal vowels dropped by Character tokenization

### DIFF
--- a/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
+++ b/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
@@ -114,7 +114,16 @@ public final class KokoroModel: Module, SpeechGenerationModel, @unchecked Sendab
     // MARK: - Tokenizer
 
     func tokenize(_ text: String) -> [Int] {
-        text.compactMap { config.vocab[String($0)] }
+        // Iterate Unicode scalars, not Characters. Swift's `for ch in String`
+        // returns extended grapheme clusters, which fuse combining marks into
+        // their base character. The IPA lexicon emits French nasal vowels as
+        // base vowel + U+0303 COMBINING TILDE (e.g. "ɔ" + "̃"), which Swift
+        // collapses into a single Character "ɔ̃" that isn't in `config.vocab`
+        // — so `compactMap` silently drops the entire nasal vowel and
+        // "bonjour" comes out as "bjour". Iterating scalars preserves the
+        // base + combining pair as two separate tokens, both of which exist
+        // in the vocab. See https://github.com/Blaizzy/mlx-audio-swift/issues/187
+        text.unicodeScalars.compactMap { config.vocab[String($0)] }
     }
 
     // MARK: - SpeechGenerationModel


### PR DESCRIPTION
## Summary

Fixes #187.

Kokoro's `tokenize` iterated `String` as `Character` (extended grapheme clusters). French IPA nasal vowels from the lexicon are emitted as base vowel + U+0303 COMBINING TILDE (e.g. `ɔ` + `̃`). Swift fuses that into a single `Character` that is not in `config.vocab`, so `compactMap` silently drops the entire nasal — e.g. "bonjour" phonemizes as `b ɔ̃ ʒ u ʁ` but tokenizes as if `ɔ̃` were missing.

Iterate `unicodeScalars` instead so the base vowel and combining mark are looked up independently; both exist in the vocab.

## Test plan

- [ ] Generate French TTS with `voice: "ff_siwis"`, `language: "fr"`, text `"Bonjour"` — nasal `[ɔ̃]` should be audible
- [ ] Spot-check other languages (EN, ES, IT) for regressions
- [ ] `swift test --filter KokoroTTS`


Made with [Cursor](https://cursor.com)