### PR TITLE
Add Irodori-TTS (Japanese flow-matching TTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MLXAudio follows a modular design allowing you to import only what you need:
 
 - **MLXAudioCore**: Base types, protocols, and utilities
 - **MLXAudioCodecs**: Audio codec implementations (SNAC, Encodec, Vocos, Mimi, DACVAE)
-- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, Fish Audio S2 Pro, Soprano, VyvoTTS, Orpheus, Marvis TTS, Pocket TTS)
+- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, Fish Audio S2 Pro, Soprano, VyvoTTS, Orpheus, Marvis TTS, Pocket TTS, Irodori TTS)
 - **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Voxtral Realtime, Cohere Transcribe, Parakeet, Nemotron ASR, GLMASR)
 - **MLXAudioVAD**: Voice Activity Detection & Speaker Diarization (Sortformer, SmartTurn)
 - **MLXAudioSTS**: Speech-to-Speech models (LFM2.5-Audio, SAM-Audio, MossFormer2-SE, DeepFilterNet)
@@ -126,6 +126,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 | MOSS-TTS | [MOSS-TTS README](Sources/MLXAudioTTS/Models/MossTTS/README.md) | [OpenMOSS-Team/MOSS-TTS](https://huggingface.co/OpenMOSS-Team/MOSS-TTS), [OpenMOSS-Team/MOSS-TTSD-v1.0](https://huggingface.co/OpenMOSS-Team/MOSS-TTSD-v1.0), [OpenMOSS-Team/MOSS-TTS-Local-Transformer](https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Local-Transformer) |
 | Marvis TTS | [Marvis TTS README](Sources/MLXAudioTTS/Models/Marvis/README.md) | [Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit](https://huggingface.co/Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit) |
 | Pocket TTS | [Pocket TTS README](Sources/MLXAudioTTS/Models/PocketTTS/README.md) | [mlx-community/pocket-tts](https://huggingface.co/mlx-community/pocket-tts) |
+| Irodori TTS | [Irodori TTS README](Sources/MLXAudioTTS/Models/IrodoriTTS/README.md) | [mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit) |
 
 ### STT Models
 

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriDiT.swift
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriDiT.swift
@@ -1,0 +1,961 @@
+import Foundation
+import MLX
+import MLXAudioCore
+import MLXNN
+
+// MARK: - Irodori DiT (MLX Swift port of mlx_audio/tts/models/irodori_tts/model.py)
+//
+// Reuses Echo TTS primitives where the math and weight keys are identical:
+//   EchoRMSNorm == RMSNorm, EchoLowRankAdaLN == LowRankAdaLN, EchoMLP == SwiGLU,
+//   EchoSelfAttention == SelfAttention (non-causal), EchoEncoderTransformerBlock == TextBlock,
+//   echoTtsPrecomputeFreqsCis / echoTtsApplyRotaryEmb / echoTtsTimestepEmbedding.
+
+typealias IrodoriKVCache = (keys: MLXArray, values: MLXArray)
+
+// MARK: - Helpers
+
+/// Convert boolean mask (B, Sq, Sk) to additive float mask (B, 1, Sq, Sk).
+func irodoriBoolToAdditiveMask(_ mask: MLXArray) -> MLXArray {
+    let zero = MLXArray.zeros(mask.shape, dtype: .float32)
+    let negInf = MLXArray.full(mask.shape, values: MLXArray(-1e9), dtype: .float32)
+    return MLX.where(mask, zero, negInf).expandedDimensions(axis: 1)
+}
+
+/// Patch along the sequence axis.
+///   seq  : (B, S, D)   -> (B, S/patch, D*patch)
+///   mask : (B, S) bool -> (B, S/patch) bool (true iff all tokens in patch are valid)
+func irodoriPatchSequenceWithMask(
+    seq: MLXArray,
+    mask: MLXArray,
+    patchSize: Int
+) -> (MLXArray, MLXArray) {
+    if patchSize <= 1 {
+        return (seq, mask)
+    }
+    let bsz = seq.shape[0]
+    let seqLen = seq.shape[1]
+    let dim = seq.shape[2]
+    let usable = (seqLen / patchSize) * patchSize
+    let patchedSeq = seq[0..., 0..<usable, 0...].reshaped([bsz, usable / patchSize, dim * patchSize])
+    let patchedMask = mask[0..., 0..<usable].reshaped([bsz, usable / patchSize, patchSize])
+    return (patchedSeq, patchedMask.all(axis: -1))
+}
+
+/// Ensure at least one position is valid per batch for attention pooling.
+func irodoriSafeAttentionMask(_ x: MLXArray, _ mask: MLXArray) throws -> (MLXArray, MLXArray) {
+    guard mask.ndim == 2, mask.shape[0] == x.shape[0], mask.shape[1] == x.shape[1] else {
+        throw IrodoriTTSError.generation(
+            "mask must have shape (B, S) matching x, got x=\(x.shape) mask=\(mask.shape)"
+        )
+    }
+    let maskBool = mask.asType(.bool)
+    let hasAny = maskBool.any(axis: 1)
+    if MLX.all(hasAny).item(Bool.self) {
+        return (x, maskBool)
+    }
+    guard x.shape[1] > 0 else {
+        throw IrodoriTTSError.generation("Cannot attention-pool an empty sequence.")
+    }
+    let zeroedX = MLX.where(
+        hasAny.expandedDimensions(axes: [1, 2]),
+        x,
+        MLXArray.zeros(x.shape, dtype: x.dtype)
+    )
+    // Set first position valid for batches with no valid positions
+    let fallback = .!hasAny
+    let firstValid = MLX.concatenated(
+        [MLXArray.ones([x.shape[0], 1], dtype: .bool), maskBool[0..., 1...]],
+        axis: 1
+    )
+    let fixedMask = MLX.where(fallback.expandedDimensions(axis: 1), firstValid, maskBool)
+    return (zeroedX, fixedMask)
+}
+
+// MARK: - Joint attention
+
+/// Joint attention over latent self-tokens, text context, and speaker/caption context.
+/// Half-RoPE: RoPE applied to the first half of attention heads.
+/// speakerCtxDim and/or captionCtxDim may be provided independently;
+/// dual mode (v3 VoiceDesign) sets both.
+final class IrodoriJointAttention: Module {
+    let numHeads: Int
+    let headDim: Int
+    let scale: Float
+    let hasSpeakerCondition: Bool
+    let hasCaptionCondition: Bool
+
+    @ModuleInfo(key: "wq") var wq: Linear
+    @ModuleInfo(key: "wk") var wk: Linear
+    @ModuleInfo(key: "wv") var wv: Linear
+    @ModuleInfo(key: "wk_text") var wkText: Linear
+    @ModuleInfo(key: "wv_text") var wvText: Linear
+    @ModuleInfo(key: "wk_speaker") var wkSpeaker: Linear?
+    @ModuleInfo(key: "wv_speaker") var wvSpeaker: Linear?
+    @ModuleInfo(key: "wk_caption") var wkCaption: Linear?
+    @ModuleInfo(key: "wv_caption") var wvCaption: Linear?
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ModuleInfo(key: "wo") var wo: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: EchoRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: EchoRMSNorm
+
+    init(
+        dim: Int,
+        heads: Int,
+        textCtxDim: Int,
+        speakerCtxDim: Int?,
+        normEps: Float,
+        captionCtxDim: Int?
+    ) throws {
+        precondition(dim % heads == 0, "dim must be divisible by heads")
+        guard speakerCtxDim != nil || captionCtxDim != nil else {
+            throw IrodoriTTSError.generation(
+                "At least one of speakerCtxDim or captionCtxDim must be set"
+            )
+        }
+        self.numHeads = heads
+        self.headDim = dim / heads
+        self.scale = 1 / sqrt(Float(self.headDim))
+        self.hasSpeakerCondition = speakerCtxDim != nil
+        self.hasCaptionCondition = captionCtxDim != nil
+
+        self._wq = ModuleInfo(wrappedValue: Linear(dim, dim, bias: false))
+        self._wk = ModuleInfo(wrappedValue: Linear(dim, dim, bias: false))
+        self._wv = ModuleInfo(wrappedValue: Linear(dim, dim, bias: false))
+        self._wkText = ModuleInfo(wrappedValue: Linear(textCtxDim, dim, bias: false))
+        self._wvText = ModuleInfo(wrappedValue: Linear(textCtxDim, dim, bias: false))
+        self._wkSpeaker = ModuleInfo(wrappedValue: speakerCtxDim.map { Linear($0, dim, bias: false) })
+        self._wvSpeaker = ModuleInfo(wrappedValue: speakerCtxDim.map { Linear($0, dim, bias: false) })
+        self._wkCaption = ModuleInfo(wrappedValue: captionCtxDim.map { Linear($0, dim, bias: false) })
+        self._wvCaption = ModuleInfo(wrappedValue: captionCtxDim.map { Linear($0, dim, bias: false) })
+        self._gate = ModuleInfo(wrappedValue: Linear(dim, dim, bias: false))
+        self._wo = ModuleInfo(wrappedValue: Linear(dim, dim, bias: false))
+        self._qNorm = ModuleInfo(wrappedValue: EchoRMSNorm(shape: [heads, self.headDim], eps: normEps))
+        self._kNorm = ModuleInfo(wrappedValue: EchoRMSNorm(shape: [heads, self.headDim], eps: normEps))
+    }
+
+    /// Apply RoPE to the first half of attention heads only.
+    private func applyRotaryHalf(_ y: MLXArray, freqsCis: EchoTTSRotaryCache) -> MLXArray {
+        let half = y.shape[2] / 2
+        let rotated = echoTtsApplyRotaryEmb(y[0..., 0..., 0..<half, 0...], freqsCis: freqsCis)
+        return MLX.concatenated([rotated, y[0..., 0..., half..., 0...]], axis: 2)
+    }
+
+    func getKVCacheText(_ textState: MLXArray) -> IrodoriKVCache {
+        let bsz = textState.shape[0]
+        let length = textState.shape[1]
+        let keys = kNorm(wkText(textState).reshaped([bsz, length, numHeads, headDim]))
+        let values = wvText(textState).reshaped([bsz, length, numHeads, headDim])
+        return (keys, values)
+    }
+
+    func getKVCacheSpeaker(_ speakerState: MLXArray) throws -> IrodoriKVCache {
+        guard let wkSpeaker, let wvSpeaker else {
+            throw IrodoriTTSError.generation("Speaker condition modules are missing")
+        }
+        let bsz = speakerState.shape[0]
+        let length = speakerState.shape[1]
+        let keys = kNorm(wkSpeaker(speakerState).reshaped([bsz, length, numHeads, headDim]))
+        let values = wvSpeaker(speakerState).reshaped([bsz, length, numHeads, headDim])
+        return (keys, values)
+    }
+
+    func getKVCacheCaption(_ captionState: MLXArray) throws -> IrodoriKVCache {
+        guard let wkCaption, let wvCaption else {
+            throw IrodoriTTSError.generation("Caption condition modules are missing")
+        }
+        let bsz = captionState.shape[0]
+        let length = captionState.shape[1]
+        let keys = kNorm(wkCaption(captionState).reshaped([bsz, length, numHeads, headDim]))
+        let values = wvCaption(captionState).reshaped([bsz, length, numHeads, headDim])
+        return (keys, values)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        textMask: MLXArray,
+        freqsCis: EchoTTSRotaryCache,
+        kvCacheText: IrodoriKVCache,
+        kvCacheSpeaker: IrodoriKVCache?,
+        speakerMask: MLXArray?,
+        kvCacheCaption: IrodoriKVCache?,
+        captionMask: MLXArray?,
+        startPos: Int
+    ) -> MLXArray {
+        let bsz = x.shape[0]
+        let seqLen = x.shape[1]
+
+        var q = wq(x).reshaped([bsz, seqLen, numHeads, headDim])
+        var kSelf = wk(x).reshaped([bsz, seqLen, numHeads, headDim])
+        let vSelf = wv(x).reshaped([bsz, seqLen, numHeads, headDim])
+        let gateValues = gate(x)
+
+        q = qNorm(q)
+        kSelf = kNorm(kSelf)
+
+        let qFreqs = (
+            cos: freqsCis.cos[startPos ..< (startPos + seqLen)],
+            sin: freqsCis.sin[startPos ..< (startPos + seqLen)]
+        )
+        q = applyRotaryHalf(q, freqsCis: qFreqs)
+        kSelf = applyRotaryHalf(kSelf, freqsCis: qFreqs)
+
+        let selfMask = MLXArray.ones([bsz, seqLen], dtype: .bool)
+        var kParts = [kSelf, kvCacheText.keys]
+        var vParts = [vSelf, kvCacheText.values]
+        var maskParts = [selfMask, textMask]
+
+        if let kvCacheSpeaker, let speakerMask {
+            kParts.append(kvCacheSpeaker.keys)
+            vParts.append(kvCacheSpeaker.values)
+            maskParts.append(speakerMask)
+        }
+        if let kvCacheCaption, let captionMask {
+            kParts.append(kvCacheCaption.keys)
+            vParts.append(kvCacheCaption.values)
+            maskParts.append(captionMask)
+        }
+
+        let keys = MLX.concatenated(kParts, axis: 1)
+        let values = MLX.concatenated(vParts, axis: 1)
+        let fullMask = MLX.concatenated(maskParts, axis: 1)
+        let attentionMask = irodoriBoolToAdditiveMask(
+            MLX.broadcast(fullMask.expandedDimensions(axis: 1), to: [bsz, seqLen, fullMask.shape[1]])
+        )
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: q.transposed(0, 2, 1, 3),
+            keys: keys.transposed(0, 2, 1, 3),
+            values: values.transposed(0, 2, 1, 3),
+            scale: scale,
+            mask: attentionMask
+        )
+        let merged = output.transposed(0, 2, 1, 3).reshaped([bsz, seqLen, numHeads * headDim])
+        return wo(merged * sigmoid(gateValues))
+    }
+}
+
+// MARK: - Encoders
+
+/// Text encoder: embedding + non-causal Transformer blocks.
+/// Applies mask zeroing after each block so fully-masked positions stay zero.
+/// Used for both text and caption encoding.
+final class IrodoriTextEncoder: Module {
+    let headDim: Int
+
+    @ModuleInfo(key: "text_embedding") var textEmbedding: Embedding
+    @ModuleInfo(key: "blocks") var blocks: [EchoEncoderTransformerBlock]
+
+    init(
+        vocabSize: Int,
+        dim: Int,
+        heads: Int,
+        numLayers: Int,
+        mlpRatio: Float,
+        normEps: Float
+    ) {
+        self.headDim = dim / heads
+        self._textEmbedding = ModuleInfo(wrappedValue: Embedding(embeddingCount: vocabSize, dimensions: dim))
+        let mlpHidden = Int(Float(dim) * mlpRatio)
+        self._blocks = ModuleInfo(wrappedValue: (0 ..< numLayers).map { _ in
+            EchoEncoderTransformerBlock(
+                modelSize: dim,
+                numHeads: heads,
+                intermediateSize: mlpHidden,
+                isCausal: false,
+                normEps: normEps
+            )
+        })
+    }
+
+    func callAsFunction(_ inputIDs: MLXArray, mask: MLXArray?) -> MLXArray {
+        var x = textEmbedding(inputIDs)
+        let freqs = echoTtsPrecomputeFreqsCis(dim: headDim, end: inputIDs.shape[1])
+        if let mask {
+            let maskF = mask.expandedDimensions(axis: -1).asType(x.dtype)
+            x = x * maskF
+            for block in blocks {
+                x = block(x, mask: mask, freqsCis: freqs)
+                x = x * maskF
+            }
+            return x * maskF
+        } else {
+            for block in blocks {
+                x = block(x, mask: nil, freqsCis: freqs)
+            }
+            return x
+        }
+    }
+}
+
+/// Encoder for reference (speaker) audio latents.
+/// Receives already-patched DACVAE latents: (B, S, latentDim * speakerPatchSize).
+/// Uses non-causal attention (unlike Echo TTS which uses causal).
+final class IrodoriReferenceLatentEncoder: Module {
+    let headDim: Int
+
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "blocks") var blocks: [EchoEncoderTransformerBlock]
+
+    init(
+        inDim: Int,
+        dim: Int,
+        heads: Int,
+        numLayers: Int,
+        mlpRatio: Float,
+        normEps: Float
+    ) {
+        self.headDim = dim / heads
+        self._inProj = ModuleInfo(wrappedValue: Linear(inDim, dim, bias: true))
+        let mlpHidden = Int(Float(dim) * mlpRatio)
+        self._blocks = ModuleInfo(wrappedValue: (0 ..< numLayers).map { _ in
+            EchoEncoderTransformerBlock(
+                modelSize: dim,
+                numHeads: heads,
+                intermediateSize: mlpHidden,
+                isCausal: false,
+                normEps: normEps
+            )
+        })
+    }
+
+    func callAsFunction(_ latent: MLXArray, mask: MLXArray?) -> MLXArray {
+        var x = inProj(latent) / 6
+        let freqs = echoTtsPrecomputeFreqsCis(dim: headDim, end: x.shape[1])
+        if let mask {
+            let maskF = mask.expandedDimensions(axis: -1).asType(x.dtype)
+            x = x * maskF
+            for block in blocks {
+                x = block(x, mask: mask, freqsCis: freqs)
+                x = x * maskF
+            }
+            return x * maskF
+        } else {
+            for block in blocks {
+                x = block(x, mask: nil, freqsCis: freqs)
+            }
+            return x
+        }
+    }
+}
+
+// MARK: - Diffusion block
+
+/// Single DiT block: JointAttention + SwiGLU, both conditioned via LowRankAdaLN.
+final class IrodoriDiffusionBlock: Module {
+    @ModuleInfo(key: "attention") var attention: IrodoriJointAttention
+    @ModuleInfo(key: "mlp") var mlp: EchoMLP
+    @ModuleInfo(key: "attention_adaln") var attentionAdaLN: EchoLowRankAdaLN
+    @ModuleInfo(key: "mlp_adaln") var mlpAdaLN: EchoLowRankAdaLN
+
+    init(
+        dim: Int,
+        heads: Int,
+        mlpHiddenDim: Int,
+        textCtxDim: Int,
+        speakerCtxDim: Int?,
+        adalnRank: Int,
+        normEps: Float,
+        captionCtxDim: Int?
+    ) throws {
+        self._attention = ModuleInfo(wrappedValue: try IrodoriJointAttention(
+            dim: dim,
+            heads: heads,
+            textCtxDim: textCtxDim,
+            speakerCtxDim: speakerCtxDim,
+            normEps: normEps,
+            captionCtxDim: captionCtxDim
+        ))
+        self._mlp = ModuleInfo(wrappedValue: EchoMLP(modelSize: dim, intermediateSize: mlpHiddenDim))
+        self._attentionAdaLN = ModuleInfo(wrappedValue: EchoLowRankAdaLN(modelSize: dim, rank: adalnRank, eps: normEps))
+        self._mlpAdaLN = ModuleInfo(wrappedValue: EchoLowRankAdaLN(modelSize: dim, rank: adalnRank, eps: normEps))
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        condEmbed: MLXArray,
+        textMask: MLXArray,
+        freqsCis: EchoTTSRotaryCache,
+        kvCacheText: IrodoriKVCache,
+        kvCacheSpeaker: IrodoriKVCache?,
+        speakerMask: MLXArray?,
+        kvCacheCaption: IrodoriKVCache?,
+        captionMask: MLXArray?,
+        startPos: Int
+    ) -> MLXArray {
+        let (attentionInput, attentionGate) = attentionAdaLN(x, condEmbed: condEmbed)
+        let attended = attention(
+            attentionInput,
+            textMask: textMask,
+            freqsCis: freqsCis,
+            kvCacheText: kvCacheText,
+            kvCacheSpeaker: kvCacheSpeaker,
+            speakerMask: speakerMask,
+            kvCacheCaption: kvCacheCaption,
+            captionMask: captionMask,
+            startPos: startPos
+        )
+        let withAttention = x + attentionGate * attended
+
+        let (mlpInput, mlpGate) = mlpAdaLN(withAttention, condEmbed: condEmbed)
+        return withAttention + mlpGate * mlp(mlpInput)
+    }
+}
+
+// MARK: - Duration predictor (v3, token-sum architectures)
+
+/// SwiGLU block with optional AdaRN-Zero modulation for the duration predictor.
+/// Supports dual modulation (speaker + caption) added together, matching
+/// the token_sum_dual_adarn_zero_no_aux architecture.
+final class IrodoriDurationSwiGLUBlock: Module {
+    @ModuleInfo(key: "norm") var norm: EchoRMSNorm
+    @ModuleInfo(key: "mlp") var mlp: EchoMLP
+    @ModuleInfo(key: "modulation") var modulation: Linear?
+    @ModuleInfo(key: "caption_modulation") var captionModulation: Linear?
+
+    init(
+        dim: Int,
+        hiddenDim: Int,
+        normEps: Float,
+        condDim: Int?,
+        captionCondDim: Int?
+    ) {
+        self._norm = ModuleInfo(wrappedValue: EchoRMSNorm(dimensions: dim, eps: normEps))
+        self._mlp = ModuleInfo(wrappedValue: EchoMLP(modelSize: dim, intermediateSize: hiddenDim))
+        self._modulation = ModuleInfo(wrappedValue: condDim.map { Linear($0, dim * 3, bias: true) })
+        self._captionModulation = ModuleInfo(wrappedValue: captionCondDim.map { Linear($0, dim * 3, bias: true) })
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        cond: MLXArray?,
+        captionCond: MLXArray?
+    ) throws -> MLXArray {
+        var h = norm(x)
+        guard modulation != nil || captionModulation != nil else {
+            return x + mlp(h)
+        }
+
+        var shift = MLXArray.zeros(h.shape, dtype: h.dtype)
+        var scale = MLXArray.zeros(h.shape, dtype: h.dtype)
+        var gateAccum = MLXArray.zeros(h.shape, dtype: h.dtype)
+
+        if let modulation {
+            guard let cond else {
+                throw IrodoriTTSError.generation("cond is required for AdaRN-Zero duration blocks.")
+            }
+            var parts = modulation(silu(cond)).split(parts: 3, axis: -1)
+            if h.ndim == 3, parts[0].ndim == 2 {
+                parts = parts.map { $0.expandedDimensions(axis: 1) }
+            }
+            shift = shift + parts[0]
+            scale = scale + parts[1]
+            gateAccum = gateAccum + parts[2]
+        }
+        if let captionModulation {
+            guard let captionCond else {
+                throw IrodoriTTSError.generation("captionCond is required for caption AdaRN-Zero blocks.")
+            }
+            var parts = captionModulation(silu(captionCond)).split(parts: 3, axis: -1)
+            if h.ndim == 3, parts[0].ndim == 2 {
+                parts = parts.map { $0.expandedDimensions(axis: 1) }
+            }
+            shift = shift + parts[0]
+            scale = scale + parts[1]
+            gateAccum = gateAccum + parts[2]
+        }
+
+        h = h * (scale + 1) + shift
+        return x + tanh(gateAccum) * mlp(h)
+    }
+}
+
+/// Duration predictor that regresses log1p(num_frames) from text state.
+///
+/// Only the token-sum architectures are ported (the v3 defaults):
+///   - token_sum_adarn_zero_no_aux (speaker-only)
+///   - token_sum_dual_adarn_zero_no_aux (speaker + caption, v3 VoiceDesign)
+/// The legacy pooled architectures throw at init.
+final class IrodoriDurationPredictor: Module {
+    let textDim: Int
+    let auxDim: Int
+    let speakerDim: Int?
+    let captionDim: Int?
+    let architecture: String
+
+    @ParameterInfo(key: "null_speaker") var nullSpeaker: MLXArray?
+    @ParameterInfo(key: "null_caption") var nullCaption: MLXArray?
+    @ModuleInfo(key: "token_input_proj") var tokenInputProj: Linear
+    @ModuleInfo(key: "token_blocks") var tokenBlocks: [IrodoriDurationSwiGLUBlock]
+    @ModuleInfo(key: "token_out_norm") var tokenOutNorm: EchoRMSNorm
+    @ModuleInfo(key: "token_out_proj") var tokenOutProj: Linear
+
+    init(
+        textDim: Int,
+        auxDim: Int,
+        hiddenDim: Int,
+        layers: Int,
+        normEps: Float,
+        speakerDim: Int?,
+        captionDim: Int?,
+        architecture: String,
+        tokenInitFrames: Float
+    ) throws {
+        guard architecture == "token_sum_adarn_zero_no_aux"
+            || architecture == "token_sum_dual_adarn_zero_no_aux"
+        else {
+            throw IrodoriTTSError.generation(
+                "Unsupported duration architecture: \(architecture). "
+                    + "Only token-sum architectures are ported."
+            )
+        }
+        let isDual = architecture == "token_sum_dual_adarn_zero_no_aux"
+
+        self.textDim = textDim
+        self.auxDim = auxDim
+        self.speakerDim = speakerDim
+        self.captionDim = captionDim
+        self.architecture = architecture
+
+        self._nullSpeaker = ParameterInfo(wrappedValue: speakerDim.map { MLXArray.zeros([$0]) })
+        self._nullCaption = ParameterInfo(wrappedValue: captionDim.map { MLXArray.zeros([$0]) })
+
+        self._tokenInputProj = ModuleInfo(wrappedValue: Linear(textDim, hiddenDim, bias: true))
+        self._tokenBlocks = ModuleInfo(wrappedValue: (0 ..< layers).map { _ in
+            IrodoriDurationSwiGLUBlock(
+                dim: hiddenDim,
+                hiddenDim: hiddenDim,
+                normEps: normEps,
+                condDim: speakerDim,
+                captionCondDim: isDual ? captionDim : nil
+            )
+        })
+        self._tokenOutNorm = ModuleInfo(wrappedValue: EchoRMSNorm(dimensions: hiddenDim, eps: normEps))
+        self._tokenOutProj = ModuleInfo(wrappedValue: Linear(hiddenDim, 1, bias: true))
+    }
+
+    private func speakerVec(
+        batchSize: Int,
+        dtype: DType,
+        speakerState: MLXArray?,
+        hasSpeaker: MLXArray
+    ) throws -> MLXArray {
+        guard let nullSpeaker, let speakerDim else {
+            throw IrodoriTTSError.generation("Duration speaker modules are missing.")
+        }
+        let nullVec = MLX.broadcast(
+            nullSpeaker.asType(dtype).expandedDimensions(axis: 0),
+            to: [batchSize, speakerDim]
+        )
+        guard let speakerState else { return nullVec }
+        let vec = speakerState[0..., 0, 0...].asType(dtype)
+        return MLX.where(hasSpeaker.expandedDimensions(axis: 1), vec, nullVec)
+    }
+
+    private func captionVec(
+        batchSize: Int,
+        dtype: DType,
+        captionState: MLXArray?,
+        captionMask: MLXArray?,
+        hasCaption: MLXArray
+    ) throws -> MLXArray {
+        guard let nullCaption, let captionDim else {
+            throw IrodoriTTSError.generation("Duration caption modules are missing.")
+        }
+        let nullVec = MLX.broadcast(
+            nullCaption.asType(dtype).expandedDimensions(axis: 0),
+            to: [batchSize, captionDim]
+        )
+        guard let captionState else { return nullVec }
+        let state = captionState.asType(dtype)
+        let vec: MLXArray
+        if let captionMask {
+            let maskF = captionMask.expandedDimensions(axis: -1).asType(dtype)
+            let denom = MLX.maximum(maskF.sum(axis: 1), MLXArray(1.0).asType(dtype))
+            vec = (state * maskF).sum(axis: 1) / denom
+        } else {
+            vec = state.mean(axis: 1)
+        }
+        return MLX.where(hasCaption.expandedDimensions(axis: 1), vec, nullVec)
+    }
+
+    func callAsFunction(
+        textState rawTextState: MLXArray,
+        textMask rawTextMask: MLXArray,
+        auxFeatures: MLXArray,
+        speakerState: MLXArray?,
+        hasSpeaker: MLXArray?,
+        captionState: MLXArray?,
+        captionMask: MLXArray?,
+        hasCaption: MLXArray?
+    ) throws -> MLXArray {
+        guard rawTextState.ndim == 3, rawTextState.shape[2] == textDim else {
+            throw IrodoriTTSError.generation(
+                "textState must have shape (B, S, \(textDim)), got \(rawTextState.shape)"
+            )
+        }
+        guard auxFeatures.ndim == 2, auxFeatures.shape[1] == auxDim else {
+            throw IrodoriTTSError.generation(
+                "auxFeatures must have shape (B, \(auxDim)), got \(auxFeatures.shape)"
+            )
+        }
+        let (textState, textMask) = try irodoriSafeAttentionMask(rawTextState, rawTextMask)
+        let isDual = architecture == "token_sum_dual_adarn_zero_no_aux"
+
+        guard speakerDim != nil else {
+            throw IrodoriTTSError.generation("Token-sum duration architecture requires speaker modules.")
+        }
+        guard let hasSpeaker else {
+            throw IrodoriTTSError.generation(
+                "hasSpeaker is required for speaker-conditioned duration prediction."
+            )
+        }
+        let speakerVector = try speakerVec(
+            batchSize: textState.shape[0],
+            dtype: textState.dtype,
+            speakerState: speakerState,
+            hasSpeaker: hasSpeaker.asType(.bool)
+        )
+
+        var captionVector: MLXArray?
+        if isDual {
+            guard captionDim != nil else {
+                throw IrodoriTTSError.generation(
+                    "Dual token-sum architecture requires both speaker and caption modules."
+                )
+            }
+            guard let hasCaption else {
+                throw IrodoriTTSError.generation("hasCaption is required for dual duration prediction.")
+            }
+            captionVector = try captionVec(
+                batchSize: textState.shape[0],
+                dtype: textState.dtype,
+                captionState: captionState,
+                captionMask: captionMask,
+                hasCaption: hasCaption.asType(.bool)
+            )
+        }
+
+        var h = tokenInputProj(textState)
+        for block in tokenBlocks {
+            h = try block(h, cond: speakerVector, captionCond: captionVector)
+        }
+        let tokenLogits = tokenOutProj(tokenOutNorm(h)).squeezed(axis: -1)
+        // NOTE: softplus, computed as log(1 + exp(x)) in float32 (matches Python port)
+        let tokenFrames = MLX.log(1 + MLX.exp(tokenLogits.asType(.float32)))
+        let totalFrames = (tokenFrames * textMask.asType(tokenFrames.dtype)).sum(axis: 1)
+        return MLX.log1p(MLX.maximum(totalFrames, MLXArray(Float(0))))
+    }
+}
+
+// MARK: - Main DiT model
+
+/// Irodori-TTS DiT model (Swift port of TextToLatentRFDiT).
+///
+/// Supports speaker-only, caption-only, and dual (v3 VoiceDesign) conditioning.
+/// Input x_t : (B, S, latentDim * latentPatchSize); output v_t : same shape
+/// (velocity prediction for the Rectified Flow ODE).
+public final class IrodoriDiT: Module {
+    let cfg: IrodoriDiTConfig
+    let headDim: Int
+
+    @ModuleInfo(key: "text_encoder") var textEncoder: IrodoriTextEncoder
+    @ModuleInfo(key: "text_norm") var textNorm: EchoRMSNorm
+    @ModuleInfo(key: "speaker_encoder") var speakerEncoder: IrodoriReferenceLatentEncoder?
+    @ModuleInfo(key: "speaker_norm") var speakerNorm: EchoRMSNorm?
+    @ModuleInfo(key: "caption_encoder") var captionEncoder: IrodoriTextEncoder?
+    @ModuleInfo(key: "caption_norm") var captionNorm: EchoRMSNorm?
+    @ModuleInfo(key: "duration_predictor") var durationPredictor: IrodoriDurationPredictor?
+    @ModuleInfo(key: "cond_module") var condModule: EchoSequential
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "blocks") var blocks: [IrodoriDiffusionBlock]
+    @ModuleInfo(key: "out_norm") var outNorm: EchoRMSNorm
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    init(cfg: IrodoriDiTConfig) throws {
+        self.cfg = cfg
+        self.headDim = cfg.modelDim / cfg.numHeads
+
+        self._textEncoder = ModuleInfo(wrappedValue: IrodoriTextEncoder(
+            vocabSize: cfg.textVocabSize,
+            dim: cfg.textDim,
+            heads: cfg.textHeads,
+            numLayers: cfg.textLayers,
+            mlpRatio: cfg.textMlpRatioResolved,
+            normEps: cfg.normEps
+        ))
+        self._textNorm = ModuleInfo(wrappedValue: EchoRMSNorm(dimensions: cfg.textDim, eps: cfg.normEps))
+
+        var speakerCtxDim: Int?
+        var captionCtxDim: Int?
+
+        if cfg.useSpeakerConditionResolved {
+            self._speakerEncoder = ModuleInfo(wrappedValue: IrodoriReferenceLatentEncoder(
+                inDim: cfg.speakerPatchedLatentDim,
+                dim: cfg.speakerDim,
+                heads: cfg.speakerHeads,
+                numLayers: cfg.speakerLayers,
+                mlpRatio: cfg.speakerMlpRatioResolved,
+                normEps: cfg.normEps
+            ))
+            self._speakerNorm = ModuleInfo(wrappedValue: EchoRMSNorm(dimensions: cfg.speakerDim, eps: cfg.normEps))
+            speakerCtxDim = cfg.speakerDim
+        } else {
+            self._speakerEncoder = ModuleInfo(wrappedValue: nil)
+            self._speakerNorm = ModuleInfo(wrappedValue: nil)
+        }
+
+        if cfg.useCaptionCondition {
+            self._captionEncoder = ModuleInfo(wrappedValue: IrodoriTextEncoder(
+                vocabSize: cfg.captionVocabSizeResolved,
+                dim: cfg.captionDimResolved,
+                heads: cfg.captionHeadsResolved,
+                numLayers: cfg.captionLayersResolved,
+                mlpRatio: cfg.captionMlpRatioResolved,
+                normEps: cfg.normEps
+            ))
+            self._captionNorm = ModuleInfo(wrappedValue: EchoRMSNorm(dimensions: cfg.captionDimResolved, eps: cfg.normEps))
+            captionCtxDim = cfg.captionDimResolved
+        } else {
+            self._captionEncoder = ModuleInfo(wrappedValue: nil)
+            self._captionNorm = ModuleInfo(wrappedValue: nil)
+        }
+
+        if cfg.useDurationPredictor {
+            self._durationPredictor = ModuleInfo(wrappedValue: try IrodoriDurationPredictor(
+                textDim: cfg.textDim,
+                auxDim: cfg.durationAuxDim,
+                hiddenDim: cfg.durationHiddenDim,
+                layers: cfg.durationLayers,
+                normEps: cfg.normEps,
+                speakerDim: cfg.useSpeakerConditionResolved ? cfg.speakerDim : nil,
+                captionDim: cfg.useCaptionCondition ? cfg.captionDimResolved : nil,
+                architecture: cfg.durationArchitecture,
+                tokenInitFrames: cfg.durationTokenInitFrames
+            ))
+        } else {
+            self._durationPredictor = ModuleInfo(wrappedValue: nil)
+        }
+
+        self._condModule = ModuleInfo(wrappedValue: EchoSequential([
+            Linear(cfg.timestepEmbedDim, cfg.modelDim, bias: false),
+            SiLU(),
+            Linear(cfg.modelDim, cfg.modelDim, bias: false),
+            SiLU(),
+            Linear(cfg.modelDim, cfg.modelDim * 3, bias: false),
+        ]))
+
+        self._inProj = ModuleInfo(wrappedValue: Linear(cfg.patchedLatentDim, cfg.modelDim, bias: true))
+        let mlpHidden = Int(Float(cfg.modelDim) * cfg.mlpRatio)
+        self._blocks = ModuleInfo(wrappedValue: try (0 ..< cfg.numLayers).map { _ in
+            try IrodoriDiffusionBlock(
+                dim: cfg.modelDim,
+                heads: cfg.numHeads,
+                mlpHiddenDim: mlpHidden,
+                textCtxDim: cfg.textDim,
+                speakerCtxDim: speakerCtxDim,
+                adalnRank: cfg.adalnRank,
+                normEps: cfg.normEps,
+                captionCtxDim: captionCtxDim
+            )
+        })
+        self._outNorm = ModuleInfo(wrappedValue: EchoRMSNorm(dimensions: cfg.modelDim, eps: cfg.normEps))
+        self._outProj = ModuleInfo(wrappedValue: Linear(cfg.modelDim, cfg.patchedLatentDim, bias: true))
+    }
+
+    // MARK: Condition encoding (cached across sampling steps)
+
+    /// Encode all conditions including both speaker and caption states.
+    /// Returns (textState, textMask, speakerState, speakerMask, captionState, captionMask).
+    func encodeConditionsFull(
+        textInputIDs: MLXArray,
+        textMask: MLXArray,
+        refLatent: MLXArray?,
+        refMask: MLXArray?,
+        captionInputIDs: MLXArray?,
+        captionMask: MLXArray?
+    ) -> (
+        textState: MLXArray,
+        textMask: MLXArray,
+        speakerState: MLXArray?,
+        speakerMask: MLXArray?,
+        captionState: MLXArray?,
+        captionMask: MLXArray?
+    ) {
+        let textState = textNorm(textEncoder(textInputIDs, mask: textMask))
+
+        var speakerState: MLXArray?
+        var speakerMaskOut: MLXArray?
+        if cfg.useSpeakerConditionResolved, let speakerEncoder, let speakerNorm {
+            if let refLatent, let refMask {
+                let (refLatentP, refMaskP) = irodoriPatchSequenceWithMask(
+                    seq: refLatent,
+                    mask: refMask,
+                    patchSize: cfg.speakerPatchSize
+                )
+                speakerState = speakerNorm(speakerEncoder(refLatentP, mask: refMaskP))
+                speakerMaskOut = refMaskP
+            } else {
+                // Zero speaker state for duration prediction with no reference
+                speakerState = MLXArray.zeros(
+                    [textInputIDs.shape[0], 1, cfg.speakerDim],
+                    dtype: textState.dtype
+                )
+                speakerMaskOut = MLXArray.zeros([textInputIDs.shape[0], 1], dtype: .bool)
+            }
+        }
+
+        var captionState: MLXArray?
+        var captionMaskOut: MLXArray?
+        if cfg.useCaptionCondition, let captionEncoder, let captionNorm {
+            if let captionInputIDs, let captionMask {
+                captionState = captionNorm(captionEncoder(captionInputIDs, mask: captionMask))
+                captionMaskOut = captionMask
+            }
+        }
+
+        return (textState, textMask, speakerState, speakerMaskOut, captionState, captionMaskOut)
+    }
+
+    /// Pre-compute per-layer text/speaker/caption KV projections for fast sampling.
+    func buildKVCache(
+        textState: MLXArray,
+        speakerState: MLXArray?,
+        captionState: MLXArray?
+    ) throws -> (
+        kvText: [IrodoriKVCache],
+        kvSpeaker: [IrodoriKVCache]?,
+        kvCaption: [IrodoriKVCache]?
+    ) {
+        let kvText = blocks.map { $0.attention.getKVCacheText(textState) }
+        var kvSpeaker: [IrodoriKVCache]?
+        if let speakerState, cfg.useSpeakerConditionResolved {
+            kvSpeaker = try blocks.map { try $0.attention.getKVCacheSpeaker(speakerState) }
+        }
+        var kvCaption: [IrodoriKVCache]?
+        if let captionState, cfg.useCaptionCondition {
+            kvCaption = try blocks.map { try $0.attention.getKVCacheCaption(captionState) }
+        }
+        return (kvText, kvSpeaker, kvCaption)
+    }
+
+    /// Predict log1p(num_frames) from text state and duration features. Returns (B,) float32.
+    func predictDurationLogFrames(
+        textState: MLXArray,
+        textMask: MLXArray,
+        speakerState: MLXArray?,
+        durationFeatures: MLXArray,
+        hasSpeaker: MLXArray?,
+        captionState: MLXArray?,
+        captionMask: MLXArray?,
+        hasCaption: MLXArray?
+    ) throws -> MLXArray {
+        guard let durationPredictor else {
+            throw IrodoriTTSError.generation("Duration predictor is disabled for this model.")
+        }
+        guard durationFeatures.ndim == 2 else {
+            throw IrodoriTTSError.generation(
+                "durationFeatures must have shape (B, D), got \(durationFeatures.shape)"
+            )
+        }
+        guard durationFeatures.shape[1] == cfg.durationAuxDim else {
+            throw IrodoriTTSError.generation(
+                "durationFeatures dim mismatch: expected \(cfg.durationAuxDim), got \(durationFeatures.shape[1])"
+            )
+        }
+        let pred = try durationPredictor(
+            textState: textState,
+            textMask: textMask,
+            auxFeatures: durationFeatures,
+            speakerState: speakerState,
+            hasSpeaker: hasSpeaker,
+            captionState: captionState,
+            captionMask: captionMask,
+            hasCaption: hasCaption
+        )
+        return pred.asType(.float32)
+    }
+
+    // MARK: Forward (with pre-encoded conditions)
+
+    /// Forward pass with pre-encoded conditions.
+    ///
+    /// For speaker-only models: speakerState/Mask carry the speaker context.
+    /// For caption-only models: speakerState/Mask carry the caption context
+    /// (backward-compat; internally routed to the caption branch).
+    /// For dual models (v3 VoiceDesign): speakerState=speaker, captionState=caption.
+    func forwardWithConditions(
+        xT: MLXArray,
+        t: MLXArray,
+        textState: MLXArray,
+        textMask: MLXArray,
+        speakerState: MLXArray?,
+        speakerMask: MLXArray?,
+        kvText: [IrodoriKVCache]? = nil,
+        kvSpeaker: [IrodoriKVCache]? = nil,
+        startPos: Int = 0,
+        captionState: MLXArray? = nil,
+        captionMask: MLXArray? = nil,
+        kvCaption: [IrodoriKVCache]? = nil
+    ) throws -> MLXArray {
+        let tEmbed = echoTtsTimestepEmbedding(t, embedSize: cfg.timestepEmbedDim).asType(xT.dtype)
+        let condEmbed = condModule(tEmbed).expandedDimensions(axis: 1) // (B, 1, 3*modelDim)
+
+        var x = inProj(xT)
+        let freqs = echoTtsPrecomputeFreqsCis(dim: headDim, end: startPos + x.shape[1])
+
+        let useSpk = cfg.useSpeakerConditionResolved
+        let useCap = cfg.useCaptionCondition
+
+        // For caption-only models: speakerState arg carries caption context (backward compat)
+        let actualSpeakerState: MLXArray?
+        let actualSpeakerMask: MLXArray?
+        let actualKVSpeaker: [IrodoriKVCache]?
+        let actualCaptionState: MLXArray?
+        let actualCaptionMask: MLXArray?
+        let actualKVCaption: [IrodoriKVCache]?
+        if !useSpk && useCap {
+            actualCaptionState = captionState ?? speakerState
+            actualCaptionMask = captionMask ?? speakerMask
+            actualKVCaption = kvCaption ?? kvSpeaker
+            actualSpeakerState = nil
+            actualSpeakerMask = nil
+            actualKVSpeaker = nil
+        } else {
+            actualSpeakerState = speakerState
+            actualSpeakerMask = speakerMask
+            actualKVSpeaker = kvSpeaker
+            actualCaptionState = captionState
+            actualCaptionMask = captionMask
+            actualKVCaption = kvCaption
+        }
+
+        for (index, block) in blocks.enumerated() {
+            let kvT = kvText?[index] ?? block.attention.getKVCacheText(textState)
+            var kvS: IrodoriKVCache?
+            if useSpk, let actualSpeakerState {
+                kvS = try actualKVSpeaker?[index]
+                    ?? block.attention.getKVCacheSpeaker(actualSpeakerState)
+            }
+            var kvC: IrodoriKVCache?
+            if useCap, let actualCaptionState {
+                kvC = try actualKVCaption?[index]
+                    ?? block.attention.getKVCacheCaption(actualCaptionState)
+            }
+            x = block(
+                x,
+                condEmbed: condEmbed,
+                textMask: textMask,
+                freqsCis: freqs,
+                kvCacheText: kvT,
+                kvCacheSpeaker: kvS,
+                speakerMask: actualSpeakerMask,
+                kvCacheCaption: kvC,
+                captionMask: actualCaptionMask,
+                startPos: startPos
+            )
+        }
+
+        x = outNorm(x)
+        return outProj(x).asType(.float32)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriDuration.swift
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriDuration.swift
@@ -1,0 +1,117 @@
+import Foundation
+import MLX
+
+// MARK: - Duration features (v3 duration predictor input)
+// Mirrors mlx_audio/tts/models/irodori_tts/duration.py. The predictor NETWORK
+// itself lives with the DiT modules (model.py) — this file builds its 14-dim
+// per-utterance feature vector.
+
+let irodoriAllowedAnnotationEmojis: [String] = [
+    "⏩", "⏱️", "⏸️", "🌬️", "🍭", "🎛️", "🎭", "🎵", "🐢", "🐱", "👂", "👃", "👅",
+    "👌", "👏", "💋", "💥", "💦", "💪", "📄", "📞", "📢", "📣", "😆", "😊", "😌",
+    "😎", "😏", "😒", "😖", "😟", "😠", "😪", "😭", "😮", "😮\u{200D}💨", "😰",
+    "😱", "😲", "😴", "🙄", "🙏", "🤐", "🤔", "🤢", "🤧", "🤭", "🥤", "🥱", "🥴",
+    "🥵", "🥹", "🥺", "🫣", "🫶", "📖",
+]
+
+/// Longest-first matching, mirroring the Python regex alternation order.
+private let irodoriEmojisLongestFirst =
+    irodoriAllowedAnnotationEmojis.sorted { $0.count > $1.count }
+
+func irodoriCountAnnotationEmojis(_ text: String) -> Int {
+    var count = 0
+    var rest = Substring(text)
+    outer: while !rest.isEmpty {
+        for e in irodoriEmojisLongestFirst where rest.hasPrefix(e) {
+            count += 1
+            rest = rest.dropFirst(e.count)
+            continue outer
+        }
+        rest = rest.dropFirst()
+    }
+    return count
+}
+
+private func log1pCap(_ count: Int, _ cap: Int) -> Float {
+    let v = Float(min(max(count, 0), cap))
+    return log1p(v) / log1p(Float(cap))
+}
+
+private func log1pCapFloat(_ value: Float, _ cap: Float) -> Float {
+    let v = min(max(value, 0), cap)
+    return log1p(v) / log1p(cap)
+}
+
+private func isKana(_ s: UnicodeScalar) -> Bool {
+    (0x3040...0x309F).contains(s.value) || (0x30A0...0x30FF).contains(s.value)
+}
+
+private func isKanji(_ s: UnicodeScalar) -> Bool {
+    (0x3400...0x4DBF).contains(s.value) || (0x4E00...0x9FFF).contains(s.value)
+        || (0xF900...0xFAFF).contains(s.value) || (0x20000...0x2FA1F).contains(s.value)
+}
+
+private func isAsciiAlnum(_ s: UnicodeScalar) -> Bool {
+    s.isASCII && ((0x30...0x39).contains(s.value) || (0x41...0x5A).contains(s.value)
+        || (0x61...0x7A).contains(s.value))
+}
+
+private func occurrences(_ text: String, _ needle: Character) -> Int {
+    text.reduce(0) { $0 + ($1 == needle ? 1 : 0) }
+}
+
+/// Build the (B, 14) duration-feature matrix for the v3 duration predictor.
+/// Python counts characters via `len(str)` (scalar-ish); we count unicode scalars
+/// for kana/kanji/alnum and `String.count` for char_count — matching CPython's
+/// code-point semantics closely enough for these capped/normalised features.
+func irodoriBuildDurationFeatures(
+    texts: [String],
+    tokenCounts: [Int],
+    maxTextLen: Int,
+    hasSpeaker: [Bool]
+) -> MLXArray {
+    precondition(texts.count == tokenCounts.count && texts.count == hasSpeaker.count)
+
+    var rows = [Float]()
+    rows.reserveCapacity(texts.count * 14)
+
+    for (i, text) in texts.enumerated() {
+        let tokenCount = tokenCounts[i]
+        let speakerAvailable = hasSpeaker[i]
+
+        let charCount = max(text.unicodeScalars.count, 1)
+        var kana = 0, kanji = 0, alnum = 0
+        for s in text.unicodeScalars {
+            if isKana(s) { kana += 1 }
+            if isKanji(s) { kanji += 1 }
+            if isAsciiAlnum(s) { alnum += 1 }
+        }
+        let emoji = irodoriCountAnnotationEmojis(text)
+
+        let period = occurrences(text, "。") + occurrences(text, ".")
+        let comma = occurrences(text, "、") + occurrences(text, ",")
+        let longVowel = occurrences(text, "ー")
+        let ellipsis = occurrences(text, "…")
+        let exclamation = occurrences(text, "！") + occurrences(text, "!")
+        let question = occurrences(text, "？") + occurrences(text, "?")
+
+        rows.append(contentsOf: [
+            min(max(Float(tokenCount), 0), Float(maxTextLen)) / Float(maxTextLen),
+            log1pCapFloat(Float(charCount), 512),
+            Float(tokenCount) / Float(charCount),
+            log1pCap(period, 8),
+            log1pCap(comma, 16),
+            log1pCap(longVowel, 8),
+            log1pCap(ellipsis, 8),
+            log1pCap(exclamation, 8),
+            log1pCap(question, 8),
+            log1pCap(emoji, 8),
+            Float(kana) / Float(charCount),
+            Float(kanji) / Float(charCount),
+            Float(alnum) / Float(charCount),
+            speakerAvailable ? 1.0 : 0.0,
+        ])
+    }
+
+    return MLXArray(rows).reshaped(texts.count, 14)
+}

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSConfig.swift
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSConfig.swift
@@ -1,0 +1,289 @@
+import Foundation
+
+/// Configuration for Irodori TTS — a flow-matching Japanese TTS (Echo-TTS family)
+/// over continuous Semantic-DACVAE latents (48 kHz).
+/// Mirrors `mlx_audio/tts/models/irodori_tts/config.py`.
+public struct IrodoriDiTConfig: Codable {
+    // Audio latent dimensions (v2/v3: 32-dim Semantic-DACVAE, v1: 128-dim DACVAE)
+    public var latentDim: Int = 32
+    public var latentPatchSize: Int = 1
+
+    // DiT backbone
+    public var modelDim: Int = 1280
+    public var numLayers: Int = 12
+    public var numHeads: Int = 20
+    public var mlpRatio: Float = 2.875
+    public var textMlpRatio: Float? = 2.6
+    public var speakerMlpRatio: Float? = 2.6
+
+    // Text encoder
+    public var textVocabSize: Int = 99_574
+    public var textTokenizerRepo: String = "llm-jp/llm-jp-3-150m"
+    public var textAddBos: Bool = true
+    public var textDim: Int = 512
+    public var textLayers: Int = 10
+    public var textHeads: Int = 8
+
+    // Speaker (reference latent) encoder
+    public var speakerDim: Int = 768
+    public var speakerLayers: Int = 8
+    public var speakerHeads: Int = 12
+    public var speakerPatchSize: Int = 1
+
+    // Conditioning
+    public var timestepEmbedDim: Int = 512
+    public var adalnRank: Int = 192
+    public var normEps: Float = 1e-5
+
+    // Caption (Voice Design) conditioning — can coexist with speaker (v3 VoiceDesign dual mode)
+    public var useCaptionCondition: Bool = false
+    public var useSpeakerCondition: Bool? = nil
+    public var captionVocabSize: Int? = nil
+    public var captionTokenizerRepo: String? = nil
+    public var captionAddBos: Bool? = nil
+    public var captionDim: Int? = nil
+    public var captionLayers: Int? = nil
+    public var captionHeads: Int? = nil
+    public var captionMlpRatio: Float? = nil
+
+    // Duration predictor (v3)
+    public var useDurationPredictor: Bool = false
+    public var durationAuxDim: Int = 14
+    public var durationHiddenDim: Int = 1024
+    public var durationLayers: Int = 3
+    public var durationDropout: Float = 0.1
+    public var durationAttentionHeads: Int = 8
+    public var durationArchitecture: String = "token_sum_adarn_zero_no_aux"
+    public var durationTokenInitFrames: Float = 9.0
+    public var durationSpeakerFusion: String = "adarn_zero"
+    public var durationCaptionFusion: String = "adarn_zero"
+    public var durationCaptionPooling: String = "masked_mean"
+
+    public init() {}
+
+    // MARK: - Resolved properties (mirror config.py)
+
+    public var useSpeakerConditionResolved: Bool {
+        useSpeakerCondition ?? !useCaptionCondition
+    }
+    public var captionVocabSizeResolved: Int { captionVocabSize ?? textVocabSize }
+    public var captionTokenizerRepoResolved: String { captionTokenizerRepo ?? textTokenizerRepo }
+    public var captionAddBosResolved: Bool { captionAddBos ?? textAddBos }
+    public var captionDimResolved: Int { captionDim ?? textDim }
+    public var captionLayersResolved: Int { captionLayers ?? textLayers }
+    public var captionHeadsResolved: Int { captionHeads ?? textHeads }
+    public var captionMlpRatioResolved: Float { captionMlpRatio ?? textMlpRatioResolved }
+    public var patchedLatentDim: Int { latentDim * latentPatchSize }
+    public var speakerPatchedLatentDim: Int { patchedLatentDim * speakerPatchSize }
+    public var textMlpRatioResolved: Float { textMlpRatio ?? mlpRatio }
+    public var speakerMlpRatioResolved: Float { speakerMlpRatio ?? mlpRatio }
+
+    enum CodingKeys: String, CodingKey {
+        case latentDim = "latent_dim"
+        case latentPatchSize = "latent_patch_size"
+        case modelDim = "model_dim"
+        case numLayers = "num_layers"
+        case numHeads = "num_heads"
+        case mlpRatio = "mlp_ratio"
+        case textMlpRatio = "text_mlp_ratio"
+        case speakerMlpRatio = "speaker_mlp_ratio"
+        case textVocabSize = "text_vocab_size"
+        case textTokenizerRepo = "text_tokenizer_repo"
+        case textAddBos = "text_add_bos"
+        case textDim = "text_dim"
+        case textLayers = "text_layers"
+        case textHeads = "text_heads"
+        case speakerDim = "speaker_dim"
+        case speakerLayers = "speaker_layers"
+        case speakerHeads = "speaker_heads"
+        case speakerPatchSize = "speaker_patch_size"
+        case timestepEmbedDim = "timestep_embed_dim"
+        case adalnRank = "adaln_rank"
+        case normEps = "norm_eps"
+        case useCaptionCondition = "use_caption_condition"
+        case useSpeakerCondition = "use_speaker_condition"
+        case captionVocabSize = "caption_vocab_size"
+        case captionTokenizerRepo = "caption_tokenizer_repo"
+        case captionAddBos = "caption_add_bos"
+        case captionDim = "caption_dim"
+        case captionLayers = "caption_layers"
+        case captionHeads = "caption_heads"
+        case captionMlpRatio = "caption_mlp_ratio"
+        case useDurationPredictor = "use_duration_predictor"
+        case durationAuxDim = "duration_aux_dim"
+        case durationHiddenDim = "duration_hidden_dim"
+        case durationLayers = "duration_layers"
+        case durationDropout = "duration_dropout"
+        case durationAttentionHeads = "duration_attention_heads"
+        case durationArchitecture = "duration_architecture"
+        case durationTokenInitFrames = "duration_token_init_frames"
+        case durationSpeakerFusion = "duration_speaker_fusion"
+        case durationCaptionFusion = "duration_caption_fusion"
+        case durationCaptionPooling = "duration_caption_pooling"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        latentDim = try c.decodeIfPresent(Int.self, forKey: .latentDim) ?? 32
+        latentPatchSize = try c.decodeIfPresent(Int.self, forKey: .latentPatchSize) ?? 1
+        modelDim = try c.decodeIfPresent(Int.self, forKey: .modelDim) ?? 1280
+        numLayers = try c.decodeIfPresent(Int.self, forKey: .numLayers) ?? 12
+        numHeads = try c.decodeIfPresent(Int.self, forKey: .numHeads) ?? 20
+        mlpRatio = try c.decodeIfPresent(Float.self, forKey: .mlpRatio) ?? 2.875
+        textMlpRatio = try c.decodeIfPresent(Float.self, forKey: .textMlpRatio) ?? 2.6
+        speakerMlpRatio = try c.decodeIfPresent(Float.self, forKey: .speakerMlpRatio) ?? 2.6
+        textVocabSize = try c.decodeIfPresent(Int.self, forKey: .textVocabSize) ?? 99_574
+        textTokenizerRepo = try c.decodeIfPresent(String.self, forKey: .textTokenizerRepo) ?? "llm-jp/llm-jp-3-150m"
+        textAddBos = try c.decodeIfPresent(Bool.self, forKey: .textAddBos) ?? true
+        textDim = try c.decodeIfPresent(Int.self, forKey: .textDim) ?? 512
+        textLayers = try c.decodeIfPresent(Int.self, forKey: .textLayers) ?? 10
+        textHeads = try c.decodeIfPresent(Int.self, forKey: .textHeads) ?? 8
+        speakerDim = try c.decodeIfPresent(Int.self, forKey: .speakerDim) ?? 768
+        speakerLayers = try c.decodeIfPresent(Int.self, forKey: .speakerLayers) ?? 8
+        speakerHeads = try c.decodeIfPresent(Int.self, forKey: .speakerHeads) ?? 12
+        speakerPatchSize = try c.decodeIfPresent(Int.self, forKey: .speakerPatchSize) ?? 1
+        timestepEmbedDim = try c.decodeIfPresent(Int.self, forKey: .timestepEmbedDim) ?? 512
+        adalnRank = try c.decodeIfPresent(Int.self, forKey: .adalnRank) ?? 192
+        normEps = try c.decodeIfPresent(Float.self, forKey: .normEps) ?? 1e-5
+        useCaptionCondition = try c.decodeIfPresent(Bool.self, forKey: .useCaptionCondition) ?? false
+        useSpeakerCondition = try c.decodeIfPresent(Bool.self, forKey: .useSpeakerCondition)
+        captionVocabSize = try c.decodeIfPresent(Int.self, forKey: .captionVocabSize)
+        captionTokenizerRepo = try c.decodeIfPresent(String.self, forKey: .captionTokenizerRepo)
+        captionAddBos = try c.decodeIfPresent(Bool.self, forKey: .captionAddBos)
+        captionDim = try c.decodeIfPresent(Int.self, forKey: .captionDim)
+        captionLayers = try c.decodeIfPresent(Int.self, forKey: .captionLayers)
+        captionHeads = try c.decodeIfPresent(Int.self, forKey: .captionHeads)
+        captionMlpRatio = try c.decodeIfPresent(Float.self, forKey: .captionMlpRatio)
+        useDurationPredictor = try c.decodeIfPresent(Bool.self, forKey: .useDurationPredictor) ?? false
+        durationAuxDim = try c.decodeIfPresent(Int.self, forKey: .durationAuxDim) ?? 14
+        durationHiddenDim = try c.decodeIfPresent(Int.self, forKey: .durationHiddenDim) ?? 1024
+        durationLayers = try c.decodeIfPresent(Int.self, forKey: .durationLayers) ?? 3
+        durationDropout = try c.decodeIfPresent(Float.self, forKey: .durationDropout) ?? 0.1
+        durationAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .durationAttentionHeads) ?? 8
+        durationArchitecture = try c.decodeIfPresent(String.self, forKey: .durationArchitecture) ?? "token_sum_adarn_zero_no_aux"
+        durationTokenInitFrames = try c.decodeIfPresent(Float.self, forKey: .durationTokenInitFrames) ?? 9.0
+        durationSpeakerFusion = try c.decodeIfPresent(String.self, forKey: .durationSpeakerFusion) ?? "adarn_zero"
+        durationCaptionFusion = try c.decodeIfPresent(String.self, forKey: .durationCaptionFusion) ?? "adarn_zero"
+        durationCaptionPooling = try c.decodeIfPresent(String.self, forKey: .durationCaptionPooling) ?? "masked_mean"
+    }
+}
+
+public struct IrodoriSamplerConfig: Codable {
+    public var numSteps: Int = 40
+    public var cfgScaleText: Float = 3.0
+    public var cfgScaleSpeaker: Float = 5.0
+    public var cfgScaleCaption: Float = 3.0
+    /// "independent" (Python default, ~3x memory) or "alternating" (mobile-friendly).
+    /// On-device default is overridden to "alternating" by IrodoriTTSModel.
+    public var cfgGuidanceMode: String = "independent"
+    public var cfgMinT: Float = 0.5
+    public var cfgMaxT: Float = 1.0
+    public var truncationFactor: Float? = nil
+    public var rescaleK: Float? = nil
+    public var rescaleSigma: Float? = nil
+    public var contextKvCache: Bool = true
+    public var speakerKvScale: Float? = nil
+    public var speakerKvMinT: Float? = 0.9
+    public var speakerKvMaxLayers: Int? = nil
+    /// Python default 750 needs ~24 GB; on-device default is overridden to 300 (~2 GB, ~12 s).
+    public var sequenceLength: Int = 750
+    // Sway Sampling (v3)
+    public var tScheduleMode: String = "linear"
+    public var swayCoeff: Float = -1.0
+    // Duration prediction (v3)
+    public var durationScale: Float = 1.0
+    public var minSeconds: Float = 0.5
+    public var maxSeconds: Float = 30.0
+
+    public init() {}
+
+    enum CodingKeys: String, CodingKey {
+        case numSteps = "num_steps"
+        case cfgScaleText = "cfg_scale_text"
+        case cfgScaleSpeaker = "cfg_scale_speaker"
+        case cfgScaleCaption = "cfg_scale_caption"
+        case cfgGuidanceMode = "cfg_guidance_mode"
+        case cfgMinT = "cfg_min_t"
+        case cfgMaxT = "cfg_max_t"
+        case truncationFactor = "truncation_factor"
+        case rescaleK = "rescale_k"
+        case rescaleSigma = "rescale_sigma"
+        case contextKvCache = "context_kv_cache"
+        case speakerKvScale = "speaker_kv_scale"
+        case speakerKvMinT = "speaker_kv_min_t"
+        case speakerKvMaxLayers = "speaker_kv_max_layers"
+        case sequenceLength = "sequence_length"
+        case tScheduleMode = "t_schedule_mode"
+        case swayCoeff = "sway_coeff"
+        case durationScale = "duration_scale"
+        case minSeconds = "min_seconds"
+        case maxSeconds = "max_seconds"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        numSteps = try c.decodeIfPresent(Int.self, forKey: .numSteps) ?? 40
+        cfgScaleText = try c.decodeIfPresent(Float.self, forKey: .cfgScaleText) ?? 3.0
+        cfgScaleSpeaker = try c.decodeIfPresent(Float.self, forKey: .cfgScaleSpeaker) ?? 5.0
+        cfgScaleCaption = try c.decodeIfPresent(Float.self, forKey: .cfgScaleCaption) ?? 3.0
+        cfgGuidanceMode = try c.decodeIfPresent(String.self, forKey: .cfgGuidanceMode) ?? "independent"
+        cfgMinT = try c.decodeIfPresent(Float.self, forKey: .cfgMinT) ?? 0.5
+        cfgMaxT = try c.decodeIfPresent(Float.self, forKey: .cfgMaxT) ?? 1.0
+        truncationFactor = try c.decodeIfPresent(Float.self, forKey: .truncationFactor)
+        rescaleK = try c.decodeIfPresent(Float.self, forKey: .rescaleK)
+        rescaleSigma = try c.decodeIfPresent(Float.self, forKey: .rescaleSigma)
+        contextKvCache = try c.decodeIfPresent(Bool.self, forKey: .contextKvCache) ?? true
+        speakerKvScale = try c.decodeIfPresent(Float.self, forKey: .speakerKvScale)
+        speakerKvMinT = try c.decodeIfPresent(Float.self, forKey: .speakerKvMinT) ?? 0.9
+        speakerKvMaxLayers = try c.decodeIfPresent(Int.self, forKey: .speakerKvMaxLayers)
+        sequenceLength = try c.decodeIfPresent(Int.self, forKey: .sequenceLength) ?? 750
+        tScheduleMode = try c.decodeIfPresent(String.self, forKey: .tScheduleMode) ?? "linear"
+        swayCoeff = try c.decodeIfPresent(Float.self, forKey: .swayCoeff) ?? -1.0
+        durationScale = try c.decodeIfPresent(Float.self, forKey: .durationScale) ?? 1.0
+        minSeconds = try c.decodeIfPresent(Float.self, forKey: .minSeconds) ?? 0.5
+        maxSeconds = try c.decodeIfPresent(Float.self, forKey: .maxSeconds) ?? 30.0
+    }
+}
+
+public struct IrodoriTTSConfig: Codable {
+    public var modelType: String = "irodori_tts"
+    public var sampleRate: Int = 48_000
+    public var maxTextLength: Int = 256
+    public var maxCaptionLength: Int = 512
+    public var maxSpeakerLatentLength: Int = 6_400
+    /// DACVAE hop_length = 2*8*10*12 = 1920 (48 kHz)
+    public var audioDownsampleFactor: Int = 1920
+    public var dacvaeRepo: String = "Aratako/Semantic-DACVAE-Japanese-32dim"
+    public var modelPath: String? = nil
+    public var dit: IrodoriDiTConfig = IrodoriDiTConfig()
+    public var sampler: IrodoriSamplerConfig = IrodoriSamplerConfig()
+
+    public init() {}
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case sampleRate = "sample_rate"
+        case maxTextLength = "max_text_length"
+        case maxCaptionLength = "max_caption_length"
+        case maxSpeakerLatentLength = "max_speaker_latent_length"
+        case audioDownsampleFactor = "audio_downsample_factor"
+        case dacvaeRepo = "dacvae_repo"
+        case modelPath = "model_path"
+        case dit
+        case sampler
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "irodori_tts"
+        sampleRate = try c.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 48_000
+        maxTextLength = try c.decodeIfPresent(Int.self, forKey: .maxTextLength) ?? 256
+        maxCaptionLength = try c.decodeIfPresent(Int.self, forKey: .maxCaptionLength) ?? 512
+        maxSpeakerLatentLength = try c.decodeIfPresent(Int.self, forKey: .maxSpeakerLatentLength) ?? 6_400
+        audioDownsampleFactor = try c.decodeIfPresent(Int.self, forKey: .audioDownsampleFactor) ?? 1920
+        dacvaeRepo = try c.decodeIfPresent(String.self, forKey: .dacvaeRepo) ?? "Aratako/Semantic-DACVAE-Japanese-32dim"
+        modelPath = try c.decodeIfPresent(String.self, forKey: .modelPath)
+        dit = try c.decodeIfPresent(IrodoriDiTConfig.self, forKey: .dit) ?? IrodoriDiTConfig()
+        sampler = try c.decodeIfPresent(IrodoriSamplerConfig.self, forKey: .sampler) ?? IrodoriSamplerConfig()
+    }
+}

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSModel.swift
@@ -1,0 +1,493 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCodecs
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+import Tokenizers
+
+/// Irodori-TTS — Japanese flow-matching TTS (Echo-TTS family). Rectified-Flow
+/// DiT over Semantic-DACVAE-Japanese-32dim latents (48 kHz), with v3 automatic
+/// duration prediction and VoiceDesign (caption) conditioning.
+/// Port of mlx_audio/tts/models/irodori_tts/irodori_tts.py (the `Model` class).
+public final class IrodoriTTSModel: Module, @unchecked Sendable {
+    public let config: IrodoriTTSConfig
+    public let sampleRate: Int
+    public let defaultGenerationParameters: GenerateParameters
+
+    @ModuleInfo(key: "model") var model: IrodoriDiT
+
+    var dacvae: DACVAE?
+    var tokenizer: Tokenizers.Tokenizer?
+    var captionTokenizer: Tokenizers.Tokenizer?
+
+    /// Default VoiceDesign caption used when no `voice` is supplied.
+    static let defaultCaption = "落ち着いた自然な声で、はっきりと読み上げてください。"
+
+    init(config: IrodoriTTSConfig) throws {
+        self.config = config
+        self.sampleRate = config.sampleRate
+        self.defaultGenerationParameters = GenerateParameters(
+            maxTokens: config.sampler.sequenceLength, temperature: 0, topP: 1)
+        self._model = ModuleInfo(wrappedValue: try IrodoriDiT(cfg: config.dit))
+    }
+
+    // MARK: - Weight sanitisation (mirror irodori_tts.py `sanitize`)
+
+    /// Remap PyTorch/MLX-community checkpoint keys (snake_case) to the Swift module
+    /// tree's keys. The DiT uses camelCase @ModuleInfo properties whose `key:` is
+    /// dropped by the `self._x = ModuleInfo(wrappedValue:)` init pattern, so each
+    /// path component must be camelCased to match (the same approach as EchoTTSModel).
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // snake_case → camelCase, with the adaLN containers matching their property names.
+        func normalizedComponent(_ component: String) -> String {
+            switch component {
+            case "attention_adaln": return "attentionAdaLN"
+            case "mlp_adaln": return "mlpAdaLN"
+            default:
+                guard component.contains("_") else { return component }
+                let parts = component.split(separator: "_")
+                guard let head = parts.first else { return component }
+                return String(head) + parts.dropFirst().map {
+                    $0.prefix(1).uppercased() + $0.dropFirst()
+                }.joined()
+            }
+        }
+
+        var out = [String: MLXArray]()
+        out.reserveCapacity(weights.count)
+        for (rawKey, v) in weights {
+            var bareKey = rawKey.hasPrefix("model.") ? String(rawKey.dropFirst("model.".count)) : rawKey
+            // PyTorch Sequential integer keys → MLX nn.Sequential "layers.N"
+            if bareKey.hasPrefix("cond_module.") {
+                var parts = bareKey.split(separator: ".").map(String.init)
+                if parts.count > 1, Int(parts[1]) != nil {
+                    parts.insert("layers", at: 1)
+                    bareKey = parts.joined(separator: ".")
+                }
+            }
+            // camelCase every non-numeric path component
+            let normalized = bareKey.split(separator: ".").map { part -> String in
+                let c = String(part)
+                return Int(c) == nil ? normalizedComponent(c) : c
+            }.joined(separator: ".")
+            out["model.\(normalized)"] = v
+        }
+        return out
+    }
+
+    // MARK: - Text / caption preparation
+
+    func prepareText(_ text: String) throws -> (ids: MLXArray, mask: MLXArray) {
+        guard let tokenizer else { throw IrodoriTTSError.tokenizer("Text tokenizer not loaded") }
+        let normalized = irodoriNormalizeText(text)
+        return try irodoriEncodeText(
+            normalized, tokenizer: tokenizer,
+            maxLength: config.maxTextLength, addBos: config.dit.textAddBos)
+    }
+
+    func prepareCaption(_ caption: String) throws -> (ids: MLXArray, mask: MLXArray) {
+        let tok = captionTokenizer ?? tokenizer
+        guard let tok else { throw IrodoriTTSError.tokenizer("Caption tokenizer not loaded") }
+        return try irodoriEncodeText(
+            caption, tokenizer: tok,
+            maxLength: config.maxCaptionLength, addBos: config.dit.captionAddBosResolved)
+    }
+
+    // MARK: - Reference-audio encoding (optional voice clone)
+
+    func encodeRefAudio(_ audioIn: MLXArray) throws -> (latent: MLXArray, mask: MLXArray) {
+        guard let dacvae else { throw IrodoriTTSError.generation("DACVAE not loaded") }
+        var audio = audioIn
+        if audio.ndim == 1 { audio = audio.expandedDimensions(axis: 0) }
+        else if audio.ndim == 2 && audio.shape[0] > 1 { audio = mean(audio, axis: 0, keepDims: true) }
+
+        let maxSamples = config.maxSpeakerLatentLength * config.audioDownsampleFactor
+        if audio.shape[1] > maxSamples { audio = audio[0..., 0..<maxSamples] }
+
+        // DACVAE.encode expects (B, L, 1) → returns (B, 128, T) channels-first
+        let latentCF = dacvae.encode(audio.expandedDimensions(axis: 2))
+        var latent = latentCF.transposed(0, 2, 1)  // (B, T, C)
+
+        var actualT = audio.shape[1] / config.audioDownsampleFactor
+        actualT = min(actualT, latent.shape[1])
+        latent = latent[0..., 0..<actualT]
+        var maskLen = actualT
+
+        let p = config.dit.speakerPatchSize
+        if p > 1 && actualT % p != 0 {
+            let trim = (actualT / p) * p
+            latent = latent[0..., 0..<trim]
+            maskLen = trim
+        }
+        let mask = MLXArray.ones([1, maskLen], dtype: .bool)
+        return (latent, mask)
+    }
+
+    // MARK: - Duration → latent step count
+
+    private func computeLatentSteps(
+        text: String,
+        textMask: MLXArray,
+        textInputIDs: MLXArray,
+        refLatent: MLXArray?,
+        refMask: MLXArray?,
+        captionInputIDs: MLXArray?,
+        captionMask: MLXArray?,
+        secondsOverride: Float?
+    ) throws -> Int {
+        let dsr = Float(config.sampleRate) / Float(config.audioDownsampleFactor)
+
+        if let secs = secondsOverride {
+            let clamped = min(config.sampler.maxSeconds, max(config.sampler.minSeconds, secs))
+            let targetSamples = Int(clamped * Float(config.sampleRate))
+            return Int(ceil(Double(targetSamples) / Double(config.audioDownsampleFactor)))
+        }
+
+        guard config.dit.useDurationPredictor else {
+            return config.sampler.sequenceLength  // fallback
+        }
+
+        let normalized = irodoriNormalizeText(text)
+        let tokenCount = textMask.sum().item(Int.self)
+        let hasSpeaker = refMask.map { $0.any().item(Bool.self) } ?? false
+
+        let features = irodoriBuildDurationFeatures(
+            texts: [normalized], tokenCounts: [tokenCount],
+            maxTextLen: config.maxTextLength, hasSpeaker: [hasSpeaker])
+
+        let enc = model.encodeConditionsFull(
+            textInputIDs: textInputIDs, textMask: textMask,
+            refLatent: refLatent, refMask: refMask,
+            captionInputIDs: captionInputIDs, captionMask: captionMask)
+
+        let hasCaption = (captionMask?.any().item(Bool.self)) ?? false
+        let predLog = try model.predictDurationLogFrames(
+            textState: enc.textState, textMask: enc.textMask,
+            speakerState: enc.speakerState,
+            durationFeatures: features,
+            hasSpeaker: MLXArray([hasSpeaker]),
+            captionState: enc.captionState, captionMask: enc.captionMask,
+            hasCaption: MLXArray([hasCaption]))
+
+        let predFrames = expm1(predLog[0]).item(Float.self)
+        let scaled = predFrames * config.sampler.durationScale
+        let minFrames = max(1, Int(ceil(Double(config.sampler.minSeconds * dsr))))
+        let maxFrames = max(1, Int(floor(Double(config.sampler.maxSeconds * dsr))))
+        return max(minFrames, min(maxFrames, Int((scaled).rounded())))
+    }
+
+    // MARK: - Generate (latent → waveform)
+
+    func generateWaveform(
+        text: String,
+        caption: String?,
+        refAudio: MLXArray?,
+        rngSeed: Int,
+        secondsOverride: Float?
+    ) throws -> MLXArray {
+        guard let dacvae else {
+            throw AudioGenerationError.modelNotInitialized("Irodori-TTS requires DACVAE to be loaded")
+        }
+
+        let (textIDs, textMask) = try prepareText(text)
+
+        var captionIDs: MLXArray?
+        var captionMask: MLXArray?
+        if config.dit.useCaptionCondition {
+            let cap = caption ?? Self.defaultCaption
+            let c = try prepareCaption(cap)
+            captionIDs = c.ids
+            captionMask = c.mask
+        }
+
+        var refLatent: MLXArray?
+        var refMask: MLXArray?
+        if let refAudio {
+            let r = try encodeRefAudio(refAudio)
+            refLatent = r.latent
+            refMask = r.mask
+        }
+        // Zero speaker context when needed (matches Python defaults)
+        if config.dit.useSpeakerConditionResolved || !config.dit.useCaptionCondition {
+            if refLatent == nil { refLatent = MLXArray.zeros([1, 1, config.dit.latentDim]) }
+            if refMask == nil { refMask = MLXArray.zeros([1, refLatent!.shape[1]], dtype: .bool) }
+        }
+
+        let latentSteps = try computeLatentSteps(
+            text: text, textMask: textMask, textInputIDs: textIDs,
+            refLatent: refLatent, refMask: refMask,
+            captionInputIDs: captionIDs, captionMask: captionMask,
+            secondsOverride: secondsOverride)
+
+        let patchedSteps = Int(ceil(Double(latentSteps) / Double(config.dit.latentPatchSize)))
+
+        var params = IrodoriSamplerParams()
+        let s = config.sampler
+        params.numSteps = s.numSteps
+        params.cfgScaleText = s.cfgScaleText
+        params.cfgScaleSpeaker = s.cfgScaleSpeaker
+        params.cfgScaleCaption = s.cfgScaleCaption
+        params.cfgGuidanceMode = s.cfgGuidanceMode
+        params.cfgMinT = s.cfgMinT
+        params.cfgMaxT = s.cfgMaxT
+        params.truncationFactor = s.truncationFactor
+        params.rescaleK = s.rescaleK
+        params.rescaleSigma = s.rescaleSigma
+        params.contextKvCache = s.contextKvCache
+        params.speakerKvScale = s.speakerKvScale
+        params.speakerKvMinT = s.speakerKvMinT
+        params.speakerKvMaxLayers = s.speakerKvMaxLayers
+        params.tScheduleMode = s.tScheduleMode
+        params.swayCoeff = s.swayCoeff
+
+        let latentOut = try irodoriSampleEulerCFG(
+            model: model,
+            textInputIDs: textIDs, textMask: textMask,
+            refLatent: refLatent, refMask: refMask,
+            captionInputIDs: captionIDs, captionMask: captionMask,
+            latentDim: config.dit.patchedLatentDim,
+            sequenceLength: patchedSteps,
+            rngSeed: rngSeed, params: params)
+
+        // Decode latent → waveform. (1, T, latentDim) → (1, latentDim, T)
+        let latentForDecode = latentOut.transposed(0, 2, 1)
+        // Chunked decode keeps ConvTranspose intermediates small on-device.
+        var audioOut = dacvae.decode(latentForDecode, chunkSize: 50)  // (1, L, 1)
+        audioOut = audioOut[0..., 0..., 0]  // (1, L)
+        eval(audioOut)
+
+        // Trim trailing silence, clamped to the predicted/manual duration.
+        let silenceT = irodoriFindSilencePoint(latentOut[0])
+        var trimSamples = silenceT * config.audioDownsampleFactor
+        let targetSamples = latentSteps * config.audioDownsampleFactor
+        trimSamples = min(trimSamples, targetSamples)
+        trimSamples = min(trimSamples, audioOut.shape[1])
+        if trimSamples > 0 { audioOut = audioOut[0..., 0..<trimSamples] }
+
+        let waveform = audioOut[0]
+        eval(waveform)
+        return waveform
+    }
+
+    // MARK: - Loading
+
+    public static func fromPretrained(
+        _ modelRepo: String,
+        cache: HubCache = .default
+    ) async throws -> IrodoriTTSModel {
+        guard let repoID = Repo.ID(rawValue: modelRepo) else {
+            throw AudioGenerationError.invalidInput("Invalid repository ID: \(modelRepo)")
+        }
+        // Pull the model + the dacvae/ subdirectory.
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["dacvae/*"],
+            cache: cache)
+        return try await fromModelDirectory(modelDir, cache: cache)
+    }
+
+    public static func fromModelDirectory(
+        _ modelDir: URL,
+        cache: HubCache = .default
+    ) async throws -> IrodoriTTSModel {
+        let configURL = modelDir.appendingPathComponent("config.json")
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(IrodoriTTSConfig.self, from: configData)
+        let model = try IrodoriTTSModel(config: config)
+
+        // Load DiT weights (top-level safetensors only — exclude dacvae/)
+        let files = try FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: nil)
+        let weightFiles = files
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard !weightFiles.isEmpty else {
+            throw AudioGenerationError.modelNotInitialized("No model safetensors in \(modelDir.path)")
+        }
+        var weights = [String: MLXArray]()
+        for file in weightFiles {
+            for (k, v) in try loadArrays(url: file) { weights[k] = v }
+        }
+        let sanitized = model.sanitize(weights: weights)
+
+        // Quantize matching Linear layers before loading packed weights (8-bit checkpoints).
+        if let q = decodeQuantization(configURL: configURL) {
+            quantize(model: model) { path, _ in
+                sanitized["\(path).scales"] != nil ? (q.groupSize, q.bits) : nil
+            }
+        }
+
+        try model.update(
+            parameters: ModuleParameters.unflattened(sanitized), verify: .noUnusedKeys)
+        eval(model.parameters())
+
+        // DACVAE codec from the local dacvae/ subdir (fp weights — not quantized).
+        let dacvaeDir = modelDir.appendingPathComponent("dacvae")
+        if FileManager.default.fileExists(atPath: dacvaeDir.appendingPathComponent("config.json").path) {
+            model.dacvae = try DACVAE.fromModelDirectory(dacvaeDir)
+        } else {
+            model.dacvae = try await DACVAE.fromPretrained(config.dacvaeRepo, cache: cache)
+        }
+
+        // Tokenizer (separate repo — not bundled with the model).
+        let tokRepo = config.dit.textTokenizerRepo
+        if let tokRepoID = Repo.ID(rawValue: tokRepo) {
+            let tokDir = try await ModelUtils.resolveOrDownloadModel(
+                repoID: tokRepoID, requiredExtension: ".json", cache: cache)
+            // swift-transformers' tokenizer loader crashes on llm-jp's config; strip the
+            // pieces we don't need (we add BOS manually, like the Python's
+            // add_special_tokens=False) and cap the giant model_max_length sentinel.
+            irodoriSanitizeTokenizerFiles(in: tokDir)
+            model.tokenizer = try await AutoTokenizer.from(modelFolder: tokDir)
+            let capRepo = config.dit.captionTokenizerRepoResolved
+            if capRepo == tokRepo {
+                model.captionTokenizer = model.tokenizer
+            } else if let capRepoID = Repo.ID(rawValue: capRepo) {
+                let capDir = try await ModelUtils.resolveOrDownloadModel(
+                    repoID: capRepoID, requiredExtension: ".json", cache: cache)
+                model.captionTokenizer = try await AutoTokenizer.from(modelFolder: capDir)
+            }
+        }
+        guard model.tokenizer != nil else {
+            throw IrodoriTTSError.tokenizer("Could not load tokenizer from \(tokRepo)")
+        }
+
+        return model
+    }
+}
+
+// MARK: - SpeechGenerationModel conformance
+
+extension IrodoriTTSModel: SpeechGenerationModel {
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        _ = refText
+        _ = language
+        // `voice` carries the VoiceDesign caption.
+        return try generateWaveform(
+            text: text, caption: voice, refAudio: refAudio,
+            rngSeed: 0, secondsOverride: nil)
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+        let task = Task { @Sendable [weak self] in
+            guard let self else {
+                continuation.finish(throwing: AudioGenerationError.modelNotInitialized("Model deallocated"))
+                return
+            }
+            do {
+                let started = CFAbsoluteTimeGetCurrent()
+                let waveform = try self.generateWaveform(
+                    text: text, caption: voice, refAudio: refAudio, rngSeed: 0, secondsOverride: nil)
+                let elapsed = max(CFAbsoluteTimeGetCurrent() - started, 1e-6)
+                let info = AudioGenerationInfo(
+                    promptTokenCount: 0,
+                    generationTokenCount: waveform.shape.last ?? 0,
+                    prefillTime: 0, generateTime: elapsed,
+                    tokensPerSecond: 0,
+                    peakMemoryUsage: Double(Memory.peakMemory) / 1e9)
+                continuation.yield(.info(info))
+                continuation.yield(.audio(waveform))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
+        return stream
+    }
+}
+
+// MARK: - Helpers
+
+/// Detect trailing silence in a generated latent (T, D). Mirrors `_find_silence_point`.
+func irodoriFindSilencePoint(_ latent: MLXArray, windowSize: Int = 20, stdThreshold: Float = 0.05) -> Int {
+    let t = latent.shape[0]
+    let d = latent.shape[1]
+    // Pull to host once; windows are small and T is bounded (~300).
+    let flat = latent.asArray(Float.self)  // row-major (T, D)
+    func windowStats(_ start: Int) -> (std: Float, mean: Float) {
+        var sum: Float = 0, sumSq: Float = 0
+        let count = windowSize * d
+        for r in 0..<windowSize {
+            let row = start + r
+            for c in 0..<d {
+                let v = (row < t) ? flat[row * d + c] : 0  // zero-padding past the end
+                sum += v
+                sumSq += v * v
+            }
+        }
+        let m = sum / Float(count)
+        let variance = max(0, sumSq / Float(count) - m * m)
+        return (sqrt(variance), m)
+    }
+    for i in 0..<t {
+        let (std, m) = windowStats(i)
+        if std < stdThreshold && abs(m) < 0.1 { return i }
+    }
+    return t
+}
+
+/// Make the llm-jp (SentencePiece **Unigram**) tokenizer loadable by
+/// swift-transformers 1.1.x. That version resolves the model class from
+/// `tokenizer_class` alone (ignoring `model.type`): `PreTrainedTokenizerFast` maps
+/// to BPETokenizer, which then fatal-errors ("requires merges") on a Unigram model.
+/// We rewrite `tokenizer_class` to `XLMRobertaTokenizer` — which its registry maps
+/// to `UnigramTokenizer` — and also cap the giant `model_max_length` sentinel and
+/// strip the unused `post_processor`/`decoder` (we add BOS manually, encode-only,
+/// matching the Python's `add_special_tokens=False`). Best-effort; no-op on failure.
+func irodoriSanitizeTokenizerFiles(in dir: URL) {
+    func loadJSON(_ name: String) -> (url: URL, obj: [String: Any])? {
+        let url = dir.appendingPathComponent(name)
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return (url, obj)
+    }
+    func write(_ url: URL, _ obj: [String: Any]) {
+        if let data = try? JSONSerialization.data(withJSONObject: obj, options: []) {
+            try? data.write(to: url)
+        }
+    }
+
+    if var (url, tok) = loadJSON("tokenizer.json").map({ ($0.url, $0.obj) }) {
+        tok["post_processor"] = NSNull()
+        tok["decoder"] = NSNull()
+        write(url, tok)
+    }
+    if var (url, cfg) = loadJSON("tokenizer_config.json").map({ ($0.url, $0.obj) }) {
+        // Force swift-transformers to instantiate UnigramTokenizer (not BPE).
+        cfg["tokenizer_class"] = "XLMRobertaTokenizer"
+        if let mml = cfg["model_max_length"] as? NSNumber, mml.doubleValue > 1_000_000 {
+            cfg["model_max_length"] = 4096
+        }
+        write(url, cfg)
+    }
+}
+
+/// Minimal quantization spec read straight from config.json.
+private struct IrodoriQuantSpec { let groupSize: Int; let bits: Int }
+
+private func decodeQuantization(configURL: URL) -> IrodoriQuantSpec? {
+    guard let data = try? Data(contentsOf: configURL),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+    let q = (obj["quantization"] as? [String: Any]) ?? (obj["quantization_config"] as? [String: Any])
+    guard let q, let g = q["group_size"] as? Int, let b = q["bits"] as? Int else { return nil }
+    return IrodoriQuantSpec(groupSize: g, bits: b)
+}

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSSampling.swift
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSSampling.swift
@@ -1,0 +1,446 @@
+import Foundation
+import MLX
+
+// MARK: - Rectified-Flow Euler sampler with Classifier-Free Guidance
+// Faithful port of mlx_audio/tts/models/irodori_tts/sampling.py (sample_euler_cfg).
+// Three CFG modes:
+//   independent — text/speaker/caption guidance in a single batched forward (up to 4×).
+//   joint       — single combined unconditional (two sequential passes).
+//   alternating — text-uncond and context-uncond alternate per step (single-context only).
+
+typealias IrodoriKVCacheList = [IrodoriKVCache]
+
+/// Concatenate KV caches from multiple conditions along the batch axis.
+private func irodoriConcatKVCaches(_ caches: [IrodoriKVCacheList]) -> IrodoriKVCacheList {
+    var result = IrodoriKVCacheList()
+    let layers = caches[0].count
+    result.reserveCapacity(layers)
+    for i in 0..<layers {
+        let k = MLX.concatenated(caches.map { $0[i].keys }, axis: 0)
+        let v = MLX.concatenated(caches.map { $0[i].values }, axis: 0)
+        result.append((keys: k, values: v))
+    }
+    return result
+}
+
+/// Return a new KV cache with (the first `maxLayers`) speaker KVs scaled.
+private func irodoriScaleKVCache(
+    _ cache: IrodoriKVCacheList,
+    scale: Float,
+    maxLayers: Int? = nil
+) -> IrodoriKVCacheList {
+    let n = maxLayers.map { min($0, cache.count) } ?? cache.count
+    var result = IrodoriKVCacheList()
+    result.reserveCapacity(cache.count)
+    for (i, kv) in cache.enumerated() {
+        if i < n {
+            result.append((keys: kv.keys * scale, values: kv.values * scale))
+        } else {
+            result.append(kv)
+        }
+    }
+    return result
+}
+
+/// Temporal score rescaling from https://arxiv.org/pdf/2510.01184.
+private func irodoriTemporalScoreRescale(
+    vPred: MLXArray, xT: MLXArray, t: Float, rescaleK: Float, rescaleSigma: Float
+) -> MLXArray {
+    if t >= 1.0 { return vPred }
+    let oneMinusT = 1.0 - t
+    let snr = (oneMinusT * oneMinusT) / (t * t)
+    let sigmaSq = rescaleSigma * rescaleSigma
+    let ratio = (snr * sigmaSq + 1.0) / (snr * sigmaSq / rescaleK + 1.0)
+    return (ratio * (oneMinusT * vPred + xT) - xT) / oneMinusT
+}
+
+/// Parameters for the Euler-CFG sampler (mirrors sampling.py kwargs).
+struct IrodoriSamplerParams {
+    var numSteps: Int = 40
+    var cfgScaleText: Float = 3.0
+    var cfgScaleSpeaker: Float = 5.0
+    var cfgScaleCaption: Float = 3.0
+    var cfgGuidanceMode: String = "independent"
+    var cfgMinT: Float = 0.5
+    var cfgMaxT: Float = 1.0
+    var truncationFactor: Float? = nil
+    var rescaleK: Float? = nil
+    var rescaleSigma: Float? = nil
+    var contextKvCache: Bool = true
+    var speakerKvScale: Float? = nil
+    var speakerKvMinT: Float? = nil
+    var speakerKvMaxLayers: Int? = nil
+    var tScheduleMode: String = "linear"
+    var swayCoeff: Float = -1.0
+}
+
+/// Build the t-schedule (length numSteps+1) including optional Sway Sampling (v3).
+private func irodoriTSchedule(numSteps: Int, initScale: Float, mode: String, swayCoeff: Float) -> [Float] {
+    if mode.trimmingCharacters(in: .whitespaces).lowercased() == "sway" {
+        var out = [Float]()
+        out.reserveCapacity(numSteps + 1)
+        for i in 0...numSteps {
+            let u0 = Float(i) / Float(numSteps)
+            var u = u0 + swayCoeff * (cos(0.5 * Float.pi * u0) + u0 - 1.0)
+            u = min(max(u, 0.0), 1.0)
+            out.append((1.0 - u) * initScale)
+        }
+        return out
+    }
+    // linear: linspace(1*initScale, 0, numSteps+1)
+    var out = [Float]()
+    out.reserveCapacity(numSteps + 1)
+    for i in 0...numSteps {
+        let frac = Float(i) / Float(numSteps)
+        out.append(initScale * (1.0 - frac))
+    }
+    return out
+}
+
+/// Euler sampler for the Rectified-Flow ODE with CFG.
+/// Returns latent of shape (batch, sequenceLength, latentDim).
+func irodoriSampleEulerCFG(
+    model: IrodoriDiT,
+    textInputIDs: MLXArray,
+    textMask: MLXArray,
+    refLatent: MLXArray?,
+    refMask: MLXArray?,
+    captionInputIDs: MLXArray?,
+    captionMask: MLXArray?,
+    latentDim: Int,
+    sequenceLength: Int,
+    rngSeed: Int,
+    params: IrodoriSamplerParams
+) throws -> MLXArray {
+    let useSpk = model.cfg.useSpeakerConditionResolved
+    let useCap = model.cfg.useCaptionCondition
+    let isDual = useSpk && useCap
+
+    let cfgScaleText = params.cfgScaleText
+    let cfgScaleSpeaker = params.cfgScaleSpeaker
+    let cfgScaleCaption = params.cfgScaleCaption
+    let cfgScaleContext = isDual ? cfgScaleSpeaker : (useCap ? cfgScaleCaption : cfgScaleSpeaker)
+
+    let mode = params.cfgGuidanceMode.trimmingCharacters(in: .whitespaces).lowercased()
+    precondition(["independent", "joint", "alternating"].contains(mode),
+                 "Unknown cfgGuidanceMode=\(mode)")
+
+    let batchSize = textInputIDs.shape[0]
+    let hasTextCfg = cfgScaleText > 0
+    let hasSpeakerCfg = cfgScaleSpeaker > 0 && useSpk
+    let hasCaptionCfg = cfgScaleCaption > 0 && useCap
+    let hasContextCfg = isDual ? false : (cfgScaleContext > 0)
+
+    // ---- encode all conditions ----
+    let enc = model.encodeConditionsFull(
+        textInputIDs: textInputIDs,
+        textMask: textMask,
+        refLatent: refLatent,
+        refMask: refMask,
+        captionInputIDs: captionInputIDs,
+        captionMask: captionMask
+    )
+    let textStateCond = enc.textState
+    let textMaskCond = enc.textMask
+
+    // For single-context caption models, alias caption into the "speaker" slot.
+    var speakerStateCond: MLXArray?
+    var speakerMaskCond: MLXArray?
+    var captionStateCond: MLXArray?
+    var captionMaskCond: MLXArray?
+    if !isDual && useCap {
+        speakerStateCond = enc.captionState
+        speakerMaskCond = enc.captionMask
+        captionStateCond = nil
+        captionMaskCond = nil
+    } else {
+        speakerStateCond = enc.speakerState
+        speakerMaskCond = enc.speakerMask
+        captionStateCond = enc.captionState
+        captionMaskCond = enc.captionMask
+    }
+
+    eval(textStateCond)
+    if let s = speakerStateCond { eval(s) }
+    if let c = captionStateCond { eval(c) }
+
+    // unconditioned states
+    let textStateUncond = MLXArray.zeros(like: textStateCond)
+    let textMaskUncond = MLXArray.zeros(like: textMaskCond)
+    let speakerStateUncond = speakerStateCond.map { MLXArray.zeros(like: $0) }
+    let speakerMaskUncond = speakerMaskCond.map { MLXArray.zeros(like: $0) }
+    let captionStateUncond = captionStateCond.map { MLXArray.zeros(like: $0) }
+    let captionMaskUncond = captionMaskCond.map { MLXArray.zeros(like: $0) }
+
+    // ---- build KV caches ----
+    let useKVCache = params.contextKvCache || (params.speakerKvScale != nil)
+
+    var kvTextCond: IrodoriKVCacheList?
+    var kvSpeakerCond: IrodoriKVCacheList?
+    var kvCaptionCond: IrodoriKVCacheList?
+    var kvTextCfg: IrodoriKVCacheList?
+    var kvSpeakerCfg: IrodoriKVCacheList?
+    var kvCaptionCfg: IrodoriKVCacheList?
+    var kvTextUncondJoint: IrodoriKVCacheList?
+    var kvSpeakerUncondJoint: IrodoriKVCacheList?
+    var kvCaptionUncondJoint: IrodoriKVCacheList?
+    var kvTextUncondAlt: IrodoriKVCacheList?
+    var kvSpeakerUncondAlt: IrodoriKVCacheList?
+
+    if useKVCache {
+        let c = try model.buildKVCache(
+            textState: textStateCond, speakerState: speakerStateCond, captionState: captionStateCond)
+        kvTextCond = c.kvText
+        kvSpeakerCond = c.kvSpeaker
+        kvCaptionCond = c.kvCaption
+        if let scale = params.speakerKvScale, let kvs = kvSpeakerCond {
+            kvSpeakerCond = irodoriScaleKVCache(kvs, scale: scale, maxLayers: params.speakerKvMaxLayers)
+        }
+
+        if mode == "independent" {
+            if isDual {
+                let nBundles = 1 + [hasTextCfg, hasSpeakerCfg, hasCaptionCfg].filter { $0 }.count
+                if nBundles > 1 {
+                    if let t = kvTextCond { kvTextCfg = irodoriConcatKVCaches(Array(repeating: t, count: nBundles)) }
+                    if let s = kvSpeakerCond { kvSpeakerCfg = irodoriConcatKVCaches(Array(repeating: s, count: nBundles)) }
+                    if let cp = kvCaptionCond { kvCaptionCfg = irodoriConcatKVCaches(Array(repeating: cp, count: nBundles)) }
+                }
+            } else {
+                if hasTextCfg && hasContextCfg {
+                    if let t = kvTextCond { kvTextCfg = irodoriConcatKVCaches([t, t, t]) }
+                    if let s = kvSpeakerCond { kvSpeakerCfg = irodoriConcatKVCaches([s, s, s]) }
+                } else if hasTextCfg || hasContextCfg {
+                    if let t = kvTextCond { kvTextCfg = irodoriConcatKVCaches([t, t]) }
+                    if let s = kvSpeakerCond { kvSpeakerCfg = irodoriConcatKVCaches([s, s]) }
+                }
+            }
+        } else if mode == "joint" {
+            if isDual {
+                if hasTextCfg || hasSpeakerCfg || hasCaptionCfg {
+                    let u = try model.buildKVCache(
+                        textState: textStateUncond, speakerState: speakerStateUncond, captionState: captionStateUncond)
+                    kvTextUncondJoint = u.kvText
+                    kvSpeakerUncondJoint = u.kvSpeaker
+                    kvCaptionUncondJoint = u.kvCaption
+                }
+            } else {
+                if hasTextCfg || hasContextCfg {
+                    let u = try model.buildKVCache(
+                        textState: textStateUncond, speakerState: speakerStateUncond, captionState: nil)
+                    kvTextUncondJoint = u.kvText
+                    kvSpeakerUncondJoint = u.kvSpeaker
+                }
+            }
+        } else if mode == "alternating" {
+            if !isDual {
+                if hasTextCfg {
+                    let a = try model.buildKVCache(
+                        textState: textStateUncond, speakerState: speakerStateCond, captionState: nil)
+                    kvTextUncondAlt = a.kvText
+                }
+                if hasContextCfg {
+                    let b = try model.buildKVCache(
+                        textState: textStateCond, speakerState: speakerStateUncond, captionState: nil)
+                    kvSpeakerUncondAlt = b.kvSpeaker
+                    if let scale = params.speakerKvScale, let kvs = kvSpeakerUncondAlt {
+                        kvSpeakerUncondAlt = irodoriScaleKVCache(kvs, scale: scale, maxLayers: params.speakerKvMaxLayers)
+                    }
+                }
+            }
+        }
+
+        if let t = kvTextCond { for kv in t { eval(kv.keys, kv.values) } }
+        if let s = kvSpeakerCond { for kv in s { eval(kv.keys, kv.values) } }
+        if let cp = kvCaptionCond { for kv in cp { eval(kv.keys, kv.values) } }
+    }
+
+    // ---- initial noise ----
+    MLXRandom.seed(UInt64(rngSeed))
+    let initScale: Float = 0.999
+    var xT = MLXRandom.normal([batchSize, sequenceLength, latentDim])
+    if let tf = params.truncationFactor { xT = xT * tf }
+
+    let tSchedule = irodoriTSchedule(
+        numSteps: params.numSteps, initScale: initScale,
+        mode: params.tScheduleMode, swayCoeff: params.swayCoeff)
+
+    var speakerKvActive = params.speakerKvScale != nil
+
+    // ---- Euler steps ----
+    for i in 0..<params.numSteps {
+        let t = tSchedule[i]
+        let tNext = tSchedule[i + 1]
+        let tArr = MLX.full([batchSize], values: t)
+        let useCfg = (hasTextCfg || hasSpeakerCfg) && (params.cfgMinT <= t && t <= params.cfgMaxT)
+
+        var vPred: MLXArray
+
+        if useCfg && mode == "independent" && isDual {
+            // Dual: build bundle list [cond, text-uncond?, spk-uncond?, cap-uncond?]
+            var bx = [xT], bt = [textStateCond], btm = [textMaskCond]
+            var bs = [speakerStateCond], bsm = [speakerMaskCond]
+            var bc = [captionStateCond], bcm = [captionMaskCond]
+            if hasTextCfg {
+                bx.append(xT); bt.append(textStateUncond); btm.append(textMaskUncond)
+                bs.append(speakerStateCond); bsm.append(speakerMaskCond)
+                bc.append(captionStateCond); bcm.append(captionMaskCond)
+            }
+            if hasSpeakerCfg {
+                bx.append(xT); bt.append(textStateCond); btm.append(textMaskCond)
+                bs.append(speakerStateUncond); bsm.append(speakerMaskUncond)
+                bc.append(captionStateCond); bcm.append(captionMaskCond)
+            }
+            if hasCaptionCfg {
+                bx.append(xT); bt.append(textStateCond); btm.append(textMaskCond)
+                bs.append(speakerStateCond); bsm.append(speakerMaskCond)
+                bc.append(captionStateUncond); bcm.append(captionMaskUncond)
+            }
+            let nB = bx.count
+            let vOut = try model.forwardWithConditions(
+                xT: MLX.concatenated(bx, axis: 0),
+                t: MLX.full([batchSize * nB], values: t),
+                textState: MLX.concatenated(bt, axis: 0),
+                textMask: MLX.concatenated(btm, axis: 0),
+                speakerState: irodoriConcatOpt(bs),
+                speakerMask: irodoriConcatOpt(bsm),
+                kvText: kvTextCfg, kvSpeaker: kvSpeakerCfg,
+                captionState: irodoriConcatOpt(bc), captionMask: irodoriConcatOpt(bcm),
+                kvCaption: kvCaptionCfg)
+            let splits = vOut.split(parts: nB, axis: 0)
+            let vCond = splits[0]
+            vPred = vCond
+            var idx = 1
+            if hasTextCfg { vPred = vPred + cfgScaleText * (vCond - splits[idx]); idx += 1 }
+            if hasSpeakerCfg { vPred = vPred + cfgScaleSpeaker * (vCond - splits[idx]); idx += 1 }
+            if hasCaptionCfg { vPred = vPred + cfgScaleCaption * (vCond - splits[idx]) }
+
+        } else if useCfg && mode == "independent" && hasTextCfg && hasContextCfg {
+            // single-context 3× batch: [cond, text-uncond, context-uncond]
+            let vOut = try model.forwardWithConditions(
+                xT: MLX.concatenated([xT, xT, xT], axis: 0),
+                t: MLX.full([batchSize * 3], values: t),
+                textState: MLX.concatenated([textStateCond, textStateUncond, textStateCond], axis: 0),
+                textMask: MLX.concatenated([textMaskCond, textMaskUncond, textMaskCond], axis: 0),
+                speakerState: irodoriConcatOpt([speakerStateCond, speakerStateCond, speakerStateUncond]),
+                speakerMask: irodoriConcatOpt([speakerMaskCond, speakerMaskCond, speakerMaskUncond]),
+                kvText: kvTextCfg, kvSpeaker: kvSpeakerCfg)
+            let s = vOut.split(parts: 3, axis: 0)
+            vPred = s[0] + cfgScaleText * (s[0] - s[1]) + cfgScaleContext * (s[0] - s[2])
+
+        } else if useCfg && mode == "independent" && hasTextCfg {
+            let vOut = try model.forwardWithConditions(
+                xT: MLX.concatenated([xT, xT], axis: 0),
+                t: MLX.full([batchSize * 2], values: t),
+                textState: MLX.concatenated([textStateCond, textStateUncond], axis: 0),
+                textMask: MLX.concatenated([textMaskCond, textMaskUncond], axis: 0),
+                speakerState: irodoriConcatOpt([speakerStateCond, speakerStateCond]),
+                speakerMask: irodoriConcatOpt([speakerMaskCond, speakerMaskCond]),
+                kvText: kvTextCfg, kvSpeaker: kvSpeakerCfg)
+            let s = vOut.split(parts: 2, axis: 0)
+            vPred = s[0] + cfgScaleText * (s[0] - s[1])
+
+        } else if useCfg && mode == "independent" {  // context-only
+            let vOut = try model.forwardWithConditions(
+                xT: MLX.concatenated([xT, xT], axis: 0),
+                t: MLX.full([batchSize * 2], values: t),
+                textState: MLX.concatenated([textStateCond, textStateCond], axis: 0),
+                textMask: MLX.concatenated([textMaskCond, textMaskCond], axis: 0),
+                speakerState: irodoriConcatOpt([speakerStateCond, speakerStateUncond]),
+                speakerMask: irodoriConcatOpt([speakerMaskCond, speakerMaskUncond]),
+                kvText: kvTextCfg, kvSpeaker: kvSpeakerCfg)
+            let s = vOut.split(parts: 2, axis: 0)
+            vPred = s[0] + cfgScaleContext * (s[0] - s[1])
+
+        } else if useCfg && mode == "joint" {
+            let jointScale: Float
+            if isDual {
+                let scales = [(cfgScaleText, hasTextCfg), (cfgScaleSpeaker, hasSpeakerCfg), (cfgScaleCaption, hasCaptionCfg)]
+                    .filter { $0.1 }.map { $0.0 }
+                jointScale = scales.first ?? cfgScaleText
+            } else if hasTextCfg && hasContextCfg {
+                precondition(abs(cfgScaleText - cfgScaleContext) <= 1e-6,
+                             "joint mode requires equal text/context scales")
+                jointScale = cfgScaleText
+            } else {
+                jointScale = hasTextCfg ? cfgScaleText : cfgScaleContext
+            }
+            let vCond = try model.forwardWithConditions(
+                xT: xT, t: tArr,
+                textState: textStateCond, textMask: textMaskCond,
+                speakerState: speakerStateCond, speakerMask: speakerMaskCond,
+                kvText: kvTextCond, kvSpeaker: kvSpeakerCond,
+                captionState: captionStateCond, captionMask: captionMaskCond, kvCaption: kvCaptionCond)
+            let vUncond = try model.forwardWithConditions(
+                xT: xT, t: tArr,
+                textState: textStateUncond, textMask: textMaskUncond,
+                speakerState: speakerStateUncond, speakerMask: speakerMaskUncond,
+                kvText: kvTextUncondJoint, kvSpeaker: kvSpeakerUncondJoint,
+                captionState: captionStateUncond, captionMask: captionMaskUncond, kvCaption: kvCaptionUncondJoint)
+            vPred = vCond + jointScale * (vCond - vUncond)
+
+        } else if useCfg {  // alternating (single-context only)
+            let vCond = try model.forwardWithConditions(
+                xT: xT, t: tArr,
+                textState: textStateCond, textMask: textMaskCond,
+                speakerState: speakerStateCond, speakerMask: speakerMaskCond,
+                kvText: kvTextCond, kvSpeaker: kvSpeakerCond)
+            let useTextUncond = (hasTextCfg && hasContextCfg && i % 2 == 0) || (hasTextCfg && !hasContextCfg)
+            if useTextUncond {
+                let vUncond = try model.forwardWithConditions(
+                    xT: xT, t: tArr,
+                    textState: textStateUncond, textMask: textMaskUncond,
+                    speakerState: speakerStateCond, speakerMask: speakerMaskCond,
+                    kvText: kvTextUncondAlt, kvSpeaker: kvSpeakerCond)
+                vPred = vCond + cfgScaleText * (vCond - vUncond)
+            } else {
+                let vUncond = try model.forwardWithConditions(
+                    xT: xT, t: tArr,
+                    textState: textStateCond, textMask: textMaskCond,
+                    speakerState: speakerStateUncond, speakerMask: speakerMaskUncond,
+                    kvText: kvTextCond, kvSpeaker: kvSpeakerUncondAlt)
+                vPred = vCond + cfgScaleContext * (vCond - vUncond)
+            }
+
+        } else {
+            // no CFG this step
+            vPred = try model.forwardWithConditions(
+                xT: xT, t: tArr,
+                textState: textStateCond, textMask: textMaskCond,
+                speakerState: speakerStateCond, speakerMask: speakerMaskCond,
+                kvText: kvTextCond, kvSpeaker: kvSpeakerCond,
+                captionState: captionStateCond, captionMask: captionMaskCond, kvCaption: kvCaptionCond)
+        }
+
+        if let rk = params.rescaleK, let rs = params.rescaleSigma {
+            vPred = irodoriTemporalScoreRescale(vPred: vPred, xT: xT, t: t, rescaleK: rk, rescaleSigma: rs)
+        }
+
+        // speaker KV scale rollback at threshold
+        if speakerKvActive, let minT = params.speakerKvMinT, let scale = params.speakerKvScale,
+           tNext < minT && minT <= t, let kvs = kvSpeakerCond {
+            let inv = 1.0 / scale
+            kvSpeakerCond = irodoriScaleKVCache(kvs, scale: inv, maxLayers: params.speakerKvMaxLayers)
+            if kvSpeakerCfg != nil, let s = kvSpeakerCond {
+                let nRep = (!isDual && hasTextCfg && hasContextCfg) ? 3 : 2
+                kvSpeakerCfg = irodoriConcatKVCaches(Array(repeating: s, count: nRep))
+            }
+            if let alt = kvSpeakerUncondAlt {
+                kvSpeakerUncondAlt = irodoriScaleKVCache(alt, scale: inv, maxLayers: params.speakerKvMaxLayers)
+            }
+            speakerKvActive = false
+        }
+
+        // Euler update: x_{t-dt} = x_t + v * (t_next - t)
+        xT = xT + vPred * (tNext - t)
+        eval(xT)
+    }
+
+    return xT
+}
+
+/// Concatenate a list of optional MLXArrays along batch axis; nil if all nil.
+private func irodoriConcatOpt(_ arrays: [MLXArray?]) -> MLXArray? {
+    let present = arrays.compactMap { $0 }
+    guard present.count == arrays.count, !present.isEmpty else { return nil }
+    return MLX.concatenated(present, axis: 0)
+}

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSText.swift
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/IrodoriTTSText.swift
@@ -1,0 +1,137 @@
+import Foundation
+import MLX
+import Tokenizers
+
+// MARK: - Japanese text normalisation
+// Mirrors mlx_audio/tts/models/irodori_tts/text.py (itself ported from
+// Irodori-TTS/irodori_tts/text_normalization.py).
+
+private let irodoriRegexReplacements: [(pattern: String, replacement: String)] = [
+    ("\\t", ""),
+    ("\\[n\\]", ""),
+    ("\u{202F}", ""),               // narrow no-break space
+    ("\u{3000}", ""),               // ideographic space
+    ("[;▼♀♂《》≪≫①②③④⑤⑥]", ""),
+    ("[\u{02d7}\u{2010}-\u{2015}\u{2043}\u{2212}\u{23af}\u{23e4}\u{2500}\u{2501}\u{2e3a}\u{2e3b}]", ""),
+    ("[\u{ff5e}\u{301C}]", "ー"),
+    ("？", "?"),
+    ("！", "!"),
+    ("[●◯〇]", "○"),
+    ("♥", "♡"),
+]
+
+private func irodoriWidthFold(_ scalar: UnicodeScalar) -> UnicodeScalar {
+    let v = scalar.value
+    // Fullwidth A-Z a-z → halfwidth
+    if (0xFF21...0xFF3A).contains(v) { return UnicodeScalar(v - 0xFF21 + 0x41)! }
+    if (0xFF41...0xFF5A).contains(v) { return UnicodeScalar(v - 0xFF41 + 0x61)! }
+    // Fullwidth 0-9 → halfwidth
+    if (0xFF10...0xFF19).contains(v) { return UnicodeScalar(v - 0xFF10 + 0x30)! }
+    return scalar
+}
+
+// Halfwidth katakana → fullwidth katakana (positional map, mirrors str.maketrans)
+private let irodoriHWKana = Array("ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ")
+private let irodoriFWKana = Array("ヲァィゥェォャュョッーアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワン")
+private let irodoriKanaMap: [Character: Character] = {
+    var m = [Character: Character]()
+    for (h, f) in zip(irodoriHWKana, irodoriFWKana) { m[h] = f }
+    return m
+}()
+
+/// Normalise Japanese text for Irodori TTS input.
+/// - Removes noise characters; folds fullwidth alnum → halfwidth and
+///   halfwidth katakana → fullwidth; strips surrounding brackets and
+///   trailing 。/、 punctuation; collapses 3+ ellipses to two.
+func irodoriNormalizeText(_ input: String) -> String {
+    var text = input
+
+    for (pattern, replacement) in irodoriRegexReplacements {
+        if let regex = try? NSRegularExpression(pattern: pattern) {
+            let range = NSRange(text.startIndex..., in: text)
+            text = regex.stringByReplacingMatches(in: text, range: range, withTemplate: replacement)
+        }
+    }
+
+    // Width folding + kana widening
+    text = String(String.UnicodeScalarView(text.unicodeScalars.map(irodoriWidthFold)))
+    text = String(text.map { irodoriKanaMap[$0] ?? $0 })
+
+    // Collapse runs of 3+ ellipses to double
+    if let regex = try? NSRegularExpression(pattern: "…{3,}") {
+        let range = NSRange(text.startIndex..., in: text)
+        text = regex.stringByReplacingMatches(in: text, range: range, withTemplate: "……")
+    }
+
+    // Strip surrounding bracket pairs
+    for (open, close) in [("「", "」"), ("『", "』"), ("（", "）"), ("【", "】"), ("(", ")")] {
+        if text.hasPrefix(open) && text.hasSuffix(close) && text.count >= 2 {
+            text = String(text.dropFirst().dropLast())
+        }
+    }
+
+    // Strip trailing Japanese sentence-ending punctuation
+    while text.hasSuffix("。") || text.hasSuffix("、") {
+        text = String(text.dropLast())
+    }
+
+    return text
+}
+
+// MARK: - Tokenisation
+
+/// Tokenise a single string with an HF tokenizer, mirroring Irodori's
+/// PretrainedTextTokenizer: no special tokens from the tokenizer, manual BOS,
+/// right-padding to `maxLength` with the pad (or EOS) token id.
+/// Returns `(ids: (1, maxLength) int32, mask: (1, maxLength) bool)`.
+func irodoriEncodeText(
+    _ text: String,
+    tokenizer: Tokenizer,
+    maxLength: Int,
+    addBos: Bool = true
+) throws -> (ids: MLXArray, mask: MLXArray) {
+    var tokenIds = tokenizer.encode(text: text, addSpecialTokens: false)
+
+    if addBos {
+        // swift-transformers' bosTokenId only checks the (Unigram) model vocab; llm-jp's
+        // <s> lives in added_tokens, so fall back to a token lookup that sees them.
+        guard let bos = tokenizer.bosTokenId ?? tokenizer.convertTokenToId("<s>") else {
+            throw IrodoriTTSError.tokenizer("Tokenizer has no bos_token_id but add_bos=true")
+        }
+        tokenIds.insert(bos, at: 0)
+    }
+
+    if tokenIds.count > maxLength {
+        tokenIds = Array(tokenIds.prefix(maxLength))
+    }
+    let n = tokenIds.count
+
+    // Padding is masked out, so the exact id is irrelevant — resolve </s>, else 0.
+    let padId = tokenizer.eosTokenId ?? tokenizer.convertTokenToId("</s>") ?? 0
+
+    var padded = tokenIds
+    padded.append(contentsOf: Array(repeating: padId, count: maxLength - n))
+
+    let ids = MLXArray(padded.map { Int32($0) }).reshaped(1, maxLength)
+    var maskVals = [Bool](repeating: false, count: maxLength)
+    for i in 0..<n { maskVals[i] = true }
+    let mask = MLXArray(maskVals).reshaped(1, maxLength)
+
+    return (ids, mask)
+}
+
+// MARK: - Errors
+
+public enum IrodoriTTSError: Error, LocalizedError {
+    case tokenizer(String)
+    case weights(String)
+    case generation(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .tokenizer(let m): return "IrodoriTTS tokenizer error: \(m)"
+        case .weights(let m): return "IrodoriTTS weights error: \(m)"
+        case .generation(let m): return "IrodoriTTS generation error: \(m)"
+        }
+    }
+}

