### PR TITLE
feat(voxtral): true incremental streaming for Voxtral Realtime

### DIFF
--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift
@@ -210,7 +210,7 @@ public final class VoxtralRealtimeModel: Module, STTGenerationModel {
     }
 }
 
-private extension VoxtralRealtimeModel {
+extension VoxtralRealtimeModel {
     func numAudioTokens(_ audioLength: Int) -> Int {
         let hop = VoxtralRealtimeConstants.hopLength
         let perTok = VoxtralRealtimeConstants.audioLengthPerToken
@@ -292,28 +292,57 @@ private extension VoxtralRealtimeModel {
         return (mel, nDelay)
     }
 
-    func encodeAndPrefill(
+    /// Encode audio → audio-conditioning rows (`adapterOut`), the per-token span
+    /// (`nAudioTotal`), and the decoder prompt length. Shared by the offline
+    /// (`encodeAndPrefill`) and streaming (`VoxtralRealtimeStreamSession`) paths.
+    /// Causal conv + causal/sliding-window attention make `adapterOut[0..<k]`
+    /// identical whether encoded from a prefix or the full buffer.
+    /// Conv-stem seam: audio → conv-stem frames (`convOut`, the transformer input),
+    /// the per-token span, and the prompt length. Shared by the offline encode and
+    /// the streaming session (which feeds `convOut` incrementally).
+    func convStemForAudio(
         audio: MLXArray,
-        verbose: Bool,
         transcriptionDelayMs: Int?
-    ) -> VoxtralPrefillContext {
-        let start = Date()
-
+    ) -> (convOut: MLXArray, nAudioTotal: Int, promptLength: Int) {
         ensureAdaScales(transcriptionDelayMs: transcriptionDelayMs)
         let (mel, nDelay) = prepareMel(audio, transcriptionDelayMs: transcriptionDelayMs)
 
         let convOut = encoder.convStem(mel)
         let ds = config.encoderArgs.downsampleFactor
         let nAudioTotal = convOut.shape[0] / ds
-
         let promptLength = 1 + config.nLeftPadTokens + nDelay
+        return (convOut, nAudioTotal, promptLength)
+    }
 
+    func encodeAudio(
+        audio: MLXArray,
+        transcriptionDelayMs: Int?
+    ) -> (adapterOut: MLXArray, nAudioTotal: Int, promptLength: Int) {
+        let (convOut, nAudioTotal, promptLength) = convStemForAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
         let adapterOut: MLXArray
         if convOut.shape[0] <= config.encoderArgs.slidingWindow {
             adapterOut = encoder.encodeFull(convOut)
         } else {
             adapterOut = encoder.encodeChunked(convOut)
         }
+        return (adapterOut, nAudioTotal, promptLength)
+    }
+
+    fileprivate func encodeAndPrefill(
+        audio: MLXArray,
+        verbose: Bool,
+        transcriptionDelayMs: Int?
+    ) -> VoxtralPrefillContext {
+        let start = Date()
+
+        let (adapterOut, nAudioTotal, promptLength) = encodeAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        let nDelay = promptLength - 1 - config.nLeftPadTokens
 
         let promptIds = [config.bosTokenId] + Array(
             repeating: config.streamingPadTokenId,
@@ -353,6 +382,12 @@ private extension VoxtralRealtimeModel {
             cache: cache,
             startTime: start
         )
+    }
+
+    /// Token-id → text seam for the streaming session (which lives in another file
+    /// and cannot reach the private `tokenizer`).
+    func decodeStreaming(_ tokenIds: [Int]) -> String {
+        tokenizer?.decode(tokenIds: tokenIds) ?? ""
     }
 
     func sample(logits: MLXArray, temperature: Float) -> Int {

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
@@ -320,6 +320,26 @@ final class VoxtralRealtimeAudioEncoder: Module {
         return downsampleAndProject(encoded)
     }
 
+    /// Feed a block of new conv-stem frames at absolute positions `[startPos, startPos+n)`
+    /// through the transformer with persistent per-layer KV-caches, returning the
+    /// transformer-normed frames (pre-downsample). While the total fed length stays
+    /// `<= slidingWindow` the caches never trim, so the result is bit-identical to
+    /// `encodeFull` over the same prefix — see `VoxtralRealtimeStreamSession`.
+    func encodeIncremental(
+        _ convBlock: MLXArray,
+        startPos: Int,
+        caches: inout [VoxtralRealtimeEncoderKVCache?]
+    ) -> MLXArray {
+        var x = convBlock
+        let positions = MLXArray(startPos..<(startPos + convBlock.shape[0])).asType(.int32)
+        for i in transformerLayers.indices {
+            let next = transformerLayers[i](x, positions: positions, cache: caches[i])
+            x = next.0
+            caches[i] = next.1
+        }
+        return transformerNorm(x)
+    }
+
     func downsampleAndProject(_ encoded: MLXArray) -> MLXArray {
         let seqLen = encoded.shape[0]
         let ds = config.downsampleFactor

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
@@ -1,0 +1,303 @@
+import Foundation
+import MLX
+import MLXAudioCore
+
+// True incremental (online) streaming for Voxtral Realtime.
+//
+// The offline `generate(...)` path encodes the entire audio buffer up front and only
+// then walks the decoder. This session ingests audio *as it arrives* (e.g. 80 ms mic
+// chunks), feeds only newly-frozen conv frames through the transformer encoder with a
+// persistent per-layer KV-cache, maintains the decoder KV-cache, and emits tokens with
+// the model's native transcription delay — O(1) work per chunk.
+//
+// Correctness (WER 0 vs offline):
+//   * conv stem is causal and `prepareMel` right-pads with zeros, so `convOut[0..<k]`
+//     re-derived from a prefix is bit-identical to the offline full encode for every
+//     frozen row k. The only unfrozen row is the trailing partial token (chunk ended
+//     mid-1280-sample-token) — guarded by `frozenGuardTokens`.
+//   * RoPE attention is relative-position invariant, so feeding conv frames in
+//     sliding-window-aligned blocks with the cache RESET at each boundary reproduces
+//     `encodeChunked` (>sw) exactly; a single un-reset block reproduces `encodeFull`
+//     (<=sw). See `feedIncremental`.
+//   * `finish()` reproduces the offline tail zero-pad ⇒ final transcript == generate().
+
+/// Persistent incremental-encoder state carried across `step` calls.
+struct VoxtralRealtimeStreamEncoderState {
+    var caches: [VoxtralRealtimeEncoderKVCache?]
+    var blockBase = 0   // absolute conv-frame index where the current sw-block began
+    var consumed = 0    // conv frames already fed to the transformer
+
+    init(layers: Int) {
+        caches = Array(repeating: nil, count: layers)
+    }
+}
+
+extension VoxtralRealtimeAudioEncoder {
+    /// Feed conv frames `[state.consumed, upTo)` through the transformer incrementally,
+    /// resetting the per-layer caches at each `slidingWindow` boundary so the result is
+    /// bit-identical to offline `encodeFull` (<=sw) / `encodeChunked` (>sw). Returns the
+    /// new transformer-normed frames (pre-downsample).
+    func feedIncremental(
+        _ convOut: MLXArray,
+        upTo: Int,
+        state: inout VoxtralRealtimeStreamEncoderState
+    ) -> MLXArray {
+        let sw = config.slidingWindow
+        var pieces: [MLXArray] = []
+        while state.consumed < upTo {
+            let blockEnd = state.blockBase + sw
+            let end = min(upTo, blockEnd)
+            let block = convOut[state.consumed..<end, 0...]
+            // Block-relative positions: RoPE is relative, so this matches the absolute
+            // positions offline uses within each independent sw-block.
+            let relStart = state.consumed - state.blockBase
+            pieces.append(encodeIncremental(block, startPos: relStart, caches: &state.caches))
+            state.consumed = end
+            if state.consumed == blockEnd {
+                state.caches = Array(repeating: nil, count: transformerLayers.count)
+                state.blockBase = blockEnd
+            }
+        }
+        if pieces.isEmpty { return convOut[0..<0, 0...] }
+        return pieces.count == 1 ? pieces[0] : MLX.concatenated(pieces, axis: 0)
+    }
+}
+
+public final class VoxtralRealtimeStreamSession {
+    /// Text + token ids decoded by a single `step` / `finish` call.
+    public struct Delta {
+        public let text: String
+        public let tokenIds: [Int]
+    }
+
+    private let model: VoxtralRealtimeModel
+    private let temperature: Float
+    private let maxTokens: Int
+    private let transcriptionDelayMs: Int?
+
+    // Only the trailing partial token (chunk ended mid-1280-sample-token) is unfrozen.
+    private let frozenGuardTokens = 1
+
+    private var realAudio: [Float] = []
+    private var encState: VoxtralRealtimeStreamEncoderState
+    private var adapterBuf: MLXArray?
+    private var decCache: [VoxtralRealtimeDecoderKVCache?]?
+    private var lastLogits: MLXArray?
+    private var decPos = 0
+    private var promptLength = 0
+    private var prefilled = false
+    private var done = false
+
+    private var generated: [Int] = []
+    private var emittedText = ""
+
+    public init(
+        model: VoxtralRealtimeModel,
+        temperature: Float = 0.0,
+        maxTokens: Int = 4096,
+        transcriptionDelayMs: Int? = nil
+    ) {
+        self.model = model
+        self.temperature = temperature
+        self.maxTokens = maxTokens
+        self.transcriptionDelayMs = transcriptionDelayMs
+        self.encState = VoxtralRealtimeStreamEncoderState(
+            layers: model.encoder.transformerLayers.count
+        )
+    }
+
+    /// Full transcript decoded so far.
+    public var text: String { emittedText }
+    /// Token ids decoded so far (EOS stripped).
+    public var tokens: [Int] { generated }
+    /// Whether the stream has emitted EOS / hit maxTokens.
+    public var isFinished: Bool { done }
+
+    /// Ingest a chunk of 16 kHz mono samples; returns the text decoded by this call.
+    @discardableResult
+    public func step(_ samples: [Float]) -> Delta {
+        realAudio.append(contentsOf: samples)
+        return advance(final: false)
+    }
+
+    @discardableResult
+    public func step(_ samples: MLXArray) -> Delta {
+        let flat = samples.ndim > 1 ? samples.mean(axis: -1) : samples
+        return step(flat.asType(.float32).asArray(Float.self))
+    }
+
+    /// Flush the tail: reproduces the offline zero-pad so the final transcript equals
+    /// `generate(...)`. Call once after the last `step`.
+    @discardableResult
+    public func finish() -> Delta {
+        advance(final: true)
+    }
+
+    private func advance(final: Bool) -> Delta {
+        guard !done else { return Delta(text: "", tokenIds: []) }
+        guard !realAudio.isEmpty else { return Delta(text: "", tokenIds: []) }
+
+        let ds = model.config.encoderArgs.downsampleFactor
+        let audio = MLXArray(realAudio)
+        let (convOut, nAudioTotal, pLen) = model.convStemForAudio(
+            audio: audio,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+        promptLength = pLen
+
+        let realRegion = model.config.nLeftPadTokens + model.numAudioTokens(realAudio.count)
+        let emitLimit = final ? nAudioTotal : max(0, min(nAudioTotal, realRegion - frozenGuardTokens))
+        let convFreeze = min(convOut.shape[0], emitLimit * ds)
+
+        if convFreeze > encState.consumed {
+            let newEnc = model.encoder.feedIncremental(convOut, upTo: convFreeze, state: &encState)
+            let rows = model.encoder.downsampleAndProject(newEnc)   // multiple-of-ds ⇒ whole rows
+            adapterBuf = adapterBuf == nil ? rows : MLX.concatenated([adapterBuf!, rows], axis: 0)
+            freezeEncoderState()
+        }
+
+        guard let adapter = adapterBuf else {
+            Memory.clearCache()
+            return Delta(text: "", tokenIds: [])
+        }
+        prefillIfNeeded(adapter: adapter)
+        let delta = decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
+
+        Memory.clearCache()
+        return delta
+    }
+
+    /// Materialise the adapter buffer + encoder caches so the lazy graph stays bounded
+    /// across chunks (each chunk would otherwise extend one unbroken graph).
+    private func freezeEncoderState() {
+        var arrays: [MLXArray] = []
+        if let adapterBuf { arrays.append(adapterBuf) }
+        for cache in encState.caches {
+            if let cache { arrays.append(cache.keys); arrays.append(cache.values) }
+        }
+        if !arrays.isEmpty { MLX.eval(arrays) }
+    }
+
+    private func prefillIfNeeded(adapter: MLXArray) {
+        guard !prefilled, adapter.shape[0] >= promptLength else { return }
+
+        let nLeft = model.config.nLeftPadTokens
+        let nDelay = promptLength - 1 - nLeft
+        let promptIds = [model.config.bosTokenId]
+            + Array(repeating: model.config.streamingPadTokenId, count: nLeft + nDelay)
+        let promptIdsMX = MLXArray(promptIds.map(Int32.init))
+        let promptTextEmbeds = model.decoder.embedTokens(promptIdsMX)
+
+        let prefixEmbeds = adapter[0..<promptLength, 0...] + promptTextEmbeds
+        let prefill = model.decoder(prefixEmbeds, startPos: 0, cache: nil)
+        lastLogits = model.decoder.logits(prefill.0[prefill.0.shape[0] - 1])
+        decCache = prefill.1
+        decPos = promptLength
+        prefilled = true
+        MLX.eval(lastLogits!)
+    }
+
+    private func decode(adapter: MLXArray, upTo emitLimit: Int) -> Delta {
+        guard prefilled else { return Delta(text: "", tokenIds: []) }
+
+        var newIds: [Int] = []
+        // Mirrors the offline `generate` loop exactly (append → check → pop trailing
+        // EOS) so the streamed token stream is identical at temperature 0.
+        while decPos < emitLimit {
+            guard let logits = lastLogits else { break }
+            let token = model.sample(logits: logits, temperature: temperature)
+            generated.append(token)
+
+            if token == model.config.eosTokenId || generated.count > maxTokens {
+                done = true
+                if generated.last == model.config.eosTokenId { generated.removeLast() }
+                break
+            }
+            newIds.append(token)
+
+            let tokenEmbed = model.decoder.embedToken(tokenId: token)
+            let inputEmbed = decPos < adapter.shape[0]
+                ? adapter[decPos] + tokenEmbed
+                : tokenEmbed
+            let next = model.decoder(
+                inputEmbed.expandedDimensions(axis: 0),
+                startPos: decPos,
+                cache: decCache
+            )
+            decCache = next.1
+            lastLogits = model.decoder.logits(next.0[0])
+            decPos += 1
+            MLX.eval(lastLogits!)
+        }
+
+        let textSoFar = model.decodeStreaming(generated)
+        let delta: String
+        if textSoFar.hasPrefix(emittedText) {
+            delta = String(textSoFar.dropFirst(emittedText.count))
+        } else {
+            delta = textSoFar
+        }
+        emittedText = textSoFar
+        return Delta(text: delta, tokenIds: newIds)
+    }
+}
+
+public extension VoxtralRealtimeModel {
+    /// Create an online streaming session. Feed audio with `step(_:)`, then `finish()`.
+    func makeStreamSession(
+        temperature: Float = 0.0,
+        maxTokens: Int = 4096,
+        transcriptionDelayMs: Int? = nil
+    ) -> VoxtralRealtimeStreamSession {
+        VoxtralRealtimeStreamSession(
+            model: self,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            transcriptionDelayMs: transcriptionDelayMs
+        )
+    }
+
+    /// Transcribe a whole audio buffer through the online streaming session, feeding
+    /// fixed `chunkMs`-sized chunks as a live caller would — instead of the whole-buffer
+    /// `generateStream`. `onDelta` receives each newly decoded fragment as it is produced
+    /// (use it to render live output); the returned `STTOutput` is the full transcript.
+    func transcribeStreaming(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters = STTGenerateParameters(),
+        chunkMs: Int = 480,
+        onDelta: ((String) -> Void)? = nil
+    ) -> STTOutput {
+        let mono = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        let samples = mono.asType(.float32).asArray(Float.self)
+        let chunk = max(1, 16000 * chunkMs / 1000)
+
+        let session = makeStreamSession(
+            temperature: generationParameters.temperature,
+            maxTokens: generationParameters.maxTokens
+        )
+        let start = CFAbsoluteTimeGetCurrent()
+
+        func emit(_ delta: VoxtralRealtimeStreamSession.Delta) {
+            guard !delta.text.isEmpty else { return }
+            onDelta?(delta.text)
+        }
+        var idx = 0
+        while idx < samples.count {
+            let end = min(idx + chunk, samples.count)
+            emit(session.step(Array(samples[idx..<end])))
+            idx = end
+        }
+        emit(session.finish())
+
+        let totalTime = CFAbsoluteTimeGetCurrent() - start
+        let tokenCount = session.tokens.count
+        return STTOutput(
+            text: session.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            language: generationParameters.language,
+            generationTokens: tokenCount,
+            totalTokens: tokenCount,
+            generationTps: totalTime > 0 ? Double(tokenCount) / totalTime : 0,
+            totalTime: totalTime
+        )
+    }
+}

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -363,6 +363,13 @@ enum App {
         audio: MLXArray,
         parameters: STTGenerateParameters
     ) async throws -> STTOutput {
+        // Voxtral Realtime has a true online streaming session — feed audio as it
+        // arrives (480 ms chunks ~ the model's native transcription delay) instead of
+        // the whole-buffer `generateStream`.
+        if let voxtral = model as? VoxtralRealtimeModel {
+            return runVoxtralStreaming(model: voxtral, audio: audio, parameters: parameters)
+        }
+
         var finalOutput: STTOutput?
         var streamedText = ""
         var emittedToken = false
@@ -390,6 +397,24 @@ enum App {
         }
 
         return STTOutput(text: streamedText.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Drive Voxtral's streaming transcription from a file, printing each delta live.
+    /// The chunked-feed logic lives in `VoxtralRealtimeModel.transcribeStreaming` so other
+    /// callers can reuse it; the CLI only renders the deltas.
+    private static func runVoxtralStreaming(
+        model: VoxtralRealtimeModel,
+        audio: MLXArray,
+        parameters: STTGenerateParameters
+    ) -> STTOutput {
+        var emitted = false
+        let output = model.transcribeStreaming(audio: audio, generationParameters: parameters) { delta in
+            emitted = true
+            print(delta, terminator: "")
+            fflush(stdout)
+        }
+        if emitted { print() }
+        return output
     }
 
     private static func loadModel(repo: String) async throws -> LoadedModel {

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -2849,6 +2849,91 @@ struct VoxtralRealtimeSTTTests {
         #expect(output.totalTokens == output.promptTokens)
         #expect(output.text == "")
     }
+
+    @Test func streamSessionMatchesOfflineOnFixture() throws {
+        let fixtureDir = try Self.makeEOSFixture()
+        defer { try? FileManager.default.removeItem(at: fixtureDir) }
+
+        let model = try VoxtralRealtimeModel.fromDirectory(fixtureDir)
+        let samples = Array(repeating: Float(0), count: 16000)
+        let params = STTGenerateParameters(maxTokens: 8, temperature: 0.0)
+
+        let offline = model.generate(audio: MLXArray(samples), generationParameters: params)
+
+        // Feed the identical audio in 80 ms (1280-sample) chunks through the online path.
+        let session = model.makeStreamSession(maxTokens: 8)
+        var idx = 0
+        while idx < samples.count {
+            let end = min(idx + 1280, samples.count)
+            _ = session.step(Array(samples[idx..<end]))
+            idx = end
+        }
+        _ = session.finish()
+
+        // Online transcript must equal the offline transcript (WER 0).
+        #expect(session.text == offline.text)
+        #expect(session.tokens.count == offline.generationTokens)
+    }
+
+    /// Minimal all-zero fixture: argmax always lands on the EOS id, so both paths
+    /// terminate immediately and must agree.
+    static func makeEOSFixture() throws -> URL {
+        let fixtureDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voxtral-fixture-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: fixtureDir, withIntermediateDirectories: true)
+
+        let configJSON = """
+        {
+          "model_type": "voxtral_realtime",
+          "encoder_args": {
+            "dim": 16, "n_layers": 0, "n_heads": 2, "head_dim": 8, "hidden_dim": 32,
+            "n_kv_heads": 2, "norm_eps": 1e-5, "rope_theta": 1000000,
+            "sliding_window": 64, "causal": true, "use_biases": true, "downsample_factor": 4
+          },
+          "decoder": {
+            "dim": 16, "n_layers": 0, "n_heads": 2, "n_kv_heads": 2, "head_dim": 8,
+            "hidden_dim": 32, "vocab_size": 8, "norm_eps": 1e-5, "rope_theta": 1000000,
+            "sliding_window": 64, "tied_embeddings": true,
+            "ada_rms_norm_t_cond": false, "ada_rms_norm_t_cond_dim": 4
+          },
+          "audio_encoding_args": {
+            "sampling_rate": 16000, "frame_rate": 12.5, "num_mel_bins": 128,
+            "hop_length": 160, "window_size": 400, "global_log_mel_max": 1.5
+          },
+          "transcription_delay_ms": 0, "bos_token_id": 1, "eos_token_id": 0,
+          "streaming_pad_token_id": 2, "n_left_pad_tokens": 1
+        }
+        """
+        try configJSON.write(
+            to: fixtureDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        let tekkenJSON = """
+        {
+          "vocab": [
+            {"token_bytes":"YQ=="},{"token_bytes":"Yg=="},{"token_bytes":"Yw=="},
+            {"token_bytes":"ZA=="},{"token_bytes":"ZQ=="},{"token_bytes":"Zg=="},
+            {"token_bytes":"Zw=="},{"token_bytes":"aA=="}
+          ],
+          "config":{"default_num_special_tokens":0},"special_tokens":[]
+        }
+        """
+        try tekkenJSON.write(
+            to: fixtureDir.appendingPathComponent("tekken.json"), atomically: true, encoding: .utf8)
+
+        let weights: [String: MLXArray] = [
+            "encoder.conv_layers_0_conv.conv.weight": MLXArray.zeros([16, 3, 128], type: Float.self),
+            "encoder.conv_layers_0_conv.conv.bias": MLXArray.zeros([16], type: Float.self),
+            "encoder.conv_layers_1_conv.conv.weight": MLXArray.zeros([16, 3, 16], type: Float.self),
+            "encoder.conv_layers_1_conv.conv.bias": MLXArray.zeros([16], type: Float.self),
+            "encoder.transformer_norm.weight": MLXArray.ones([16], type: Float.self),
+            "encoder.audio_language_projection_0.weight": MLXArray.zeros([16, 64], type: Float.self),
+            "encoder.audio_language_projection_2.weight": MLXArray.zeros([16, 16], type: Float.self),
+            "decoder.tok_embeddings.weight": MLXArray.zeros([8, 16], type: Float.self),
+            "decoder.norm.weight": MLXArray.ones([16], type: Float.self),
+        ]
+        try MLX.save(arrays: weights, url: fixtureDir.appendingPathComponent("model.safetensors"))
+        return fixtureDir
+    }
 }
 
 @Suite("FireRed ASR 2 Tests", .serialized)


### PR DESCRIPTION
## Summary

`VoxtralRealtimeModel` ran the **"Realtime"** model **offline**: `generateStream` consumed the whole audio buffer up front (`encodeAndPrefill`) and only then yielded the finished transcript token-by-token. This adds a genuine **online** path — feed audio as it arrives, emit tokens at the model's native transcription delay, O(1) work per chunk.

## What's added

- **`VoxtralRealtimeStreamSession`** (`model.makeStreamSession()` → `step(samples)` / `finish()`): ingests audio incrementally, feeds only newly-frozen conv frames through the transformer encoder with a **persistent per-layer KV-cache**, maintains the decoder KV-cache across calls, emits tokens at the native delay.
- **Incremental encoder** (`encodeIncremental` + sliding-window-aligned block feeding): the key trick is that **RoPE is relative-position invariant**, so feeding conv frames in `sliding_window`-aligned blocks with a **cache reset at each boundary** is bit-exact to both `encodeFull` (≤sw) and `encodeChunked` (>sw) in a single path. Adds a shared `convStemForAudio` / `encodeAudio` seam used by offline + streaming.
- **CLI**: `mlx-audio-swift-stt --stream` routes Voxtral through the session (feeds 480 ms chunks, prints deltas live).
- **Fixture parity test** (compile-guarded — `swift test` can't load the MLX metallib in-sandbox, so MLX runtime verification is done via an executable harness).

## Correctness (WER 0 vs offline)

- The decode loop is already per-audio-token (`inputEmbed = adapterOut[pos] + tokenEmbed`); only `adapterOut` (encoder output) was offline-in-one-shot.
- Conv stem is causal and `prepareMel` right-pads with zeros ⇒ prefix conv frames are frozen (only the trailing partial token is guarded).
- `finish()` reproduces the offline tail zero-pad ⇒ final transcript equals `generate()`.

## Validation (4-bit model, memory-capped 18 GB, M-series)

| Clip | WER vs offline | RTF | per-chunk | realtime |
|---|---|---|---|---|
| intention (1.5 s) | **0.0000** | 1.26 | max 0.452 s | ✅ (cold-start bound) |
| conversational_a (13.26 s) | **0.0000** | **0.649** | median 0.285 s, max 0.455 s (budget 0.480) | ✅ end-to-end + steady-state |

Transcript is bit-identical to `generate()` on both clips.

## Files
- `Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift` (new)
- `Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift` (+`encodeIncremental`)
- `Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift` (`encodeAudio`/`convStemForAudio` seams)
- `Sources/Tools/mlx-audio-swift-stt/App.swift` (Voxtral `--stream`)
- `Tests/MLXAudioSTTTests.swift` (fixture parity test)

## Test plan
- `swift build` ✅ · `swift build --build-tests` ✅
- `mlx-audio-swift-stt --model mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit --audio <clip> --stream` → streams transcript, realtime.

## Follow-ups (not in this PR)
- Incremental conv-stem (raw-sample tail + causal conv caches) to cap per-chunk cost on *minutes*-long streams.
- Expose `--stream-chunk-ms` as a CLI flag (currently 480 ms).