### PR TITLE
feat(nemotron_asr): incremental NemotronASRStreamSession for live mic

### DIFF
--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift
@@ -141,61 +141,18 @@ public final class NemotronASRModel: Module, STTGenerationModel {
             let frameSeconds = Double(self.encoderConfig.subsamplingFactor * self.preprocessConfig.hopLength)
                 / Double(sampleRate)
 
-            var results: [NemoAlignedToken] = []
-            var lastToken = self.blankTokenID
-            var decoderState: NemoLSTMState?
+            let rnntState = NemotronASRStreamRNNTState(blankToken: self.blankTokenID)
             var previousText = ""
-            var globalTime = 0
 
             // Cache-aware streaming: incremental subsampling + per-layer attn/conv
-            // caches. Token-identical to decode() at the native chunk size.
+            // caches, greedy RNN-T per chunk. Token-identical to decode() at the
+            // native chunk size; shares both loops with NemotronASRStreamSession.
             self.cacheAwareStreamEncode(mel, language: generationParameters.language) { prompted in
-                let chunkLen = prompted.shape[1]
-                var time = 0
-                var newSymbols = 0
-                while time < chunkLen {
-                    let frame = prompted[0..., time..<(time + 1), 0...]
-                    let currentToken: MLXArray? = lastToken == self.blankTokenID
-                        ? nil
-                        : MLXArray(Int32(lastToken)).reshaped([1, 1]).asType(.int32)
-                    let decoderOutput = self.decoder(currentToken, state: decoderState)
-                    let pred = decoderOutput.0.asType(frame.dtype)
-                    let proposedState: NemoLSTMState = (
-                        hidden: decoderOutput.1.hidden?.asType(frame.dtype),
-                        cell: decoderOutput.1.cell?.asType(frame.dtype)
-                    )
-                    let jointOutput = self.joint(frame, pred)
-                    let token = jointOutput.argMax(axis: -1).item(Int.self)
-                    let step = NemoDecodingLogic.rnntStep(
-                        predictedToken: token,
-                        blankToken: self.blankTokenID,
-                        time: time,
-                        newSymbols: newSymbols,
-                        maxSymbols: self.maxSymbols
-                    )
-                    if step.emittedToken {
-                        lastToken = token
-                        decoderState = proposedState
-                        if !NemotronASRTokenizer.isSpecialToken(token, vocabulary: self.vocabulary) {
-                            results.append(
-                                NemoAlignedToken(
-                                    id: token,
-                                    text: NemotronASRTokenizer.decode(tokens: [token], vocabulary: self.vocabulary),
-                                    start: Double(globalTime + time) * frameSeconds,
-                                    duration: frameSeconds
-                                )
-                            )
-                        }
-                    }
-                    time = step.nextTime
-                    newSymbols = step.nextNewSymbols
-                }
-                globalTime += chunkLen
+                self.streamRNNTDecode(prompted, state: rnntState, frameSeconds: frameSeconds)
 
-                let currentResult = NemoAlignment.sentencesToResult(
-                    NemoAlignment.tokensToSentences(results)
-                )
-                let fullText = currentResult.text
+                let fullText = NemoAlignment.sentencesToResult(
+                    NemoAlignment.tokensToSentences(rnntState.results)
+                ).text
                 let nextText = fullText.hasPrefix(previousText)
                     ? String(fullText.dropFirst(previousText.count))
                     : fullText
@@ -206,7 +163,7 @@ public final class NemotronASRModel: Module, STTGenerationModel {
             }
 
             let finalResult = NemoAlignment.sentencesToResult(
-                NemoAlignment.tokensToSentences(results)
+                NemoAlignment.tokensToSentences(rnntState.results)
             )
             continuation.yield(
                 .result(

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRStreamSession.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRStreamSession.swift
@@ -1,0 +1,288 @@
+import Foundation
+import MLX
+import MLXAudioCore
+import MLXNN
+
+// True incremental (online) streaming for Nemotron 3.5 ASR.
+//
+// The offline `generateStream(...)` computes the mel of the whole utterance up
+// front and only then walks the cache-aware encoder. A live caller (e.g. a mic
+// feeding 80 ms chunks) instead wants to push audio as it arrives and read text
+// back with the model's native chunk delay. This session does exactly that, while
+// staying bit-identical to the offline encode.
+//
+// Why it is bit-identical (transcript == generateStream(wholeAudio)):
+//   * The preprocessor uses `normalize: "NA"` (verified on the shipped checkpoint),
+//     so each mel frame is an independent function of a fixed sample window — no
+//     per-utterance mean/std that would shift as audio grows. preemph is causal.
+//   * The STFT centers with `nFft/2` zero-pad, so mel frame m covers original
+//     samples [m·hop − nFft/2, m·hop + nFft/2). Frame m is *frozen* — unaffected by
+//     future audio — once `m·hop + nFft/2 <= bufferLen`. The session only feeds the
+//     encoder frozen, whole chunks; the trailing partial chunk waits for `finish()`,
+//     which reproduces the offline right-pad exactly.
+//   * The cache-aware encoder + greedy RNN-T already carry all their state in
+//     `NemotronASRStreamEncoderState` / `NemotronASRStreamRNNTState`, so resuming
+//     across `step` calls reproduces the single-shot walk.
+//
+// Cost note: v1 recomputes the full mel from the raw buffer each `step` (O(buffer)).
+// Mel is ~1% of encode, so this is negligible at utterance scale; an incremental
+// mel over a sliding raw window is a future optimization.
+
+/// Per-stream greedy RNN-T state, carried across chunks / `step` calls.
+final class NemotronASRStreamRNNTState {
+    var results: [NemoAlignedToken] = []
+    var lastToken: Int
+    var decoderState: NemoLSTMState?
+    var globalTime = 0  // absolute subsampled-frame index, for token timestamps
+
+    init(blankToken: Int) { lastToken = blankToken }
+}
+
+extension NemotronASRModel {
+    /// Greedy RNN-T over one chunk of prompted encoder frames `(1, c, d)`, mutating
+    /// `state`. Lifted verbatim from the offline streaming loop so the one-shot and
+    /// session paths share a single decoder (SSOT).
+    func streamRNNTDecode(
+        _ prompted: MLXArray,
+        state: NemotronASRStreamRNNTState,
+        frameSeconds: Double
+    ) {
+        let chunkLen = prompted.shape[1]
+        var time = 0
+        var newSymbols = 0
+        while time < chunkLen {
+            let frame = prompted[0..., time..<(time + 1), 0...]
+            let currentToken: MLXArray? = state.lastToken == blankTokenID
+                ? nil
+                : MLXArray(Int32(state.lastToken)).reshaped([1, 1]).asType(.int32)
+            let decoderOutput = decoder(currentToken, state: state.decoderState)
+            let pred = decoderOutput.0.asType(frame.dtype)
+            let proposedState: NemoLSTMState = (
+                hidden: decoderOutput.1.hidden?.asType(frame.dtype),
+                cell: decoderOutput.1.cell?.asType(frame.dtype)
+            )
+            let jointOutput = joint(frame, pred)
+            let token = jointOutput.argMax(axis: -1).item(Int.self)
+            let step = NemoDecodingLogic.rnntStep(
+                predictedToken: token,
+                blankToken: blankTokenID,
+                time: time,
+                newSymbols: newSymbols,
+                maxSymbols: maxSymbols
+            )
+            if step.emittedToken {
+                state.lastToken = token
+                state.decoderState = proposedState
+                if !NemotronASRTokenizer.isSpecialToken(token, vocabulary: vocabulary) {
+                    state.results.append(
+                        NemoAlignedToken(
+                            id: token,
+                            text: NemotronASRTokenizer.decode(tokens: [token], vocabulary: vocabulary),
+                            start: Double(state.globalTime + time) * frameSeconds,
+                            duration: frameSeconds
+                        )
+                    )
+                }
+            }
+            time = step.nextTime
+            newSymbols = step.nextNewSymbols
+        }
+        state.globalTime += chunkLen
+    }
+}
+
+public final class NemotronASRStreamSession {
+    /// Text + token ids decoded by a single `step` / `finish` call.
+    public struct Delta {
+        public let text: String
+        public let tokenIds: [Int]
+    }
+
+    private let model: NemotronASRModel
+    private let language: String?
+    private let chunkFrames: Int?
+    private let frameSeconds: Double
+
+    private var rawBuffer: [Float] = []
+    private let encState: NemotronASRStreamEncoderState
+    private let rnntState: NemotronASRStreamRNNTState
+    private var emittedText = ""
+    private var done = false
+
+    init(model: NemotronASRModel, language: String?, chunkFrames: Int?) {
+        self.model = model
+        self.language = language
+        self.chunkFrames = chunkFrames
+        self.encState = NemotronASRStreamEncoderState(layers: model.encoder.layers.count)
+        self.rnntState = NemotronASRStreamRNNTState(blankToken: model.blankTokenID)
+        self.frameSeconds = Double(model.encoderConfig.subsamplingFactor * model.preprocessConfig.hopLength)
+            / Double(model.preprocessConfig.sampleRate)
+        let norm = model.preprocessConfig.normalize.lowercased()
+        precondition(
+            norm == "na" || norm == "none",
+            "NemotronASRStreamSession requires NA mel normalization (got \(model.preprocessConfig.normalize)); "
+                + "per-utterance normalization is not frozen incrementally."
+        )
+    }
+
+    /// Full transcript decoded so far.
+    public var text: String { emittedText }
+    /// Sentence-level segments with start/end times, built from the same alignment
+    /// as `text`. Matches the offline path's `STTOutput.segments` so `--format srt`
+    /// / `vtt` / `json` keep their timestamps when streaming.
+    public var segments: [[String: Any]] {
+        NemoAlignment.sentencesToResult(
+            NemoAlignment.tokensToSentences(rnntState.results)
+        ).segments
+    }
+    /// Token ids decoded so far.
+    public var tokens: [Int] { rnntState.results.map { $0.id } }
+    /// Whether `finish()` has been called.
+    public var isFinished: Bool { done }
+
+    /// Ingest a chunk of 16 kHz mono samples; returns the text decoded by this call.
+    @discardableResult
+    public func step(_ samples: [Float]) -> Delta {
+        rawBuffer.append(contentsOf: samples)
+        return advance(final: false)
+    }
+
+    @discardableResult
+    public func step(_ samples: MLXArray) -> Delta {
+        let mono = samples.ndim > 1 ? samples.mean(axis: -1) : samples
+        return step(mono.asType(.float32).asArray(Float.self))
+    }
+
+    /// Flush the trailing partial chunk so the final transcript equals
+    /// `generateStream(wholeAudio)`. Call once after the last `step`.
+    @discardableResult
+    public func finish() -> Delta {
+        advance(final: true)
+    }
+
+    private func advance(final: Bool) -> Delta {
+        guard !done else { return Delta(text: "", tokenIds: []) }
+        guard !rawBuffer.isEmpty else {
+            if final { done = true }
+            return Delta(text: "", tokenIds: [])
+        }
+
+        let audio = MLXArray(rawBuffer)
+        let mel = NemotronASRAudio.logMelSpectrogram(audio, config: model.preprocessConfig)  // (1, T, F)
+        let totalMel = mel.shape[1]
+        let limit = final ? totalMel : frozenMelFrames(totalMel: totalMel)
+
+        let firstNew = rnntState.results.count
+        model.streamEncodeChunks(
+            mel,
+            language: language,
+            limit: limit,
+            chunkFrames: chunkFrames,
+            flushTail: final,
+            state: encState
+        ) { prompted in
+            model.streamRNNTDecode(prompted, state: rnntState, frameSeconds: frameSeconds)
+        }
+
+        // Bound the lazy graph across steps: materialize the caches the next step
+        // resumes from (the in-loop `.item()` already forced this chunk's encoder).
+        var live: [MLXArray] = []
+        if let mc = encState.melCache { live.append(mc) }
+        for c in encState.attnCache where c != nil { live.append(c!) }
+        for c in encState.convCache where c != nil { live.append(c!) }
+        if !live.isEmpty { MLX.asyncEval(live) }
+
+        let fullText = NemoAlignment.sentencesToResult(
+            NemoAlignment.tokensToSentences(rnntState.results)
+        ).text
+        let deltaText = fullText.hasPrefix(emittedText)
+            ? String(fullText.dropFirst(emittedText.count))
+            : fullText
+        emittedText = fullText
+        let deltaIds = rnntState.results[firstNew...].map { $0.id }
+
+        if final { done = true }
+        Memory.clearCache()
+        return Delta(text: deltaText, tokenIds: Array(deltaIds))
+    }
+
+    /// Number of mel frames whose STFT window is fully covered by real audio, hence
+    /// bit-identical to the final offline mel regardless of future samples. The STFT
+    /// centers with `nFft/2` zero-pad, so frame m is frozen iff m·hop + nFft/2 <=
+    /// bufferLen. Conservative by construction: an under-count only delays a chunk
+    /// by one `step` (latency), never corrupts output.
+    private func frozenMelFrames(totalMel: Int) -> Int {
+        let hop = model.preprocessConfig.hopLength
+        let half = model.preprocessConfig.nFft / 2
+        guard rawBuffer.count >= half else { return 0 }
+        let largestFrozen = (rawBuffer.count - half) / hop
+        return min(totalMel, largestFrozen + 1)
+    }
+}
+
+public extension NemotronASRModel {
+    /// Create an online streaming session. Feed audio with `step(_:)`, then `finish()`.
+    ///
+    /// - Parameters:
+    ///   - language: language prompt (e.g. "ru"); `nil` uses the model default.
+    ///   - chunkMs: chunk size in ms; maps to right-context per the latency ladder
+    ///     (80→[56,0], 160→[56,1], 320→[56,3], 560→[56,6], 1120→[56,13]). `nil` uses
+    ///     the model's native chunk (`default_att_context_size`). Smaller chunks cut
+    ///     latency at a modest WER cost — see the model card's chunk-size table.
+    func makeStreamSession(
+        language: String? = nil,
+        chunkMs: Int? = nil
+    ) -> NemotronASRStreamSession {
+        let chunkFrames: Int?
+        if let chunkMs {
+            let msPerSubframe = encoderConfig.subsamplingFactor * preprocessConfig.hopLength * 1000
+                / preprocessConfig.sampleRate  // 8*160*1000/16000 = 80 ms
+            chunkFrames = max(1, Int((Double(chunkMs) / Double(msPerSubframe)).rounded()))
+        } else {
+            chunkFrames = nil
+        }
+        return NemotronASRStreamSession(model: self, language: language, chunkFrames: chunkFrames)
+    }
+
+    /// Transcribe a whole audio buffer through the online streaming session, feeding
+    /// fixed `chunkMs`-sized chunks as a live caller would — instead of the whole-buffer
+    /// `generateStream`. `onDelta` receives each newly decoded fragment as it is produced
+    /// (use it to render live output); the returned `STTOutput` is the full transcript.
+    func transcribeStreaming(
+        audio: MLXArray,
+        generationParameters: STTGenerateParameters = STTGenerateParameters(),
+        chunkMs: Int = 480,
+        onDelta: ((String) -> Void)? = nil
+    ) -> STTOutput {
+        let mono = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        let samples = mono.asType(.float32).asArray(Float.self)
+        let chunk = max(1, 16000 * chunkMs / 1000)
+
+        let session = makeStreamSession(language: generationParameters.language)
+        let start = CFAbsoluteTimeGetCurrent()
+
+        func emit(_ delta: NemotronASRStreamSession.Delta) {
+            guard !delta.text.isEmpty else { return }
+            onDelta?(delta.text)
+        }
+        var idx = 0
+        while idx < samples.count {
+            let end = min(idx + chunk, samples.count)
+            emit(session.step(Array(samples[idx..<end])))
+            idx = end
+        }
+        emit(session.finish())
+
+        let totalTime = CFAbsoluteTimeGetCurrent() - start
+        let tokenCount = session.tokens.count
+        return STTOutput(
+            text: session.text.trimmingCharacters(in: .whitespacesAndNewlines),
+            segments: session.segments,
+            language: generationParameters.language,
+            generationTokens: tokenCount,
+            totalTokens: tokenCount,
+            generationTps: totalTime > 0 ? Double(tokenCount) / totalTime : 0,
+            totalTime: totalTime
+        )
+    }
+}

--- a/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRStreaming.swift
+++ b/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRStreaming.swift
@@ -11,6 +11,23 @@ import MLXNN
 
 private let nemoPreEncodeMelCache = 16  // >= causal receptive field of 8x dw-striding
 
+/// Per-stream cache-aware encoder state, carried across chunks (and, in a live
+/// session, across `step` calls). Holding it outside the chunk loop is what lets
+/// the same loop serve both the one-shot `generateStream` and the incremental
+/// `NemotronASRStreamSession`.
+final class NemotronASRStreamEncoderState {
+    var attnCache: [MLXArray?]
+    var convCache: [MLXArray?]
+    var melCache: MLXArray?
+    var emitted = 0   // subsampled frames already emitted to the decoder (absolute)
+    var consumed = 0  // mel frames already consumed by the encoder (absolute)
+
+    init(layers: Int) {
+        attnCache = [MLXArray?](repeating: nil, count: layers)
+        convCache = [MLXArray?](repeating: nil, count: layers)
+    }
+}
+
 extension NemotronASRModel {
     private func nemoStreamBlock(
         _ block: NemotronASRConformerBlock,
@@ -52,10 +69,44 @@ extension NemotronASRModel {
 
     /// Run encoder + prompt fusion in cache-aware chunks, invoking `onChunk` with
     /// each chunk's post-prompt encoder frames (1, c, d). Frame-identical to offline.
+    /// One-shot wrapper: encodes the whole `mel` with a fresh state and a flushed tail.
     func cacheAwareStreamEncode(
         _ mel: MLXArray,
         language: String?,
         chunkFrames: Int? = nil,
+        onChunk: (MLXArray) -> Void
+    ) {
+        var features = mel
+        if features.ndim == 2 { features = features.expandedDimensions(axis: 0) }
+        let state = NemotronASRStreamEncoderState(layers: encoder.layers.count)
+        streamEncodeChunks(
+            features,
+            language: language,
+            limit: features.shape[1],
+            chunkFrames: chunkFrames,
+            flushTail: true,
+            state: state,
+            onChunk: onChunk
+        )
+    }
+
+    /// Resumable cache-aware encoder loop shared by `cacheAwareStreamEncode` (one-shot)
+    /// and `NemotronASRStreamSession` (incremental). Processes `mel` frames in
+    /// `[state.consumed, limit)`:
+    ///   * `flushTail == false`: only whole `chunkMel`-sized chunks are emitted; a
+    ///     trailing partial chunk is left for a later call (when more audio arrives).
+    ///   * `flushTail == true`: the final partial chunk is processed and all of its
+    ///     subsampled frames are emitted (matches the offline encoder tail).
+    /// `limit` lets a live caller cap processing to *frozen* mel frames (those whose
+    /// STFT window is fully covered by real audio), keeping the output bit-identical
+    /// to the offline encode. All counters live in `state`, so calls compose.
+    func streamEncodeChunks(
+        _ mel: MLXArray,
+        language: String?,
+        limit: Int,
+        chunkFrames: Int?,
+        flushTail: Bool,
+        state: NemotronASRStreamEncoderState,
         onChunk: (MLXArray) -> Void
     ) {
         var features = mel
@@ -68,46 +119,41 @@ extension NemotronASRModel {
         let chunkMel = cf * sf
         let leftCache = defaultAttContextSize.first ?? 56
         let convLeft = encoderConfig.convKernelSize - 1
-        let n = encoder.layers.count
-        let total = features.shape[1]
 
-        var attnCache = [MLXArray?](repeating: nil, count: n)
-        var convCache = [MLXArray?](repeating: nil, count: n)
-        var melCache: MLXArray?
-        var emitted = 0
-        var consumed = 0
+        while state.consumed < limit {
+            let end = min(state.consumed + chunkMel, limit)
+            // Mid-stream: defer a partial trailing chunk until the next call / flush.
+            if !flushTail && (end - state.consumed) < chunkMel { break }
 
-        while consumed < total {
-            let end = min(consumed + chunkMel, total)
-            let m = features[0..., consumed..<end, 0...]
-            let cacheLen = melCache?.shape[1] ?? 0
-            let win = melCache == nil ? m : MLX.concatenated([melCache!, m], axis: 1)
+            let m = features[0..., state.consumed..<end, 0...]
+            let cacheLen = state.melCache?.shape[1] ?? 0
+            let win = state.melCache == nil ? m : MLX.concatenated([state.melCache!, m], axis: 1)
             let winLen = win.shape[1]
             let lengths = MLXArray([Int32(winLen)]).asType(.int32)
             let sub = encoder.preEncode(win, lengths: lengths).0  // (1, k, d)
 
-            let isFinal = end >= total
-            let base = (consumed - cacheLen) / sf
-            let lo = emitted - base
+            let isFinal = flushTail && (end >= limit)
+            let base = (state.consumed - cacheLen) / sf
+            let lo = state.emitted - base
             let hi = isFinal ? sub.shape[1] : (end / sf - base)
-            consumed = end
-            melCache = win[0..., max(0, winLen - nemoPreEncodeMelCache)..<winLen, 0...]
+            state.consumed = end
+            state.melCache = win[0..., max(0, winLen - nemoPreEncodeMelCache)..<winLen, 0...]
 
             if hi <= lo {
-                emitted = base + max(lo, hi)
+                state.emitted = base + max(lo, hi)
                 continue
             }
-            emitted = base + hi
+            state.emitted = base + hi
             var h = sub[0..., lo..<hi, 0...]
             for li in encoder.layers.indices {
                 let r = nemoStreamBlock(
                     encoder.layers[li], h,
-                    attnCache: attnCache[li], convCache: convCache[li],
+                    attnCache: state.attnCache[li], convCache: state.convCache[li],
                     leftCache: leftCache, convLeft: convLeft
                 )
                 h = r.0
-                attnCache[li] = r.1
-                convCache[li] = r.2
+                state.attnCache[li] = r.1
+                state.convCache[li] = r.2
             }
             onChunk(applyPrompt(h, language: language))
         }

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -369,6 +369,16 @@ enum App {
         if let voxtral = model as? VoxtralRealtimeModel {
             return runVoxtralStreaming(model: voxtral, audio: audio, parameters: parameters)
         }
+        // Nemotron has a true online session — feed audio as it arrives instead of the
+        // whole-buffer generateStream. The chunked-feed logic lives in the model. The
+        // session needs NA (frozen) mel normalization; for per-utterance normalization
+        // fall through to the generic stream instead of aborting on its precondition.
+        if let nemotron = model as? NemotronASRModel {
+            let norm = nemotron.preprocessConfig.normalize.lowercased()
+            if norm == "na" || norm == "none" {
+                return runNemotronStreaming(model: nemotron, audio: audio, parameters: parameters)
+            }
+        }
 
         var finalOutput: STTOutput?
         var streamedText = ""
@@ -404,6 +414,24 @@ enum App {
     /// callers can reuse it; the CLI only renders the deltas.
     private static func runVoxtralStreaming(
         model: VoxtralRealtimeModel,
+        audio: MLXArray,
+        parameters: STTGenerateParameters
+    ) -> STTOutput {
+        var emitted = false
+        let output = model.transcribeStreaming(audio: audio, generationParameters: parameters) { delta in
+            emitted = true
+            print(delta, terminator: "")
+            fflush(stdout)
+        }
+        if emitted { print() }
+        return output
+    }
+
+    /// Drive Nemotron's streaming transcription from a file, printing each delta live.
+    /// The chunked-feed logic lives in `NemotronASRModel.transcribeStreaming` so other
+    /// callers can reuse it; the CLI only renders the deltas.
+    private static func runNemotronStreaming(
+        model: NemotronASRModel,
         audio: MLXArray,
         parameters: STTGenerateParameters
     ) -> STTOutput {

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -2644,6 +2644,67 @@ struct NemotronASRTests {
         )
         #expect(NemotronASRTokenizer.detectedLanguage(tokens: [1, 2, 3], vocabulary: vocab) == "en-US")
     }
+
+    /// Synthetic 16 kHz waveform long enough to span several native chunks.
+    private func syntheticAudio(samples: Int) -> MLXArray {
+        let values = (0..<samples).map { i in
+            0.1 * sin(Float(i) * 0.05) + 0.05 * sin(Float(i) * 0.17)
+        }
+        return MLXArray(values)
+    }
+
+    private func wholeStreamText(_ model: NemotronASRModel, _ audio: MLXArray) async throws -> String {
+        var text = ""
+        for try await event in model.generateStream(
+            audio: audio,
+            generationParameters: STTGenerateParameters(language: "en-US")
+        ) {
+            if case let .result(out) = event { text = out.text }
+        }
+        return text
+    }
+
+    private func sessionText(_ model: NemotronASRModel, _ audio: MLXArray, feed: Int) -> (String, [Int]) {
+        let samples = audio.asArray(Float.self)
+        let session = model.makeStreamSession(language: "en-US")
+        var i = 0
+        while i < samples.count {
+            let e = min(i + feed, samples.count)
+            _ = session.step(Array(samples[i..<e]))
+            i = e
+        }
+        _ = session.finish()
+        return (session.text, session.tokens)
+    }
+
+    /// The incremental session, fed in small chunks, must reproduce the one-shot
+    /// `generateStream(wholeAudio)` transcript bit-for-bit (frozen-frame framing +
+    /// resumable encoder/RNN-T state).
+    @Test func streamSessionMatchesGenerateStream() async throws {
+        guard mlxRuntimeEnabled else {
+            print("Skipping Nemotron ASR MLX runtime test. Set MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS=1 to enable.")
+            return
+        }
+        let model = try tinyModel()
+        let audio = syntheticAudio(samples: 6000)
+        let whole = try await wholeStreamText(model, audio)
+        let (sessioned, tokens) = sessionText(model, audio, feed: 200)
+        #expect(sessioned == whole)
+        #expect(tokens.isEmpty == false)  // random weights still emit non-blank tokens
+    }
+
+    /// Output must be invariant to feed granularity: tiny chunks == large chunks.
+    @Test func streamSessionFeedGranularityInvariant() throws {
+        guard mlxRuntimeEnabled else {
+            print("Skipping Nemotron ASR MLX runtime test. Set MLXAUDIO_ENABLE_MLX_RUNTIME_TESTS=1 to enable.")
+            return
+        }
+        let model = try tinyModel()
+        let audio = syntheticAudio(samples: 6000)
+        let (fine, _) = sessionText(model, audio, feed: 96)
+        let (coarse, _) = sessionText(model, audio, feed: 1500)
+        #expect(fine == coarse)
+    }
 }
 
 struct VoxtralRealtimeSTTTests {


### PR DESCRIPTION
## What

Adds `NemotronASRStreamSession` — a true **online** streaming session for Nemotron 3.5 ASR. `generateStream` computes the whole-utterance mel up front, so a live caller only gets text once the entire buffer is in. This session ingests audio incrementally:

- `step(_ samples: [Float]) -> Delta` — feed a chunk, get the newly decoded text
- `finish() -> Delta` — flush the tail

Also adds `NemotronASRModel.transcribeStreaming(audio:generationParameters:onDelta:)`, which drives the session over a whole buffer (chunked feed) so any caller can reuse it — the CLI's `--stream` path just renders the deltas. (Mirrors the Voxtral streaming entrypoint from #205.)

## Changes

- **`NemotronASRStreamSession.swift`** (new) — the online session + `transcribeStreaming`
- **`NemotronASRModel.swift`**, **`NemotronASRStreaming.swift`** — extract reusable streaming primitives; no change to the existing offline / `generateStream` behaviour
- **`Tools/mlx-audio-swift-stt/App.swift`** — route `--stream` for Nemotron through `transcribeStreaming`
- **`Tests/MLXAudioSTTTests.swift`** — coverage

## Validation

- `swift build` against current `main` — green.
- Functional: streaming a ~1 min English clip via `step`/`finish` yields a transcript consistent with the offline path.