--- a/Sources/MLXAudioTTS/Models/IrodoriTTS/README.md
+++ b/Sources/MLXAudioTTS/Models/IrodoriTTS/README.md
@@ -1,0 +1,56 @@
+# Irodori TTS
+
+Japanese flow-matching text-to-speech (Echo-TTS family): a Rectified-Flow DiT over
+continuous `Semantic-DACVAE-Japanese-32dim` latents at 48 kHz, with v3 automatic
+duration prediction and **VoiceDesign** — the voice is described by a Japanese
+caption rather than a reference clip.
+
+[Hugging Face Model Repo](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit)
+
+## CLI Example
+
+```bash
+mlx-audio-swift-tts \
+  --model mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit \
+  --text "こんにちは。今日はいい天気ですね。" \
+  --voice "落ち着いた自然な女性の声で、はっきりと読み上げてください。"
+```
+
+## Swift Example
+
+```swift
+import Foundation
+import MLXAudioCore
+import MLXAudioTTS
+
+let model = try await IrodoriTTSModel.fromPretrained(
+    "mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit"
+)
+
+// `voice` is a Japanese VoiceDesign caption describing the speaker.
+let audio = try await model.generate(
+    text: "こんにちは。今日はいい天気ですね。",
+    voice: "落ち着いた自然な女性の声で、はっきりと読み上げてください。",
+    refAudio: nil,
+    refText: nil,
+    language: nil
+)
+```
+
+If `voice` is `nil`, a neutral default caption is used. The model is
+Japanese-only — pass Japanese text directly (no `language` argument needed).
+
+## Notes
+
+- The tokenizer is `llm-jp/llm-jp-3-150m` (SentencePiece Unigram), downloaded
+  separately on first load. It is **not** bundled with the model weights.
+- The DACVAE codec ships in the model repo under `dacvae/` and is loaded
+  automatically.
+- On memory-constrained devices, lower `sampler.sequence_length` and/or use
+  `cfg_guidance_mode: "alternating"` to reduce peak memory.
+
+## License
+
+See the [Irodori-TTS model repository](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit)
+and the upstream [Aratako/Irodori-TTS](https://huggingface.co/Aratako) project for
+model weight licensing.

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -123,6 +123,13 @@ public enum TTS {
                 pretrained: { try await EchoTTSModel.fromPretrained($0, cache: $1) },
                 local: { modelDir, _ in try await EchoTTSModel.fromModelDirectory(modelDir) }
             )
+        case "irodori_tts", "irodori":
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await IrodoriTTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await IrodoriTTSModel.fromModelDirectory(modelDir) }
+            )
         case "qwen3_tts":
             return try await load(
                 source,
@@ -252,6 +259,10 @@ public enum TTS {
 
     private static func inferModelType(from modelRepo: String) -> String? {
         let lower = modelRepo.lowercased()
+        // Repo names are hyphenated (e.g. "Irodori-TTS-600M-…"); match the bare name.
+        if lower.contains("irodori") {
+            return "irodori_tts"
+        }
         if lower.contains("qwen3_tts") {
             return "qwen3_tts"
         }


### PR DESCRIPTION
## Summary

Adds support for [Irodori-TTS](https://huggingface.co/Aratako/Irodori-TTS), a Japanese-specialised text-to-speech model in the Echo-TTS family, porting `mlx_audio`'s `irodori_tts` model to Swift.

Irodori-TTS is a Rectified-Flow DiT over continuous `Semantic-DACVAE-Japanese-32dim` latents at 48 kHz, with v3 automatic duration prediction and **VoiceDesign** conditioning — the voice is described by a Japanese caption instead of a reference clip.

```swift
let model = try await IrodoriTTSModel.fromPretrained(
    "mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit")

let audio = try await model.generate(
    text: "こんにちは。今日はいい天気ですね。",
    voice: "落ち着いた自然な女性の声で、はっきりと読み上げてください。",
    refAudio: nil, refText: nil, language: nil)
```

## What's included

- `IrodoriTTSConfig` — model / DiT / sampler configuration (mirrors `config.py`)
- `IrodoriTTSText` — Japanese text normalisation + HF tokenizer encoding
- `IrodoriDuration` — v3 duration-predictor feature builder
- `IrodoriDiT` — DiT backbone: joint attention, text/reference/caption encoders, diffusion blocks, duration predictor
- `IrodoriTTSSampling` — rectified-flow Euler sampler with CFG (independent / joint / alternating), sway-sampling schedule, speaker-KV cache
- `IrodoriTTSModel` — loader + generate pipeline, `SpeechGenerationModel` conformance; reuses the existing `MLXAudioCodecs.DACVAE` for the 48 kHz decode
- Registers `irodori_tts` in `TTSModel`
- Per-model README + Supported Models table entry

## Verification

Tested end-to-end on an iPhone (Apple Silicon) with `mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit`:

- Weight load is exact — `update(verify: .noUnusedKeys)` passes for all 1,824 tensors
- Tokenization matches the HuggingFace Python reference byte-for-byte (e.g. `こんにちは` → `[1, 39801]`)
- Generated Japanese audio whisper-transcribes back to the input text

## Implementation notes

- **DACVAE** — reuses the existing `MLXAudioCodecs.DACVAE` for decode; weights load from the model repo's `dacvae/` subdirectory.
- **Tokenizer** — `llm-jp/llm-jp-3-150m` is a SentencePiece **Unigram** model, downloaded separately on first load. swift-transformers 1.1.x resolves the tokenizer class from `tokenizer_class` alone (`PreTrainedTokenizerFast` → `BPETokenizer`, which requires `merges` and traps on a Unigram model). The loader works around this by rewriting the downloaded `tokenizer_class` so it maps to `UnigramTokenizer`, caps the oversized `model_max_length` sentinel, and resolves BOS/EOS via an added-token lookup (they live in `added_tokens`, not the Unigram vocab). Happy to adopt a cleaner approach if swift-transformers gains Unigram selection by `model.type`.
- **Memory** — on constrained devices, lowering `sampler.sequence_length` and/or `cfg_guidance_mode: "alternating"` reduces peak memory.

## Notes for review

Branch is based on current `main` with no other changes. The port mirrors the existing `EchoTTS` Swift structure where practical. Feedback welcome on the tokenizer workaround and on whether you'd like a CLI/integration test fixture added.
