### PR TITLE
Add OmniVoice TTS (NAR diffusion over Qwen3 + HiggsAudioV2 codec, with voice cloning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MLXAudio follows a modular design allowing you to import only what you need:
 
 - **MLXAudioCore**: Base types, protocols, and utilities
 - **MLXAudioCodecs**: Audio codec implementations (SNAC, Encodec, Vocos, Mimi, DACVAE)
-- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, Fish Audio S2 Pro, Soprano, VyvoTTS, Orpheus, Marvis TTS, Pocket TTS, Irodori TTS)
+- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, OmniVoice, Fish Audio S2 Pro, Soprano, VyvoTTS, Orpheus, MOSS-TTS, Marvis TTS, Pocket TTS, Irodori TTS)
 - **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Voxtral Realtime, Cohere Transcribe, Parakeet, Nemotron ASR, GLMASR)
 - **MLXAudioVAD**: Voice Activity Detection & Speaker Diarization (Sortformer, SmartTurn)
 - **MLXAudioSTS**: Speech-to-Speech models (LFM2.5-Audio, SAM-Audio, MossFormer2-SE, DeepFilterNet)
@@ -119,6 +119,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 | Model | Model README | HuggingFace Repo |
 |-------|--------------|------------------|
 | Qwen3-TTS | [Qwen3-TTS README](Sources/MLXAudioTTS/Models/Qwen3TTS/README.md) | [mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit) |
+| OmniVoice | [OmniVoice README](Sources/MLXAudioTTS/Models/OmniVoice/README.md) | [mlx-community/OmniVoice](https://huggingface.co/mlx-community/OmniVoice) |
 | Fish Audio S2 Pro | [Fish Audio S2 Pro README](Sources/MLXAudioTTS/Models/FishSpeech/README.md) | [mlx-community/fish-audio-s2-pro-8bit](https://huggingface.co/mlx-community/fish-audio-s2-pro-8bit) |
 | Soprano | [Soprano README](Sources/MLXAudioTTS/Models/Soprano/README.md) | [mlx-community/Soprano-80M-bf16](https://huggingface.co/mlx-community/Soprano-80M-bf16) |
 | VyvoTTS | [VyvoTTS README](Sources/MLXAudioTTS/Models/Qwen3/README.md) | [mlx-community/VyvoTTS-EN-Beta-4bit](https://huggingface.co/mlx-community/VyvoTTS-EN-Beta-4bit) |

--- a/Sources/MLXAudioCore/ModelUtils.swift
+++ b/Sources/MLXAudioCore/ModelUtils.swift
@@ -79,19 +79,16 @@ public enum ModelUtils {
             .appendingPathComponent("mlx-audio")
             .appendingPathComponent(modelSubdir)
 
-        // Check if model already exists with required files
+        // Check if model already exists with required files. Some repos keep
+        // their weights in version subfolders (e.g. DeepFilterNet v1/v2/v3),
+        // so search the snapshot recursively rather than only the top level.
         if FileManager.default.fileExists(atPath: modelDir.path) {
-            let files = try? FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: [.fileSizeKey])
-            let hasRequiredFile = files?.contains { file in
-                guard file.pathExtension == normalizedRequiredExtension else { return false }
-                let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-                return size > 0
-            } ?? false
+            let hasRequiredFile =
+                firstNonEmptyFile(withExtension: normalizedRequiredExtension, under: modelDir) != nil
 
             if hasRequiredFile {
                 // Validate that config.json is valid JSON
-                let configPath = modelDir.appendingPathComponent("config.json")
-                if FileManager.default.fileExists(atPath: configPath.path) {
+                if let configPath = firstNonEmptyFile(withExtension: "json", named: "config.json", under: modelDir) {
                     if let configData = try? Data(contentsOf: configPath),
                        let _ = try? JSONSerialization.jsonObject(with: configData) {
                         print("Using cached model at: \(modelDir.path)")
@@ -132,14 +129,9 @@ public enum ModelUtils {
         )
 
         // Post-download validation: ensure required files are non-zero
-        let downloadedFiles = try? FileManager.default.contentsOfDirectory(
-            at: modelDir, includingPropertiesForKeys: [.fileSizeKey]
-        )
-        let hasValidFile = downloadedFiles?.contains { file in
-            guard file.pathExtension == normalizedRequiredExtension else { return false }
-            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-            return size > 0
-        } ?? false
+        // (recursive, for repos that keep weights in subfolders).
+        let hasValidFile =
+            firstNonEmptyFile(withExtension: normalizedRequiredExtension, under: modelDir) != nil
 
         if !hasValidFile {
             Self.clearCaches(modelDir: modelDir, repoID: repoID, hubCache: cache)
@@ -148,6 +140,29 @@ public enum ModelUtils {
 
         print("Model downloaded to: \(modelDir.path)")
         return modelDir
+    }
+
+    /// Recursively finds a non-zero-sized file with the given extension (and
+    /// optionally an exact file name), preferring the shallowest match.
+    private static func firstNonEmptyFile(
+        withExtension pathExtension: String,
+        named fileName: String? = nil,
+        under directory: URL
+    ) -> URL? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+
+        var matches: [URL] = []
+        for case let file as URL in enumerator {
+            guard file.pathExtension == pathExtension else { continue }
+            if let fileName, file.lastPathComponent != fileName { continue }
+            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            if size > 0 { matches.append(file) }
+        }
+        return matches.min { $0.pathComponents.count < $1.pathComponents.count }
     }
 
     private static func clearCaches(modelDir: URL, repoID: Repo.ID, hubCache: HubCache) {

--- a/Sources/MLXAudioCore/ModelUtils.swift
+++ b/Sources/MLXAudioCore/ModelUtils.swift
@@ -79,16 +79,19 @@ public enum ModelUtils {
             .appendingPathComponent("mlx-audio")
             .appendingPathComponent(modelSubdir)
 
-        // Check if model already exists with required files. Some repos keep
-        // their weights in version subfolders (e.g. DeepFilterNet v1/v2/v3),
-        // so search the snapshot recursively rather than only the top level.
+        // Check if model already exists with required files
         if FileManager.default.fileExists(atPath: modelDir.path) {
-            let hasRequiredFile =
-                firstNonEmptyFile(withExtension: normalizedRequiredExtension, under: modelDir) != nil
+            let files = try? FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: [.fileSizeKey])
+            let hasRequiredFile = files?.contains { file in
+                guard file.pathExtension == normalizedRequiredExtension else { return false }
+                let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+                return size > 0
+            } ?? false
 
             if hasRequiredFile {
                 // Validate that config.json is valid JSON
-                if let configPath = firstNonEmptyFile(withExtension: "json", named: "config.json", under: modelDir) {
+                let configPath = modelDir.appendingPathComponent("config.json")
+                if FileManager.default.fileExists(atPath: configPath.path) {
                     if let configData = try? Data(contentsOf: configPath),
                        let _ = try? JSONSerialization.jsonObject(with: configData) {
                         print("Using cached model at: \(modelDir.path)")
@@ -129,9 +132,14 @@ public enum ModelUtils {
         )
 
         // Post-download validation: ensure required files are non-zero
-        // (recursive, for repos that keep weights in subfolders).
-        let hasValidFile =
-            firstNonEmptyFile(withExtension: normalizedRequiredExtension, under: modelDir) != nil
+        let downloadedFiles = try? FileManager.default.contentsOfDirectory(
+            at: modelDir, includingPropertiesForKeys: [.fileSizeKey]
+        )
+        let hasValidFile = downloadedFiles?.contains { file in
+            guard file.pathExtension == normalizedRequiredExtension else { return false }
+            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            return size > 0
+        } ?? false
 
         if !hasValidFile {
             Self.clearCaches(modelDir: modelDir, repoID: repoID, hubCache: cache)
@@ -140,29 +148,6 @@ public enum ModelUtils {
 
         print("Model downloaded to: \(modelDir.path)")
         return modelDir
-    }
-
-    /// Recursively finds a non-zero-sized file with the given extension (and
-    /// optionally an exact file name), preferring the shallowest match.
-    private static func firstNonEmptyFile(
-        withExtension pathExtension: String,
-        named fileName: String? = nil,
-        under directory: URL
-    ) -> URL? {
-        guard let enumerator = FileManager.default.enumerator(
-            at: directory,
-            includingPropertiesForKeys: [.fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-
-        var matches: [URL] = []
-        for case let file as URL in enumerator {
-            guard file.pathExtension == pathExtension else { continue }
-            if let fileName, file.lastPathComponent != fileName { continue }
-            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-            if size > 0 { matches.append(file) }
-        }
-        return matches.min { $0.pathComponents.count < $1.pathComponents.count }
     }
 
     private static func clearCaches(modelDir: URL, repoID: Repo.ID, hubCache: HubCache) {

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -32,9 +32,6 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
     /// Each projects hidden states to codebook logits: [hiddenSize, audioVocabSize]
     @ModuleInfo(key: "audio_heads") var audioHeads: [Linear]
 
-    /// Normalized codebook weights for loss computation
-    private var normalizedCodebookWeights: [Float]
-
     public var tokenizer: Tokenizers.Tokenizer?
     var audioTokenizer: OmniVoiceAudioTokenizer?
 
@@ -48,8 +45,6 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             repetitionPenalty: 1.05
         )
     }
-
-    // MARK: - OmniVoice-specific defaults (unused; parameters are passed via generate())
 
     // MARK: - Initialization
 
@@ -83,10 +78,6 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         self._audioHeads.wrappedValue = (0..<config.numAudioCodebook).map { _ in
             Linear(inputDimensions: llmConfig.hiddenSize, outputDimensions: config.audioVocabSize, bias: false)
         }
-
-        // Normalized codebook weights
-        let totalWeight = config.audioCodebookWeights.reduce(0, +)
-        self.normalizedCodebookWeights = config.audioCodebookWeights.map { Float($0) / Float(totalWeight) }
     }
 
     // MARK: - Forward Pass
@@ -142,10 +133,10 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
 
         // Run through LLM. OmniVoice is a bidirectional NAR diffusion model:
         // the default must be NO attention mask (matching the Python reference,
-        // which never applies a causal mask). NOTE: call sites passing
-        // `attentionMask: .none` actually pass Optional.none (nil) because the
-        // parameter is Optional — which previously fell through to a CAUSAL
-        // mask here and garbled generation.
+        // which never applies a causal mask). Call sites pass `nil` (Optional.none),
+        // which this `?? .none` resolves to the no-mask enum case. Passing the
+        // enum `.none` literally would be ambiguous with Optional.none and once
+        // fell through to a CAUSAL mask here, garbling generation.
         let mask: MLXFast.ScaledDotProductAttentionMaskMode = attentionMask ?? .none
         let hiddenStates = llm.forwardWithEmbeddings(
             inputsEmbeds: inputsEmbeds,
@@ -157,7 +148,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         let batchSize = hiddenStates.shape[0]
         let seqLen = hiddenStates.shape[1]
         var logitsPerCodebook: [MLXArray] = []
-        for (i, head) in audioHeads.enumerated() {
+        for head in audioHeads {
             let logits = head(hiddenStates)  // [B, S, V]
             let reshaped = logits.reshaped([batchSize, seqLen, 1, config.audioVocabSize])
             logitsPerCodebook.append(reshaped)
@@ -336,7 +327,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         let numCodebooks = config.numAudioCodebook
         let targetLen = numTargetTokens
 
-        
+
         // Unconditional input: only the target region (matching Python reference)
         let prefixLen = condLength - targetLen
         var uncondInputIds = inputIds[0..., 0..., prefixLen...]  // [1, C, T]
@@ -453,12 +444,12 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             let finalCondLogits = forward(
                 inputIds: inputIds,
                 audioMask: audioMask,
-                attentionMask: .none
+                attentionMask: nil
             ).asType(.float32)
             let finalULogitsFull = forward(
                 inputIds: uncondInputIds,
                 audioMask: uncondAudioMask,
-                attentionMask: .none
+                attentionMask: nil
             ).asType(.float32)
             let finalC = finalCondLogits[0, (condLength - targetLen)..<condLength, 0..., 0...]
                 .transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
@@ -475,13 +466,13 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
 
         // 8. Decode tokens to waveform
         var outputTokens = tokens[0, 0..., 0..<targetLen]
-        
+
         // Replace any remaining mask tokens with 0 (matching Python reference)
         let remainingMask = outputTokens .== Int32(config.audioMaskId)
         if remainingMask.any().item(Bool.self) {
             outputTokens = MLX.where(remainingMask, MLXArray.zeros(outputTokens.shape, type: Int32.self), outputTokens)
         }
-        
+
         let audio = try audioTok.decode(outputTokens)
 
         // 9. Post-process
@@ -567,13 +558,6 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             steps.append(shifted)
         }
         return steps
-    }
-
-    private func makeCausalMask(length: Int) -> MLXArray {
-        // Lower triangular matrix
-        let rowIdx = MLXArray((0..<length).map { Int32($0) }).reshaped([length, 1])
-        let colIdx = MLXArray((0..<length).map { Int32($0) }).reshaped([1, length])
-        return (rowIdx .>= colIdx)
     }
 
     private func estimateTargetTokens(
@@ -710,7 +694,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         instruct: String?,
         denoise: Bool
     ) throws -> (inputIds: MLXArray, audioMask: MLXArray) {
-        guard let tokenizer else {
+        guard tokenizer != nil else {
             throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
         }
 
@@ -779,7 +763,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             audioStartIdx = totalLength - numTargetTokens
         }
 
-        
+
         let zerosPrefix = MLXArray.zeros([audioStartIdx], type: Bool.self)
         let onesSuffix = MLXArray.ones([totalLength - audioStartIdx], type: Bool.self)
         let condAudioMask = MLX.concatenated([zerosPrefix, onesSuffix], axis: 0)
@@ -792,7 +776,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         guard let tokenizer else {
             throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
         }
-        return try tokenizer.encode(text: text, addSpecialTokens: false)
+        return tokenizer.encode(text: text, addSpecialTokens: false)
     }
 
     private func combineText(refText: String?, text: String) -> String {
@@ -1114,8 +1098,8 @@ func snakeActivation(_ x: MLXArray) -> MLXArray {
 public final class OmniVoiceDACResidualUnit: Module {
     @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
     @ModuleInfo(key: "conv2") var conv2: OmniVoiceConv1d
-    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
-    @ModuleInfo(key: "snake2") var snake2: snakeAlpha
+    @ModuleInfo(key: "snake1") var snake1: SnakeAlpha
+    @ModuleInfo(key: "snake2") var snake2: SnakeAlpha
 
     init(channels: Int, kernelSize: Int, dilation: Int) {
         // Match PyTorch DAC: kernel_size=7 for conv1 with dilation-dependent same-padding,
@@ -1140,8 +1124,8 @@ public final class OmniVoiceDACResidualUnit: Module {
             stride: 1,
             padding: conv2Padding
         )
-        self._snake1.wrappedValue = snakeAlpha(channels: channels)
-        self._snake2.wrappedValue = snakeAlpha(channels: channels)
+        self._snake1.wrappedValue = SnakeAlpha(channels: channels)
+        self._snake2.wrappedValue = SnakeAlpha(channels: channels)
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
@@ -1150,7 +1134,7 @@ public final class OmniVoiceDACResidualUnit: Module {
         let c1 = conv1(s1)
         let s2 = snake2.callAsFunction(c1)
         let h = conv2(s2)
-        
+
         // Handle potential length mismatch for residual connection
         let xLen = x.shape[2]
         let hLen = h.shape[2]
@@ -1168,7 +1152,7 @@ public final class OmniVoiceDACResidualUnit: Module {
 }
 
 /// Learnable Snake activation parameter.
-public final class snakeAlpha: Module {
+public final class SnakeAlpha: Module {
     @ModuleInfo(key: "alpha") var alpha: MLXArray
 
     init(channels: Int) {
@@ -1189,23 +1173,23 @@ public final class snakeAlpha: Module {
 /// DAC downsampling block (Higgs Audio V2 EncoderBlock):
 /// 3 ResidualUnits(dilation 1,3,9) + Snake1d + WNConv1d.
 public final class OmniVoiceDACDownBlock: Module {
-    @ModuleInfo var res_unit1: OmniVoiceDACResidualUnit
-    @ModuleInfo var res_unit2: OmniVoiceDACResidualUnit
-    @ModuleInfo var res_unit3: OmniVoiceDACResidualUnit
-    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "res_unit1") var resUnit1: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "res_unit2") var resUnit2: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "res_unit3") var resUnit3: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "snake1") var snake1: SnakeAlpha
     @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
 
     init(inputChannels: Int, outputChannels: Int, stride: Int, kernelSize: Int) {
-        self._res_unit1.wrappedValue = OmniVoiceDACResidualUnit(
+        self._resUnit1.wrappedValue = OmniVoiceDACResidualUnit(
             channels: inputChannels, kernelSize: kernelSize, dilation: 1
         )
-        self._res_unit2.wrappedValue = OmniVoiceDACResidualUnit(
+        self._resUnit2.wrappedValue = OmniVoiceDACResidualUnit(
             channels: inputChannels, kernelSize: kernelSize, dilation: 3
         )
-        self._res_unit3.wrappedValue = OmniVoiceDACResidualUnit(
+        self._resUnit3.wrappedValue = OmniVoiceDACResidualUnit(
             channels: inputChannels, kernelSize: kernelSize, dilation: 9
         )
-        self._snake1.wrappedValue = snakeAlpha(channels: inputChannels)
+        self._snake1.wrappedValue = SnakeAlpha(channels: inputChannels)
         self._conv1.wrappedValue = OmniVoiceConv1d(
             inChannels: inputChannels,
             outChannels: outputChannels,
@@ -1216,9 +1200,9 @@ public final class OmniVoiceDACDownBlock: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var h = res_unit1(x)
-        h = res_unit2(h)
-        h = res_unit3(h)
+        var h = resUnit1(x)
+        h = resUnit2(h)
+        h = resUnit3(h)
         h = snake1.callAsFunction(h)
         h = conv1(h)
         return h
@@ -1228,14 +1212,14 @@ public final class OmniVoiceDACDownBlock: Module {
 /// DAC upsampling block (Higgs Audio V2 DecoderBlock):
 /// Snake1d + ConvTranspose1d + 3 ResidualUnits(dilation 1,3,9).
 public final class OmniVoiceDACUpBlock: Module {
-    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "snake1") var snake1: SnakeAlpha
     @ModuleInfo(key: "conv_t1") var convT1: OmniVoiceConvTranspose1d
-    @ModuleInfo var res_unit1: OmniVoiceDACResidualUnit
-    @ModuleInfo var res_unit2: OmniVoiceDACResidualUnit
-    @ModuleInfo var res_unit3: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "res_unit1") var resUnit1: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "res_unit2") var resUnit2: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "res_unit3") var resUnit3: OmniVoiceDACResidualUnit
 
     init(inputChannels: Int, outputChannels: Int, stride: Int, kernelSize: Int) {
-        self._snake1.wrappedValue = snakeAlpha(channels: inputChannels)
+        self._snake1.wrappedValue = SnakeAlpha(channels: inputChannels)
         self._convT1.wrappedValue = OmniVoiceConvTranspose1d(
             inChannels: inputChannels,
             outChannels: outputChannels,
@@ -1244,22 +1228,22 @@ public final class OmniVoiceDACUpBlock: Module {
             padding: stride / 2 + stride % 2,
             outputPadding: stride % 2
         )
-        self._res_unit1.wrappedValue = OmniVoiceDACResidualUnit(
+        self._resUnit1.wrappedValue = OmniVoiceDACResidualUnit(
             channels: outputChannels, kernelSize: kernelSize, dilation: 1
         )
-        self._res_unit2.wrappedValue = OmniVoiceDACResidualUnit(
+        self._resUnit2.wrappedValue = OmniVoiceDACResidualUnit(
             channels: outputChannels, kernelSize: kernelSize, dilation: 3
         )
-        self._res_unit3.wrappedValue = OmniVoiceDACResidualUnit(
+        self._resUnit3.wrappedValue = OmniVoiceDACResidualUnit(
             channels: outputChannels, kernelSize: kernelSize, dilation: 9
         )
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         var h = convT1(snake1.callAsFunction(x))
-        h = res_unit1(h)
-        h = res_unit2(h)
-        h = res_unit3(h)
+        h = resUnit1(h)
+        h = resUnit2(h)
+        h = resUnit3(h)
         return h
     }
 }
@@ -1268,7 +1252,7 @@ public final class OmniVoiceDACUpBlock: Module {
 public final class OmniVoiceDACAcousticEncoder: Module {
     @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
     @ModuleInfo var block: [OmniVoiceDACDownBlock]
-    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "snake1") var snake1: SnakeAlpha
     @ModuleInfo(key: "conv2") var conv2: OmniVoiceConv1d
 
     init(config: OmniVoiceAudioTokenizerConfig) {
@@ -1297,7 +1281,7 @@ public final class OmniVoiceDACAcousticEncoder: Module {
         }
         self._block.wrappedValue = blocks
 
-        self._snake1.wrappedValue = snakeAlpha(channels: currentChannels)
+        self._snake1.wrappedValue = SnakeAlpha(channels: currentChannels)
         self._conv2.wrappedValue = OmniVoiceConv1d(
             inChannels: currentChannels,
             outChannels: currentChannels / 8,   // 2048 → 256 to match checkpoint
@@ -1321,7 +1305,7 @@ public final class OmniVoiceDACAcousticEncoder: Module {
 public final class OmniVoiceDACAcousticDecoder: Module {
     @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
     @ModuleInfo var block: [OmniVoiceDACUpBlock]
-    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "snake1") var snake1: SnakeAlpha
     @ModuleInfo(key: "conv2") var conv2: OmniVoiceConv1d
 
     init(config: OmniVoiceAudioTokenizerConfig) {
@@ -1351,7 +1335,7 @@ public final class OmniVoiceDACAcousticDecoder: Module {
         }
         self._block.wrappedValue = blocks
 
-        self._snake1.wrappedValue = snakeAlpha(channels: currentChannels)
+        self._snake1.wrappedValue = SnakeAlpha(channels: currentChannels)
         self._conv2.wrappedValue = OmniVoiceConv1d(
             inChannels: currentChannels,
             outChannels: 1,
@@ -1637,7 +1621,7 @@ public final class OmniVoiceAudioTokenizer: Module {
                     k = String(k.dropLast("weight".count)) + "embed"
                 }
                 // NOTE: checkpoint alpha is [1,1,C] for NLC; Swift DAC uses NCL,
-                // so we reshape at runtime in snakeAlpha.callAsFunction instead.
+                // so we reshape at runtime in SnakeAlpha.callAsFunction instead.
                 // NOTE: we do NOT transpose 3D conv weights here because
                 // OmniVoiceConv1d and OmniVoiceConvTranspose1d already
                 // transpose from PyTorch [out,in,k] / [in,out,k] to MLX
@@ -1739,7 +1723,7 @@ public final class OmniVoiceAudioTokenizer: Module {
         if !extra.isEmpty {
             print("[OmniVoiceAudioTokenizer] WARNING: \(extra.count) extra keys in checkpoint: \(extra.prefix(10))")
         }
-        
+
         // Codec weights run as float32 (reference checkpoint ships fp32).
         let float32Weights = weights.mapValues { $0.asType(.float32) }
         try tokenizer.update(parameters: ModuleParameters.unflattened(float32Weights), verify: .noUnusedKeys)

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -312,7 +312,8 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             text: text,
             refText: refText,
             numRefAudioTokens: numRefTokCount,
-            speed: ovParameters.speed
+            speed: ovParameters.speed,
+            duration: ovParameters.duration
         )
 
         // 3. Prepare inference inputs
@@ -579,13 +580,125 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         text: String,
         refText: String?,
         numRefAudioTokens: Int,
-        speed: Float
+        speed: Float,
+        duration: Float?
     ) -> Int {
-        // Simple heuristic: ~4 tokens per character
-        let chars = text.count
-        let baseEstimate = max(25, chars * 4)
+        let tokensPerSecond = Float(config.sampleRate) / 960.0
+        if let duration {
+            return max(1, Int(ceil(duration * tokensPerSecond)))
+        }
+
+        // Parity with mlx-audio Python:
+        // RuleDurationEstimator().estimate_duration(text, "Nice to meet you.", 25)
+        // followed by a 1.15 safety margin. The previous `characters * 4`
+        // heuristic over-allocated English by roughly 2x, causing the diffusion
+        // model to place speech near the end of a long target window.
+        let rawTokens = estimateRuleDurationTokens(
+            targetText: text,
+            refText: "Nice to meet you.",
+            refDuration: 25.0
+        )
+        let baseEstimate = max(10, Int(rawTokens * 1.15))
         let adjusted = speed > 0 && speed != 1.0 ? Int(Float(baseEstimate) / speed) : baseEstimate
         return max(1, adjusted)
+    }
+
+    private func estimateRuleDurationTokens(
+        targetText: String,
+        refText: String,
+        refDuration: Float,
+        lowThreshold: Float = 50.0,
+        boostStrength: Float = 3.0
+    ) -> Float {
+        guard refDuration > 0, !refText.isEmpty else { return 0 }
+        let refWeight = phoneticWeight(refText)
+        guard refWeight > 0 else { return 0 }
+
+        let speedFactor = refWeight / refDuration
+        let estimated = phoneticWeight(targetText) / speedFactor
+        if estimated < lowThreshold {
+            let alpha = 1.0 / boostStrength
+            return lowThreshold * pow(estimated / lowThreshold, alpha)
+        }
+        return estimated
+    }
+
+    private func phoneticWeight(_ text: String) -> Float {
+        text.unicodeScalars.reduce(Float(0)) { total, scalar in
+            total + phoneticWeight(scalar)
+        }
+    }
+
+    private func phoneticWeight(_ scalar: Unicode.Scalar) -> Float {
+        let code = scalar.value
+        if (65...90).contains(code) || (97...122).contains(code) {
+            return 1.0
+        }
+        if code == 32 {
+            return 0.2
+        }
+        if code == 0x0640 {
+            return 0.0
+        }
+
+        switch scalar.properties.generalCategory {
+        case .nonspacingMark, .spacingMark, .enclosingMark:
+            return 0.0
+        case .connectorPunctuation, .dashPunctuation, .openPunctuation, .closePunctuation,
+             .initialPunctuation, .finalPunctuation, .otherPunctuation,
+             .mathSymbol, .currencySymbol, .modifierSymbol, .otherSymbol:
+            return 0.5
+        case .spaceSeparator, .lineSeparator, .paragraphSeparator:
+            return 0.2
+        case .decimalNumber, .letterNumber, .otherNumber:
+            return 3.5
+        default:
+            break
+        }
+
+        return scriptWeight(for: code)
+    }
+
+    private func scriptWeight(for code: UInt32) -> Float {
+        if code <= 0x02AF { return 1.0 }
+        if code <= 0x03FF { return 1.0 }
+        if code <= 0x052F { return 1.0 }
+        if code <= 0x058F { return 1.0 }
+        if code <= 0x05FF { return 1.5 }
+        if code <= 0x08FF { return 1.5 }
+        if code <= 0x0DFF { return 1.8 }
+        if code <= 0x0EFF { return 1.5 }
+        if code <= 0x0FFF { return 1.8 }
+        if code <= 0x109F { return 1.8 }
+        if code <= 0x10FF { return 1.0 }
+        if code <= 0x11FF { return 2.5 }
+        if code <= 0x139F { return 3.0 }
+        if code <= 0x17FF { return 1.8 }
+        if code <= 0x1C7F { return 1.8 }
+        if code <= 0x1C8F { return 1.0 }
+        if code <= 0x1CBF { return 1.0 }
+        if code <= 0x1CFF { return 1.8 }
+        if code <= 0x1EFF { return 1.0 }
+        if code <= 0x309F { return 2.2 }
+        if code <= 0x30FF { return 2.2 }
+        if code <= 0x312F { return 3.0 }
+        if code <= 0x318F { return 2.5 }
+        if code <= 0x9FFF { return 3.0 }
+        if code <= 0xA4CF { return 3.0 }
+        if code <= 0xA69F { return 1.0 }
+        if code <= 0xA7FF { return 1.0 }
+        if code <= 0xA8FF { return 1.8 }
+        if code <= 0xA97F { return 2.5 }
+        if code <= 0xAADF { return 1.8 }
+        if code <= 0xAB2F { return 3.0 }
+        if code <= 0xAB6F { return 1.0 }
+        if code <= 0xABFF { return 1.8 }
+        if code <= 0xD7AF { return 2.5 }
+        if code <= 0xFAFF { return 3.0 }
+        if code <= 0xFEFF { return 1.5 }
+        if code <= 0xFFEF { return 1.0 }
+        if code > 0x20000 { return 3.0 }
+        return 1.0
     }
 
     private func prepareInferenceInputs(
@@ -1569,4 +1682,3 @@ public final class OmniVoiceAudioTokenizer: Module {
         return maxIdx >= 0 ? maxIdx + 1 : nil
     }
 }
-

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -1,0 +1,1743 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCodecs
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+import Tokenizers
+
+// MARK: - OmniVoice Model
+
+/// OmniVoice: A massively multilingual zero-shot TTS model supporting over 600 languages.
+///
+/// Built on a novel diffusion language model architecture with a Qwen3 LLM backbone,
+/// OmniVoice supports:
+/// - **Voice Cloning**: Clone any voice from a reference audio + transcript
+/// - **Voice Design**: Create custom voices via text instructions
+/// - **Auto Voice**: Default voice when no voice specification is provided
+public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sendable {
+    // MARK: - Properties
+
+    let config: OmniVoiceConfig
+
+    /// Qwen3 LLM backbone
+    @ModuleInfo(key: "llm") private var llm: Qwen3Model
+
+    /// Audio embeddings: array of embeddings, one per codebook
+    /// Each maps audio token IDs to hidden states: [audioVocabSize, hiddenSize]
+    @ModuleInfo(key: "audio_embeddings") var audioEmbeddings: [Embedding]
+
+    /// Audio heads: array of Linear layers, one per codebook
+    /// Each projects hidden states to codebook logits: [hiddenSize, audioVocabSize]
+    @ModuleInfo(key: "audio_heads") var audioHeads: [Linear]
+
+    /// Normalized codebook weights for loss computation
+    private var normalizedCodebookWeights: [Float]
+
+    public var tokenizer: Tokenizers.Tokenizer?
+    var audioTokenizer: OmniVoiceAudioTokenizer?
+
+    public var sampleRate: Int { config.sampleRate }
+
+    public var defaultGenerationParameters: GenerateParameters {
+        GenerateParameters(
+            maxTokens: 4096,
+            temperature: 1.0,
+            topP: 0.95,
+            repetitionPenalty: 1.05
+        )
+    }
+
+    // MARK: - OmniVoice-specific defaults (unused; parameters are passed via generate())
+
+    // MARK: - Initialization
+
+    init(config: OmniVoiceConfig) throws {
+        self.config = config
+        let llmConfig = config.llmConfig
+
+        // Create the Qwen3 LLM from config
+        let llmConfigWrapper = Qwen3Configuration(
+            hiddenSize: llmConfig.hiddenSize,
+            hiddenLayers: llmConfig.numHiddenLayers,
+            intermediateSize: llmConfig.intermediateSize,
+            attentionHeads: llmConfig.numAttentionHeads,
+            kvHeads: llmConfig.numKeyValueHeads,
+            headDim: llmConfig.headDim,
+            vocabularySize: llmConfig.vocabSize,
+            rmsNormEps: llmConfig.rmsNormEps,
+            ropeTheta: llmConfig.ropeTheta,
+            ropeScaling: nil,
+            tieWordEmbeddings: llmConfig.tieWordEmbeddings,
+            sampleRate: 24000
+        )
+        self._llm.wrappedValue = Qwen3Model(llmConfigWrapper)
+
+        // Audio embeddings: array of [numAudioCodebook] embeddings, each [audioVocabSize, hiddenSize]
+        self._audioEmbeddings.wrappedValue = (0..<config.numAudioCodebook).map { _ in
+            Embedding(embeddingCount: config.audioVocabSize, dimensions: llmConfig.hiddenSize)
+        }
+
+        // Audio heads: array of [numAudioCodebook] Linear layers, each [hiddenSize, audioVocabSize]
+        self._audioHeads.wrappedValue = (0..<config.numAudioCodebook).map { _ in
+            Linear(inputDimensions: llmConfig.hiddenSize, outputDimensions: config.audioVocabSize, bias: false)
+        }
+
+        // Normalized codebook weights
+        let totalWeight = config.audioCodebookWeights.reduce(0, +)
+        self.normalizedCodebookWeights = config.audioCodebookWeights.map { Float($0) / Float(totalWeight) }
+    }
+
+    // MARK: - Forward Pass
+
+    /// Prepare embeddings from input_ids with audio/text masking.
+    private func prepareEmbedInputs(
+        inputIds: MLXArray,
+        audioMask: MLXArray
+    ) -> MLXArray {
+        // Text embeddings from LLM
+        let textIds = inputIds[0..., 0, 0...]  // [B, S]
+        let textEmbeds = llm.getEmbeddings(for: textIds)
+
+        // Apply audio mask to inputIds
+        let maskedIds = inputIds * audioMask.reshaped([inputIds.shape[0], 1, inputIds.shape[2]])
+
+        // Embed each codebook separately and sum
+        var audioEmbeds: MLXArray?
+        for (i, embedding) in audioEmbeddings.enumerated() {
+            let codebookIds = maskedIds[0..., i, 0...]  // [B, S]
+            let codebookEmbeds = embedding(codebookIds)  // [B, S, D]
+            if audioEmbeds == nil {
+                audioEmbeds = codebookEmbeds
+            } else {
+                audioEmbeds = audioEmbeds! + codebookEmbeds
+            }
+        }
+
+        // Where audio: use audio_embeds, else use text_embeds
+        let result = MLX.where(
+            audioMask.reshaped([audioMask.shape[0], audioMask.shape[1], 1]),
+            audioEmbeds!,
+            textEmbeds
+        )
+        return result
+    }
+
+    /// Forward pass through the model.
+    ///
+    /// - Parameters:
+    ///   - inputIds: [batch, num_codebooks, seq_len]
+    ///   - audioMask: [batch, seq_len]
+    ///   - attentionMask: optional custom attention mask (defaults to causal)
+    ///   - cache: optional KV cache
+    /// - Returns: Audio logits [batch, num_codebooks, seq_len, vocab_size]
+    public func forward(
+        inputIds: MLXArray,
+        audioMask: MLXArray,
+        attentionMask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
+        cache: [KVCache]? = nil
+    ) -> MLXArray {
+        let inputsEmbeds = prepareEmbedInputs(inputIds: inputIds, audioMask: audioMask)
+
+        // Run through LLM. OmniVoice is a bidirectional NAR diffusion model:
+        // the default must be NO attention mask (matching the Python reference,
+        // which never applies a causal mask). NOTE: call sites passing
+        // `attentionMask: .none` actually pass Optional.none (nil) because the
+        // parameter is Optional — which previously fell through to a CAUSAL
+        // mask here and garbled generation.
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode = attentionMask ?? .none
+        let hiddenStates = llm.forwardWithEmbeddings(
+            inputsEmbeds: inputsEmbeds,
+            cache: cache,
+            mask: mask
+        )
+
+        // Project to audio codebook logits via per-codebook heads
+        let batchSize = hiddenStates.shape[0]
+        let seqLen = hiddenStates.shape[1]
+        var logitsPerCodebook: [MLXArray] = []
+        for (i, head) in audioHeads.enumerated() {
+            let logits = head(hiddenStates)  // [B, S, V]
+            let reshaped = logits.reshaped([batchSize, seqLen, 1, config.audioVocabSize])
+            logitsPerCodebook.append(reshaped)
+        }
+        let audioLogits = MLX.concatenated(logitsPerCodebook, axis: 2)  // [B, S, C, V]
+
+        return audioLogits
+    }
+
+    // MARK: - SpeechGenerationModel Protocol
+
+    /// Generate audio using the standard protocol (uses sensible defaults).
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        guard tokenizer != nil else {
+            throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
+        }
+        // Use OmniVoice-specific defaults internally
+        let ovParams = OmniVoiceGenerateParameters()
+        return try await generateAudio(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            ovParameters: ovParams
+        )
+    }
+
+    /// Generate audio with custom OmniVoice diffusion parameters.
+    ///
+    /// - Parameters:
+    ///   - text: Text to synthesize
+    ///   - voice: Voice design instruction (e.g., "male, British accent") or nil for auto voice
+    ///   - refAudio: Reference audio for voice cloning
+    ///   - refText: Transcript of reference audio
+    ///   - language: Language code
+    ///   - ovParameters: OmniVoice-specific diffusion and generation parameters
+    /// - Returns: Generated audio waveform at 24kHz
+    public func generate(
+        text: String,
+        voice: String? = nil,
+        refAudio: MLXArray? = nil,
+        refText: String? = nil,
+        language: String? = nil,
+        ovParameters: OmniVoiceGenerateParameters
+    ) async throws -> MLXArray {
+        guard tokenizer != nil else {
+            throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
+        }
+        return try await generateAudio(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            ovParameters: ovParameters
+        )
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        generateStream(
+            text: text,
+            voice: voice,
+            refAudio: refAudio,
+            refText: refText,
+            language: language,
+            generationParameters: generationParameters,
+            streamingInterval: 2.0
+        )
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let ovParams = OmniVoiceGenerateParameters()
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+        Task { @Sendable [weak self] in
+            guard let self else { return }
+            do {
+                guard tokenizer != nil else {
+                    throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
+                }
+                let audio = try await generateAudio(
+                    text: text,
+                    voice: voice,
+                    refAudio: refAudio,
+                    refText: refText,
+                    language: language,
+                    ovParameters: ovParams
+                )
+                let info = AudioGenerationInfo(
+                    promptTokenCount: 0,
+                    generationTokenCount: 0,
+                    prefillTime: 0,
+                    generateTime: 0,
+                    tokensPerSecond: 0,
+                    peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+                )
+                continuation.yield(.info(info))
+                continuation.yield(.audio(audio))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        return stream
+    }
+
+    // MARK: - Generation
+
+    private func generateAudio(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        ovParameters: OmniVoiceGenerateParameters
+    ) async throws -> MLXArray {
+        guard let audioTok = audioTokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Audio tokenizer not loaded")
+        }
+
+        // 1. Encode reference audio to tokens if provided
+        var refAudioTokens: MLXArray?
+        if let refAudio {
+            refAudioTokens = try audioTok.encode(refAudio)
+        }
+
+        // 2. Estimate target token count
+        let numRefTokCount = refAudioTokens?.shape.last ?? 0
+        let numTargetTokens = estimateTargetTokens(
+            text: text,
+            refText: refText,
+            numRefAudioTokens: numRefTokCount,
+            speed: ovParameters.speed
+        )
+
+        // 3. Prepare inference inputs
+        let prepared = try prepareInferenceInputs(
+            text: text,
+            numTargetTokens: numTargetTokens,
+            refText: refText,
+            refAudioTokens: refAudioTokens,
+            language: language,
+            instruct: voice,
+            denoise: ovParameters.denoise
+        )
+
+        var inputIds = prepared.inputIds
+        let audioMask = prepared.audioMask
+        let condLength = inputIds.shape[2]
+
+        // 4. Build batched inputs for CFG (cond + uncond)
+        let B = 1
+        let numCodebooks = config.numAudioCodebook
+        let targetLen = numTargetTokens
+
+        
+        // Unconditional input: only the target region (matching Python reference)
+        let prefixLen = condLength - targetLen
+        var uncondInputIds = inputIds[0..., 0..., prefixLen...]  // [1, C, T]
+        let uncondAudioMask = audioMask[0..., prefixLen...]  // [1, T]
+
+        // 5. Initialize target tokens to all MASK
+        var tokens = MLXArray.full(
+            [B, numCodebooks, targetLen],
+            values: MLXArray(Int32(config.audioMaskId))
+        )
+
+        // 6. Compute timesteps and unmasking schedule (parity with the Python
+        // reference: num_step+1 points spaced 1/num_step, k = max(1, ceil(total*dt)),
+        // capped by the remaining masked count so putAlong never overwrites
+        // already-revealed positions)
+        // Clamp to >= 1: numStep <= 0 would trap in getTimeSteps' 0...numStep range
+        // (a remote crash for server embedders) or skip diffusion entirely.
+        let numSteps = max(1, ovParameters.numStep)
+        let timesteps = getTimeSteps(tStart: 0.0, tEnd: 1.0, numStep: numSteps, tShift: ovParameters.tShift)
+
+        let totalMask = targetLen * numCodebooks
+        var rem = totalMask
+        var schedule: [Int] = []
+        for step in 0..<numSteps {
+            var k: Int
+            if step == numSteps - 1 {
+                k = rem
+            } else {
+                let ceilVal = max(1, Int(ceil(Float(totalMask) * (timesteps[step + 1] - timesteps[step]))))
+                k = min(ceilVal, rem)
+            }
+            if k < 0 { k = 0 }
+            schedule.append(k)
+            rem -= k
+        }
+
+        let layerIds = MLXArray((0..<numCodebooks).map { Int32($0) }).reshaped([1, numCodebooks, 1])
+
+        // Diagnostic: test backbone reconstruction on reference audio tokens
+        if let refTok = refAudioTokens {
+            let refLen = min(refTok.shape[1], targetLen)
+            let refPrefix = refTok[0..., 0..<refLen]
+            let refPadding = MLXArray.full([numCodebooks, targetLen - refLen], values: MLXArray(Int32(config.audioMaskId)))
+            let refTarget = MLX.concatenated([refPrefix, refPadding], axis: 1).reshaped([1, numCodebooks, targetLen])
+            let prefix = inputIds[0..., 0..., 0..<prefixLen]
+            let diagInputIds = MLX.concatenated([prefix, refTarget], axis: 2)
+            
+            // Step-by-step diagnostic to isolate where predictions break
+            let diagEmbeds = prepareEmbedInputs(inputIds: diagInputIds, audioMask: audioMask)
+            print("[OmniVoice DIAG] embeds: shape=\(diagEmbeds.shape), min=\(diagEmbeds.min().item(Float.self)), max=\(diagEmbeds.max().item(Float.self)), mean=\(diagEmbeds.mean().item(Float.self))")
+            
+            let diagHidden = llm.forwardWithEmbeddings(inputsEmbeds: diagEmbeds, cache: nil, mask: .none).asType(.float32)
+            print("[OmniVoice DIAG] hidden: shape=\(diagHidden.shape), min=\(diagHidden.min().item(Float.self)), max=\(diagHidden.max().item(Float.self)), mean=\(diagHidden.mean().item(Float.self))")
+            
+            var diagLogitsList: [MLXArray] = []
+            for (i, head) in audioHeads.enumerated() {
+                let hLogits = head(diagHidden)  // [B, S, V]
+                let hReshaped = hLogits.reshaped([diagHidden.shape[0], diagHidden.shape[1], 1, config.audioVocabSize])
+                diagLogitsList.append(hReshaped)
+            }
+            let diagLogits = MLX.concatenated(diagLogitsList, axis: 2).asType(.float32)
+            print("[OmniVoice DIAG] logits: shape=\(diagLogits.shape), min=\(diagLogits.min().item(Float.self)), max=\(diagLogits.max().item(Float.self)), mean=\(diagLogits.mean().item(Float.self))")
+            
+            let diagTargetLogits = diagLogits[0, (condLength - targetLen)..<condLength, 0..., 0...]
+            let diagTargetLogitsBatch = diagTargetLogits.transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
+            let diagPreds = MLX.argMax(diagTargetLogitsBatch, axis: -1)[0]
+            let refForCompare = refTarget[0..., 0..., 0..<refLen]
+            let predForCompare = diagPreds[0..., 0..<refLen]
+            let match = (refForCompare .== predForCompare).sum().item(Int32.self)
+            let total = refLen * numCodebooks
+            print("[OmniVoice] DIAGNOSTIC: backbone reconstruction accuracy on ref audio = \(match)/\(total) (\(String(format: "%.1f", Float(match)/Float(total)*100))%)")
+            
+            // Extra diagnostic: print top-1 token distribution for first codebook
+            let firstCbPreds = predForCompare[0, 0...].asArray(Int32.self)
+            let uniquePreds = Dictionary(grouping: firstCbPreds, by: { $0 }).mapValues { $0.count }
+            let topPreds = uniquePreds.sorted { $0.value > $1.value }.prefix(5)
+            print("[OmniVoice DIAG] first codebook top-5 predicted tokens: \(Array(topPreds))")
+        }
+
+        // 7. Iterative diffusion generation
+        for step in 0..<numSteps {
+            let k = schedule[step]
+            if k <= 0 { continue }
+
+            // Separate forward passes for cond and uncond to avoid custom batch mask issues
+            let condLogits = forward(
+                inputIds: inputIds,
+                audioMask: audioMask,
+                attentionMask: .none
+            ).asType(.float32)
+            let uLogitsFull = forward(
+                inputIds: uncondInputIds,
+                audioMask: uncondAudioMask,
+                attentionMask: .none
+            ).asType(.float32)
+
+            // Diagnostic: print logits statistics on step 0
+            if step == 0 {
+                let cMin = condLogits.min().item(Float.self)
+                let cMax = condLogits.max().item(Float.self)
+                let cMean = condLogits.mean().item(Float.self)
+                let cAnyNaN = isNaN(condLogits).any().item(Bool.self)
+                let cAnyInf = isInf(condLogits).any().item(Bool.self)
+                let uMin = uLogitsFull.min().item(Float.self)
+                let uMax = uLogitsFull.max().item(Float.self)
+                let uMean = uLogitsFull.mean().item(Float.self)
+                let uAnyNaN = isNaN(uLogitsFull).any().item(Bool.self)
+                let uAnyInf = isInf(uLogitsFull).any().item(Bool.self)
+                print("[OmniVoice] Step 0 cond logits: min=\(cMin), max=\(cMax), mean=\(cMean), hasNaN=\(cAnyNaN), hasInf=\(cAnyInf)")
+                print("[OmniVoice] Step 0 uncond logits: min=\(uMin), max=\(uMax), mean=\(uMean), hasNaN=\(uAnyNaN), hasInf=\(uAnyInf)")
+            }
+
+            // Extract target region logits
+            let cLogits = condLogits[0, (condLength - targetLen)..<condLength, 0..., 0...]
+            let uLogits = uLogitsFull[0, 0..<targetLen, 0..., 0...]
+
+            // Reshape for scoring: [T, C, V] -> [1, C, T, V]
+            let cLogitsBatch = cLogits.transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
+            let uLogitsBatch = uLogits.transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
+
+            // Token prediction with CFG
+            let (predTokens, scores) = predictTokensWithScoring(
+                cLogits: cLogitsBatch,
+                uLogits: uLogitsBatch,
+                guidanceScale: ovParameters.guidanceScale,
+                classTemperature: ovParameters.classTemperature
+            )
+
+            // Apply layer penalty
+            let adjustedScores = scores - (layerIds.asType(.float32) * ovParameters.layerPenaltyFactor)
+
+            // Gumbel sampling for position selection
+            var finalScores = adjustedScores
+            if ovParameters.positionTemperature > 0.0 {
+                finalScores = gumbelSample(logits: adjustedScores, temperature: ovParameters.positionTemperature)
+            }
+
+            // Mask out already-filled positions
+            let mask = tokens[0] .!= Int32(config.audioMaskId)
+            let maskInf = MLX.where(mask, MLXArray(Float(-Float.infinity)), finalScores).asType(.float32)
+
+            // Parity-debug trace: dump step-0 scoring internals
+            if step == 0, ProcessInfo.processInfo.environment["OMNIVOICE_TRACE"] != nil {
+                try? FileManager.default.createDirectory(
+                    atPath: "/tmp/ov-trace-swift", withIntermediateDirectories: true)
+                try? MLX.save(
+                    arrays: [
+                        "pred_tokens": predTokens[0].asType(.int32),
+                        "scores": scores[0].asType(.float32),
+                        "final_scores": finalScores.reshaped([numCodebooks, targetLen]).asType(.float32),
+                        "input_ids": inputIds[0].asType(.int32),
+                        "audio_mask": audioMask.asType(.int32),
+                        "uncond_input_ids": uncondInputIds[0].asType(.int32),
+                        "uncond_audio_mask": uncondAudioMask.asType(.int32),
+                        "c_logits": cLogitsBatch.asType(.float32),
+                        "u_logits": uLogitsBatch.asType(.float32),
+                    ],
+                    url: URL(fileURLWithPath: "/tmp/ov-trace-swift/step00-internals.safetensors"))
+            }
+
+            // Flatten for top-k selection
+            let flatScores = maskInf.reshaped([-1])
+            let flatTokens = tokens[0].reshaped([-1])
+            let flatPreds = predTokens[0].reshaped([-1])
+
+            // Select top-k positions to unmask
+            let negScores = MLXArray(-1.0) * flatScores.asType(.float32)
+            let sortedIndices = MLX.argSort(negScores, axis: 0)
+            let rangeIndices = MLXArray((0..<k).map { Int32($0) })
+            let topkIndices = MLX.take(sortedIndices, rangeIndices, axis: 0)
+
+            // Vectorized update using putAlong
+            let linearTopkIndices = topkIndices.reshaped([-1])
+            let updateValues = MLX.take(flatPreds, linearTopkIndices, axis: 0)
+            let updatedTokens = putAlong(flatTokens, linearTopkIndices, values: updateValues, axis: 0)
+
+            let reshapedTokens = updatedTokens.reshaped([numCodebooks, targetLen])
+            tokens = reshapedTokens.reshaped([1, numCodebooks, targetLen])
+
+            // Update cond and uncond inputs for next step
+            let condHead = inputIds[0, 0..., 0..<prefixLen]
+            inputIds = MLX.concatenated([condHead, tokens[0]], axis: 1)
+                .reshaped([1, numCodebooks, condLength])
+            uncondInputIds = tokens  // uncond is just the target region
+
+            eval(inputIds, uncondInputIds, tokens)
+
+            // Parity-debug trace: dump per-step tokens when OMNIVOICE_TRACE is set
+            if ProcessInfo.processInfo.environment["OMNIVOICE_TRACE"] != nil {
+                let dir = "/tmp/ov-trace-swift"
+                try? FileManager.default.createDirectory(
+                    atPath: dir, withIntermediateDirectories: true)
+                try? MLX.save(
+                    arrays: ["tokens": tokens[0], "k": MLXArray(Int32(k))],
+                    url: URL(fileURLWithPath: String(format: "%@/step%02d.safetensors", dir, step)))
+            }
+        }
+
+        // Safeguard: fill any remaining mask tokens with a final deterministic prediction
+        let finalMask = tokens .== Int32(config.audioMaskId)
+        if finalMask.any().item(Bool.self) {
+            let finalCondLogits = forward(
+                inputIds: inputIds,
+                audioMask: audioMask,
+                attentionMask: .none
+            ).asType(.float32)
+            let finalULogitsFull = forward(
+                inputIds: uncondInputIds,
+                audioMask: uncondAudioMask,
+                attentionMask: .none
+            ).asType(.float32)
+            let finalC = finalCondLogits[0, (condLength - targetLen)..<condLength, 0..., 0...]
+                .transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
+            let finalU = finalULogitsFull[0, 0..<targetLen, 0..., 0...]
+                .transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
+            let (finalPredTokens, _) = predictTokensWithScoring(
+                cLogits: finalC,
+                uLogits: finalU,
+                guidanceScale: ovParameters.guidanceScale,
+                classTemperature: 0.0
+            )
+            tokens = MLX.where(finalMask, finalPredTokens, tokens)
+        }
+
+        // 8. Decode tokens to waveform
+        var outputTokens = tokens[0, 0..., 0..<targetLen]
+        
+        // Replace any remaining mask tokens with 0 (matching Python reference)
+        let remainingMask = outputTokens .== Int32(config.audioMaskId)
+        if remainingMask.any().item(Bool.self) {
+            outputTokens = MLX.where(remainingMask, MLXArray.zeros(outputTokens.shape, type: Int32.self), outputTokens)
+        }
+        
+        // Diagnostic: print token statistics to debug noise issues
+        let tokenVals = outputTokens.asArray(Int32.self)
+        let uniqueVals = Set(tokenVals)
+        let maskCount = tokenVals.filter { $0 == Int32(config.audioMaskId) }.count
+        print("[OmniVoice] Token stats: min=\(uniqueVals.min() ?? -1), max=\(uniqueVals.max() ?? -1), unique=\(uniqueVals.count), maskRemaining=\(maskCount)")
+
+        // Diagnostic: bypass diffusion and decode refAudioTokens directly if available
+        if let refTok = refAudioTokens {
+            do {
+                let refDecoded = try audioTok.decode(refTok)
+                let tempDir = FileManager.default.temporaryDirectory
+                let refURL = tempDir.appendingPathComponent("omnivoice_diagnostic_ref_direct.wav")
+                try AudioUtils.writeWavFile(samples: refDecoded.asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: refURL)
+                print("[OmniVoice] DIAGNOSTIC: saved direct ref decode to \(refURL.path)")
+            } catch {
+                print("[OmniVoice] DIAGNOSTIC: ref direct decode failed: \(error)")
+            }
+        }
+
+        let audio = try audioTok.decode(outputTokens)
+        
+        // Diagnostic: print vocoder output statistics
+        let audioMin = audio.min().item(Float.self)
+        let audioMax = audio.max().item(Float.self)
+        let audioMean = audio.mean().item(Float.self)
+        let audioNaN = isNaN(audio).any().item(Bool.self)
+        let audioInf = isInf(audio).any().item(Bool.self)
+        print("[OmniVoice] Vocoder decode stats: min=\(audioMin), max=\(audioMax), mean=\(audioMean), hasNaN=\(audioNaN), hasInf=\(audioInf)")
+
+        // Temporary diagnostics: save intermediate audio to temp directory
+        do {
+            let tempDir = FileManager.default.temporaryDirectory
+            let rawURL = tempDir.appendingPathComponent("omnivoice_diagnostic_raw.wav")
+            let finalURL = tempDir.appendingPathComponent("omnivoice_diagnostic_final.wav")
+            let rawSamples = audio.asArray(Float.self)
+            try AudioUtils.writeWavFile(samples: rawSamples, sampleRate: Double(config.sampleRate), fileURL: rawURL)
+            print("[OmniVoice] DIAGNOSTIC: saved raw vocoder output to \(rawURL.path)")
+            let processed = postProcessAudio(audio, refRms: nil, postprocessOutput: ovParameters.postprocessOutput)
+            try AudioUtils.writeWavFile(samples: processed.asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: finalURL)
+            print("[OmniVoice] DIAGNOSTIC: saved post-processed audio to \(finalURL.path)")
+            return processed
+        } catch {
+            print("[OmniVoice] DIAGNOSTIC: failed to save wav: \(error)")
+        }
+
+        // 9. Post-process
+        return postProcessAudio(audio, refRms: nil, postprocessOutput: ovParameters.postprocessOutput)
+    }
+
+    // MARK: - Token Prediction with CFG
+
+    private func predictTokensWithScoring(
+        cLogits: MLXArray,
+        uLogits: MLXArray,
+        guidanceScale: Float,
+        classTemperature: Float
+    ) -> (MLXArray, MLXArray) {
+        let predTokens: MLXArray
+        let scores: MLXArray
+
+        if guidanceScale != 0 {
+            let cLogProbs = logSoftmax(cLogits, axis: -1)
+            let uLogProbs = logSoftmax(uLogits, axis: -1)
+            let combinedLogProbs = cLogProbs + guidanceScale * (cLogProbs - uLogProbs)
+            var logProbs = logSoftmax(combinedLogProbs, axis: -1)
+
+            // Mask out the audio_mask_id
+            let maskIdOnehot = MLXArray((0..<config.audioVocabSize).map { $0 == config.audioMaskId ? Float(-Float.infinity) : Float(0) })
+            let maskArr = MLXArray.ones(logProbs.shape) * maskIdOnehot.reshaped([1, 1, 1, -1])
+            logProbs = logProbs + maskArr
+
+            if classTemperature > 0.0 {
+                let filteredLogProbs = filterTopK(logits: logProbs, ratio: 0.1)
+                let sampled = gumbelSample(logits: filteredLogProbs, temperature: classTemperature)
+                predTokens = MLX.argMax(sampled, axis: -1)
+            } else {
+                predTokens = MLX.argMax(logProbs, axis: -1)
+            }
+            scores = logProbs.max(axis: -1)
+        } else {
+            var logProbs = logSoftmax(cLogits, axis: -1)
+            let maskIdOnehot = MLXArray((0..<config.audioVocabSize).map { $0 == config.audioMaskId ? Float(-Float.infinity) : Float(0) })
+            let maskArr = MLXArray.ones(logProbs.shape) * maskIdOnehot.reshaped([1, 1, 1, -1])
+            logProbs = logProbs + maskArr
+
+            if classTemperature > 0.0 {
+                let filteredLogProbs = filterTopK(logits: logProbs, ratio: 0.1)
+                let sampled = gumbelSample(logits: filteredLogProbs, temperature: classTemperature)
+                predTokens = MLX.argMax(sampled, axis: -1)
+            } else {
+                predTokens = MLX.argMax(logProbs, axis: -1)
+            }
+            scores = logProbs.max(axis: -1)
+        }
+
+        return (predTokens, scores)
+    }
+
+    // MARK: - Utility Functions
+
+    private func filterTopK(logits: MLXArray, ratio: Float) -> MLXArray {
+        let k = max(1, Int(ceil(ratio * Float(logits.shape[-1]))))
+        // Use argSort to get top-k indices
+        let sortedIndices = MLX.argSort(-logits, axis: -1)
+        let topIndices = sortedIndices[0..., 0..., 0..., 0..<k]
+        let topVals = MLX.takeAlong(logits, topIndices, axis: -1)
+
+        var filtered = MLXArray.full(logits.shape, values: MLXArray(Float(-Float.infinity)))
+        // Vectorized scatter along the last axis to avoid indexed-assignment crashes
+        filtered = putAlong(filtered, topIndices, values: topVals, axis: -1)
+        return filtered
+    }
+
+    private func gumbelSample(logits: MLXArray, temperature: Float) -> MLXArray {
+        let scaledLogits = logits / temperature
+        let u = MLXRandom.uniform(low: Float(1e-10), high: 1.0, scaledLogits.shape)
+        let gumbelNoise = -MLX.log(-MLX.log(u + 1e-10) + 1e-10)
+        return scaledLogits + gumbelNoise
+    }
+
+    private func getTimeSteps(tStart: Float, tEnd: Float, numStep: Int, tShift: Float) -> [Float] {
+        var steps: [Float] = []
+        for i in 0...numStep {
+            let t = tStart + (tEnd - tStart) * Float(i) / Float(numStep)
+            let shifted = tShift * t / (1.0 + (tShift - 1.0) * t)
+            steps.append(shifted)
+        }
+        return steps
+    }
+
+    private func makeCausalMask(length: Int) -> MLXArray {
+        // Lower triangular matrix
+        let rowIdx = MLXArray((0..<length).map { Int32($0) }).reshaped([length, 1])
+        let colIdx = MLXArray((0..<length).map { Int32($0) }).reshaped([1, length])
+        return (rowIdx .>= colIdx)
+    }
+
+    private func estimateTargetTokens(
+        text: String,
+        refText: String?,
+        numRefAudioTokens: Int,
+        speed: Float
+    ) -> Int {
+        // Simple heuristic: ~4 tokens per character
+        let chars = text.count
+        let baseEstimate = max(25, chars * 4)
+        let adjusted = speed > 0 && speed != 1.0 ? Int(Float(baseEstimate) / speed) : baseEstimate
+        return max(1, adjusted)
+    }
+
+    private func prepareInferenceInputs(
+        text: String,
+        numTargetTokens: Int,
+        refText: String?,
+        refAudioTokens: MLXArray?,
+        language: String?,
+        instruct: String?,
+        denoise: Bool
+    ) throws -> (inputIds: MLXArray, audioMask: MLXArray) {
+        guard let tokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
+        }
+
+        let numCodebooks = config.numAudioCodebook
+
+        // Build style tokens
+        var styleText = ""
+        if denoise && refAudioTokens != nil {
+            // Python reference passes denoise=has_ref at the generate call sites
+            // (omnivoice.py:387,585): <|denoise|> conditions cloning only.
+            styleText += "<|denoise|>"
+        }
+        let langStr = language ?? "None"
+        styleText += "<|lang_start|>\(langStr)<|lang_end|>"
+        let instructStr = instruct ?? "None"
+        styleText += "<|instruct_start|>\(instructStr)<|instruct_end|>"
+
+        let styleTokenIds = try tokenizeText(styleText)
+        var styleIds = MLXArray(styleTokenIds.map { Int32($0) })
+        styleIds = styleIds.reshaped([1, -1])
+        styleIds = MLX.broadcast(styleIds.reshaped([1, 1, -1]), to: [1, numCodebooks, styleIds.shape[1]])
+
+        // Build text tokens
+        let fullText = combineText(refText: refText, text: text)
+        let wrappedText = "<|text_start|>\(fullText)<|text_end|>"
+        let textTokenIds = try tokenizeText(wrappedText)
+        var textIds = MLXArray(textTokenIds.map { Int32($0) })
+        textIds = textIds.reshaped([1, -1])
+        textIds = MLX.broadcast(textIds.reshaped([1, 1, -1]), to: [1, numCodebooks, textIds.shape[1]])
+
+        // Target: all MASK
+        let targetIds = MLXArray.full(
+            [1, numCodebooks, numTargetTokens],
+            values: MLXArray(Int32(config.audioMaskId))
+        )
+
+        // Concatenate: [style, text, ref_audio (optional), target]
+        var parts: [MLXArray] = [styleIds, textIds]
+        if let refTok = refAudioTokens {
+            var alignedRefTok = refTok
+            if refTok.ndim == 2 && refTok.shape[0] != numCodebooks {
+                if refTok.shape[0] < numCodebooks {
+                    // Pad with mask tokens to match numCodebooks
+                    let padShape = [numCodebooks - refTok.shape[0], refTok.shape[1]]
+                    let pad = MLXArray.full(padShape, values: MLXArray(Int32(config.audioMaskId)))
+                    alignedRefTok = MLX.concatenated([refTok, pad], axis: 0)
+                } else {
+                    // Truncate to numCodebooks
+                    alignedRefTok = refTok[0..<numCodebooks, 0...]
+                }
+            }
+            let reshaped = alignedRefTok.reshaped([1, alignedRefTok.shape[0], alignedRefTok.shape[1]])
+            parts.append(reshaped)
+        }
+        parts.append(targetIds)
+
+        let condInputIds = MLX.concatenated(parts, axis: 2)
+        let totalLength = condInputIds.shape[2]
+
+        // Build audio mask: true for ref_audio + target regions
+        let audioStartIdx: Int
+        if refAudioTokens != nil {
+            let refTokLen = refAudioTokens!.shape[1]
+            audioStartIdx = totalLength - numTargetTokens - refTokLen
+        } else {
+            audioStartIdx = totalLength - numTargetTokens
+        }
+
+        
+        let zerosPrefix = MLXArray.zeros([audioStartIdx], type: Bool.self)
+        let onesSuffix = MLXArray.ones([totalLength - audioStartIdx], type: Bool.self)
+        let condAudioMask = MLX.concatenated([zerosPrefix, onesSuffix], axis: 0)
+            .reshaped([1, totalLength])
+
+        return (condInputIds, condAudioMask)
+    }
+
+    private func tokenizeText(_ text: String) throws -> [Int] {
+        guard let tokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Tokenizer not loaded")
+        }
+        return try tokenizer.encode(text: text, addSpecialTokens: false)
+    }
+
+    private func combineText(refText: String?, text: String) -> String {
+        var fullText = ""
+        if let refText, !refText.isEmpty {
+            fullText = refText.trimmingCharacters(in: .whitespacesAndNewlines) + " "
+        }
+        fullText += text.trimmingCharacters(in: .whitespacesAndNewlines)
+        fullText = fullText.components(separatedBy: .newlines).joined(separator: " ")
+        fullText = fullText.replacingOccurrences(of: "  ", with: " ", options: .regularExpression)
+        return fullText
+    }
+
+    private func postProcessAudio(_ audio: MLXArray, refRms: Float?, postprocessOutput: Bool) -> MLXArray {
+        var result = audio
+
+        if let refRms, refRms < 0.1 {
+            result = result * MLXArray(refRms / 0.1)
+        } else if refRms == nil {
+            let peak = MLX.abs(result).max().item(Float.self)
+            if peak > 1e-6 {
+                result = result * MLXArray(0.5 / peak)
+            }
+        }
+
+        if postprocessOutput {
+            let len = result.shape[0]
+            let fadeLen = min(480, len / 2)
+            if fadeLen > 0 {
+                let fadeIn = MLXArray((0..<fadeLen).map { Float($0) / Float(fadeLen) })
+                let fadeOut = MLXArray((0..<fadeLen).reversed().map { Float($0) / Float(fadeLen) })
+                let head = result[0..<fadeLen] * fadeIn
+                let mid = result[fadeLen..<(len - fadeLen)]
+                let tail = result[(len - fadeLen)...] * fadeOut
+                result = MLX.concatenated([head, mid, tail], axis: 0)
+            }
+        }
+
+        eval(result)
+        return result
+    }
+
+    // MARK: - Model Loading
+
+    public static func fromPretrained(
+        _ repoID: String,
+        cache: HubCache = .default
+    ) async throws -> OmniVoiceModel {
+        guard let repo = Repo.ID(rawValue: repoID) else {
+            throw AudioGenerationError.invalidInput("Invalid repository ID: \(repoID)")
+        }
+
+        // Download and parse config
+        let configURL = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repo,
+            requiredExtension: "json",
+            additionalMatchingPatterns: ["config.json"]
+        ).appendingPathComponent("config.json")
+
+        let configData = try Data(contentsOf: configURL)
+
+        // Load model weights first to infer actual num_audio_codebooks from checkpoint
+        let weightsURL = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repo,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["model.safetensors"]
+        ).appendingPathComponent("model.safetensors")
+        let rawWeights = try MLX.loadArrays(url: weightsURL)
+
+        // Parse and modify main config to match checkpoint
+        var configDict = try JSONSerialization.jsonObject(with: configData) as! [String: Any]
+        // Prefer the codebook count inferred from split checkpoint keys; fused
+        // checkpoints (audio_embeddings.weight [C*V, H]) carry no per-codebook
+        // keys, so fall back to the config value before the legacy default.
+        let inferredNumCodebooks = Self.inferNumCodebooks(from: rawWeights)
+            ?? (configDict["num_audio_codebook"] as? Int ?? 9)
+        if let currentNum = configDict["num_audio_codebook"] as? Int, currentNum != inferredNumCodebooks {
+            print("[OmniVoiceModel] INFO: overriding num_audio_codebook from \(currentNum) to \(inferredNumCodebooks) to match checkpoint")
+            configDict["num_audio_codebook"] = inferredNumCodebooks
+            if let weights = configDict["audio_codebook_weights"] as? [Int], weights.count != inferredNumCodebooks {
+                var newWeights = weights
+                while newWeights.count < inferredNumCodebooks {
+                    newWeights.append(newWeights.last ?? 2)
+                }
+                if newWeights.count > inferredNumCodebooks {
+                    newWeights = Array(newWeights.prefix(inferredNumCodebooks))
+                }
+                configDict["audio_codebook_weights"] = newWeights
+            }
+        }
+        let modifiedConfigData = try JSONSerialization.data(withJSONObject: configDict)
+        let config = try JSONDecoder().decode(OmniVoiceConfig.self, from: modifiedConfigData)
+
+        let model = try OmniVoiceModel(config: config)
+        let sanitizedWeights = model.sanitize(weights: rawWeights)
+        let moduleParams = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
+        let weightKeys = Set(sanitizedWeights.keys)
+        let paramKeys = Set(moduleParams.keys)
+        let missing = paramKeys.subtracting(weightKeys).sorted()
+        let extra = weightKeys.subtracting(paramKeys).sorted()
+        if !missing.isEmpty {
+            print("[OmniVoiceModel] WARNING: \(missing.count) parameters missing from checkpoint: \(missing.prefix(10))")
+        }
+        if !extra.isEmpty {
+            print("[OmniVoiceModel] WARNING: \(extra.count) extra keys after sanitize: \(extra.prefix(10))")
+        }
+        let float32Weights = sanitizedWeights.mapValues { $0.asType(.float32) }
+        try model.update(parameters: ModuleParameters.unflattened(float32Weights), verify: .noUnusedKeys)
+        eval(model)
+        print("[OmniVoiceModel] INFO: loaded TTS model weights as float32 for precision test")
+
+        // Load text tokenizer
+        model.tokenizer = try await AutoTokenizer.from(modelFolder: {
+            let dir = try await ModelUtils.resolveOrDownloadModel(
+                repoID: repo,
+                requiredExtension: "json",
+                additionalMatchingPatterns: ["tokenizer.json"]
+            )
+            return dir
+        }())
+
+        // Load audio tokenizer
+        model.audioTokenizer = try await OmniVoiceAudioTokenizer.fromPretrained(
+            repoID: repoID,
+            cache: cache
+        )
+
+        return model
+    }
+
+    // MARK: - Weight Inspection
+
+    private static func inferNumCodebooks(from weights: [String: MLXArray]) -> Int? {
+        var maxIdx = -1
+        for key in weights.keys {
+            if key.hasPrefix("audio_embeddings."), key.hasSuffix(".weight") {
+                let suffix = key.dropFirst("audio_embeddings.".count)
+                if let dotIdx = suffix.firstIndex(of: ".") {
+                    let numStr = suffix.prefix(upTo: dotIdx)
+                    if let idx = Int(numStr), idx > maxIdx {
+                        maxIdx = idx
+                    }
+                }
+            }
+        }
+        return maxIdx >= 0 ? maxIdx + 1 : nil
+    }
+
+    // MARK: - Weight Sanitization
+
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var sanitized: [String: MLXArray] = [:]
+
+        for (key, value) in weights {
+            if key.hasSuffix("codebook_layer_offsets") {
+                // Precomputed offsets from the PyTorch implementation; embeddings
+                // are indexed per-codebook here so the offsets are not needed
+                // (the Python port drops this key too).
+                continue
+            }
+            if key == "audio_embeddings.weight" || key == "audio_heads.weight" {
+                // Fused checkpoint layout [C*V, H]: split into C per-codebook slices
+                // (parity with the Python port's sanitize).
+                let prefix = key == "audio_embeddings.weight" ? "audio_embeddings" : "audio_heads"
+                let count = audioHeads.count
+                let vocabSize = value.dim(0) / count
+                for i in 0..<count {
+                    sanitized["\(prefix).\(i).weight"] = value[(i * vocabSize)..<((i + 1) * vocabSize)]
+                }
+            } else if key.hasPrefix("audio_embeddings.") || key.hasPrefix("audio_heads.") {
+                sanitized[key] = value
+            } else if key == "lm_head.weight" {
+                // lm_head lives on Qwen3Model, not Qwen3ModelInner
+                sanitized["llm.lm_head.weight"] = value
+            } else if key.hasPrefix("model.") {
+                // model.X -> llm.model.X
+                let stripped = String(key.dropFirst("model.".count))
+                sanitized["llm.model.\(stripped)"] = value
+            } else if key.hasPrefix("backbone.") {
+                // backbone.X -> llm.model.X
+                let stripped = String(key.dropFirst("backbone.".count))
+                sanitized["llm.model.\(stripped)"] = value
+            } else if key.hasPrefix("llm.") {
+                // llm.X -> llm.model.X
+                let stripped = String(key.dropFirst(4))
+                sanitized["llm.model.\(stripped)"] = value
+            } else {
+                // Bare key -> llm.model.X
+                sanitized["llm.model.\(key)"] = value
+            }
+        }
+
+        return sanitized
+    }
+}
+
+// MARK: - Quantizer modules matching Higgs Audio V2 checkpoint
+
+/// Codebook embedding: stores the quantization codebook.
+final class OmniVoiceQuantizerCodebook: Module {
+    @ModuleInfo(key: "embed") var embed: MLXArray  // [codebook_size, codebook_dim]
+
+    init(codebookSize: Int, codebookDim: Int) {
+        self._embed.wrappedValue = MLXRandom.uniform(
+            low: -1.0, high: 1.0, [codebookSize, codebookDim]
+        )
+    }
+}
+
+/// Single quantizer block: projects input → codebook dim, quantizes, projects back.
+final class OmniVoiceSingleQuantizer: Module {
+    @ModuleInfo(key: "codebook") var codebook: OmniVoiceQuantizerCodebook
+    @ModuleInfo(key: "project_in") var projectIn: MLXNN.Linear
+    @ModuleInfo(key: "project_out") var projectOut: MLXNN.Linear
+
+    init(inputDim: Int, outputDim: Int, codebookSize: Int, codebookDim: Int) {
+        self._codebook.wrappedValue = OmniVoiceQuantizerCodebook(
+            codebookSize: codebookSize, codebookDim: codebookDim
+        )
+        self._projectIn.wrappedValue = MLXNN.Linear(
+            inputDimensions: inputDim, outputDimensions: codebookDim
+        )
+        self._projectOut.wrappedValue = MLXNN.Linear(
+            inputDimensions: codebookDim, outputDimensions: outputDim
+        )
+    }
+}
+
+// MARK: - OmniVoice ConvTranspose1d (PyTorch weight convention)
+
+/// ConvTranspose1d using MLX weight layout [in_channels, kernel_size, out_channels].
+final class OmniVoiceConvTranspose1d: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "bias") var bias: MLXArray?
+
+    let strideVal: Int
+    let paddingVal: Int
+    let outputPaddingVal: Int
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int, stride: Int, padding: Int, outputPadding: Int = 0) {
+        self.strideVal = stride
+        self.paddingVal = padding
+        self.outputPaddingVal = outputPadding
+
+        let scale = sqrt(1.0 / Float(inChannels * kernelSize))
+        // PyTorch format: [in_channels, out_channels, kernel_size]
+        self._weight.wrappedValue = MLXRandom.uniform(
+            low: -scale, high: scale, [inChannels, outChannels, kernelSize]
+        )
+        self._bias.wrappedValue = MLXArray.zeros([outChannels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Weight stored as [in, out, kernel] (PyTorch) → transpose to [out, kernel, in] (MLX)
+        let w = weight.transposed(1, 2, 0).asType(.float32)
+        // Data flows in NCL [B, C, L]; transpose to NLC for MLX convTransposed1d
+        let xNLC = x.transposed(0, 2, 1).asType(.float32)
+        var h = MLX.convTransposed1d(xNLC, w, stride: strideVal, padding: paddingVal, outputPadding: outputPaddingVal)
+        if let b = bias {
+            let n = b.size
+            h = h + b.asType(.float32).reshaped([n])
+        }
+        // Convert back to NCL [B, C, L]
+        let out = h.transposed(0, 2, 1).asType(x.dtype)
+        return out
+    }
+}
+
+/// Conv1d using MLX weight layout [out_channels, kernel_size, in_channels].
+final class OmniVoiceConv1d: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "bias") var bias: MLXArray?
+
+    let strideVal: Int
+    let paddingVal: Int
+    let dilationVal: Int
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int, stride: Int, padding: Int, dilation: Int = 1) {
+        self.strideVal = stride
+        self.paddingVal = padding
+        self.dilationVal = dilation
+
+        let scale = sqrt(1.0 / Float(inChannels * kernelSize))
+        // MLX format: [out_channels, kernel_size, in_channels]
+        self._weight.wrappedValue = MLXRandom.uniform(
+            low: -scale, high: scale, [outChannels, kernelSize, inChannels]
+        )
+        self._bias.wrappedValue = MLXArray.zeros([outChannels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Weight stored as [out, in, kernel] (PyTorch format) → transpose to [out, kernel, in] (MLX)
+        let w = weight.transposed(0, 2, 1).asType(.float32)
+        // Data flows in NCL [B, C, L]; transpose to NLC for MLX conv1d, then back
+        let xNLC = x.transposed(0, 2, 1).asType(.float32)
+        var h = MLX.conv1d(xNLC, w, stride: strideVal, padding: paddingVal, dilation: dilationVal)
+        if let b = bias {
+            let n = b.size
+            h = h + b.asType(.float32).reshaped([n])
+        }
+        // Convert back to NCL [B, C, L]
+        let out = h.transposed(0, 2, 1).asType(x.dtype)
+        return out
+    }
+}
+
+// MARK: - DAC-style Audio Codec
+
+/// Snake activation: x + (1/a) * sin(a*x)^2
+func snakeActivation(_ x: MLXArray) -> MLXArray {
+    let alpha: Float = 1.0
+    let x32 = x.asType(.float32)
+    let recip = 1.0 / (alpha + 1e-9)
+    return (x32 + recip * MLX.square(MLX.sin(alpha * x32))).asType(x.dtype)
+}
+
+/// DAC-style residual unit with Snake activations.
+public final class OmniVoiceDACResidualUnit: Module {
+    @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
+    @ModuleInfo(key: "conv2") var conv2: OmniVoiceConv1d
+    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "snake2") var snake2: snakeAlpha
+
+    init(channels: Int, kernelSize: Int, dilation: Int) {
+        // Match PyTorch DAC: kernel_size=7 for conv1 with dilation-dependent same-padding,
+        // and kernel_size=1 for conv2 (pointwise).
+        let conv1KernelSize = 7
+        let conv1Padding = ((conv1KernelSize - 1) * dilation) / 2
+        let conv2KernelSize = 1
+        let conv2Padding = 0
+
+        self._conv1.wrappedValue = OmniVoiceConv1d(
+            inChannels: channels,
+            outChannels: channels,
+            kernelSize: conv1KernelSize,
+            stride: 1,
+            padding: conv1Padding,
+            dilation: dilation
+        )
+        self._conv2.wrappedValue = OmniVoiceConv1d(
+            inChannels: channels,
+            outChannels: channels,
+            kernelSize: conv2KernelSize,
+            stride: 1,
+            padding: conv2Padding
+        )
+        self._snake1.wrappedValue = snakeAlpha(channels: channels)
+        self._snake2.wrappedValue = snakeAlpha(channels: channels)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // DAC residual unit order: Snake → Conv → Snake → Conv + residual
+        let s1 = snake1.callAsFunction(x)
+        let c1 = conv1(s1)
+        let s2 = snake2.callAsFunction(c1)
+        let h = conv2(s2)
+        
+        // Handle potential length mismatch for residual connection
+        let xLen = x.shape[2]
+        let hLen = h.shape[2]
+        let minLen = min(xLen, hLen)
+        var xTrimmed = x
+        var hTrimmed = h
+        if xLen != hLen {
+            let xPad = (xLen - minLen) / 2
+            let hPad = (hLen - minLen) / 2
+            xTrimmed = x[0..., 0..., xPad..<(xLen - xPad)]
+            hTrimmed = h[0..., 0..., hPad..<(hLen - hPad)]
+        }
+        return xTrimmed + hTrimmed
+    }
+}
+
+/// Learnable Snake activation parameter.
+public final class snakeAlpha: Module {
+    @ModuleInfo(key: "alpha") var alpha: MLXArray
+
+    init(channels: Int) {
+        self._alpha.wrappedValue = MLXArray.ones([1, channels, 1])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let x32 = x.asType(.float32)
+        let a32 = alpha.asType(.float32)
+        let channels = a32.size
+        // Swift DAC conv layers use NCL [B,C,L]; reshape alpha to [1,C,1] for broadcasting
+        let aExpanded = a32.reshaped([1, channels, 1])
+        let recip = 1.0 / (aExpanded + 1e-9)
+        return (x32 + recip * MLX.square(MLX.sin(aExpanded * x32))).asType(x.dtype)
+    }
+}
+
+/// DAC downsampling block (Higgs Audio V2 EncoderBlock):
+/// 3 ResidualUnits(dilation 1,3,9) + Snake1d + WNConv1d.
+public final class OmniVoiceDACDownBlock: Module {
+    @ModuleInfo var res_unit1: OmniVoiceDACResidualUnit
+    @ModuleInfo var res_unit2: OmniVoiceDACResidualUnit
+    @ModuleInfo var res_unit3: OmniVoiceDACResidualUnit
+    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
+
+    init(inputChannels: Int, outputChannels: Int, stride: Int, kernelSize: Int) {
+        self._res_unit1.wrappedValue = OmniVoiceDACResidualUnit(
+            channels: inputChannels, kernelSize: kernelSize, dilation: 1
+        )
+        self._res_unit2.wrappedValue = OmniVoiceDACResidualUnit(
+            channels: inputChannels, kernelSize: kernelSize, dilation: 3
+        )
+        self._res_unit3.wrappedValue = OmniVoiceDACResidualUnit(
+            channels: inputChannels, kernelSize: kernelSize, dilation: 9
+        )
+        self._snake1.wrappedValue = snakeAlpha(channels: inputChannels)
+        self._conv1.wrappedValue = OmniVoiceConv1d(
+            inChannels: inputChannels,
+            outChannels: outputChannels,
+            kernelSize: stride * 2,
+            stride: stride,
+            padding: stride / 2 + stride % 2
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = res_unit1(x)
+        h = res_unit2(h)
+        h = res_unit3(h)
+        h = snake1.callAsFunction(h)
+        h = conv1(h)
+        return h
+    }
+}
+
+/// DAC upsampling block (Higgs Audio V2 DecoderBlock):
+/// Snake1d + ConvTranspose1d + 3 ResidualUnits(dilation 1,3,9).
+public final class OmniVoiceDACUpBlock: Module {
+    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "conv_t1") var convT1: OmniVoiceConvTranspose1d
+    @ModuleInfo var res_unit1: OmniVoiceDACResidualUnit
+    @ModuleInfo var res_unit2: OmniVoiceDACResidualUnit
+    @ModuleInfo var res_unit3: OmniVoiceDACResidualUnit
+
+    init(inputChannels: Int, outputChannels: Int, stride: Int, kernelSize: Int) {
+        self._snake1.wrappedValue = snakeAlpha(channels: inputChannels)
+        self._convT1.wrappedValue = OmniVoiceConvTranspose1d(
+            inChannels: inputChannels,
+            outChannels: outputChannels,
+            kernelSize: stride * 2,
+            stride: stride,
+            padding: stride / 2 + stride % 2,
+            outputPadding: stride % 2
+        )
+        self._res_unit1.wrappedValue = OmniVoiceDACResidualUnit(
+            channels: outputChannels, kernelSize: kernelSize, dilation: 1
+        )
+        self._res_unit2.wrappedValue = OmniVoiceDACResidualUnit(
+            channels: outputChannels, kernelSize: kernelSize, dilation: 3
+        )
+        self._res_unit3.wrappedValue = OmniVoiceDACResidualUnit(
+            channels: outputChannels, kernelSize: kernelSize, dilation: 9
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = convT1(snake1.callAsFunction(x))
+        h = res_unit1(h)
+        h = res_unit2(h)
+        h = res_unit3(h)
+        return h
+    }
+}
+
+/// Higgs Audio V2 acoustic encoder: conv1 → down blocks → snake1 → conv2.
+public final class OmniVoiceDACAcousticEncoder: Module {
+    @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
+    @ModuleInfo var block: [OmniVoiceDACDownBlock]
+    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "conv2") var conv2: OmniVoiceConv1d
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        let hiddenSize = config.encoderHiddenSize
+        let downsamplingRatios = config.downsamplingRatios
+
+        self._conv1.wrappedValue = OmniVoiceConv1d(
+            inChannels: 1,
+            outChannels: hiddenSize,
+            kernelSize: 7,
+            stride: 1,
+            padding: 3
+        )
+
+        var blocks: [OmniVoiceDACDownBlock] = []
+        var currentChannels = hiddenSize
+        for stride in downsamplingRatios {
+            let outChannels = currentChannels * 2
+            blocks.append(OmniVoiceDACDownBlock(
+                inputChannels: currentChannels,
+                outputChannels: outChannels,
+                stride: stride,
+                kernelSize: config.kernelSize
+            ))
+            currentChannels = outChannels
+        }
+        self._block.wrappedValue = blocks
+
+        self._snake1.wrappedValue = snakeAlpha(channels: currentChannels)
+        self._conv2.wrappedValue = OmniVoiceConv1d(
+            inChannels: currentChannels,
+            outChannels: currentChannels / 8,   // 2048 → 256 to match checkpoint
+            kernelSize: 3,
+            stride: 1,
+            padding: 1
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv1(x)
+        print("[OmniVoice Encoder] after conv1: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
+        for (i, b) in block.enumerated() {
+            h = b(h)
+            print("[OmniVoice Encoder] after downBlock \(i): shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
+        }
+        h = snake1.callAsFunction(h)
+        print("[OmniVoice Encoder] after snake1: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
+        h = conv2(h)
+        print("[OmniVoice Encoder] after conv2: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
+        return h
+    }
+}
+
+/// Higgs Audio V2 acoustic decoder: conv1 → up blocks → snake1 → conv2.
+public final class OmniVoiceDACAcousticDecoder: Module {
+    @ModuleInfo(key: "conv1") var conv1: OmniVoiceConv1d
+    @ModuleInfo var block: [OmniVoiceDACUpBlock]
+    @ModuleInfo(key: "snake1") var snake1: snakeAlpha
+    @ModuleInfo(key: "conv2") var conv2: OmniVoiceConv1d
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        let hiddenSize = config.decoderHiddenSize
+        let upsamplingRatios = config.upsamplingRatios
+
+        // Initial projection to decoder hidden size
+        self._conv1.wrappedValue = OmniVoiceConv1d(
+            inChannels: config.encoderHiddenSize * 4,  // 256
+            outChannels: hiddenSize,                     // 1024
+            kernelSize: 7,
+            stride: 1,
+            padding: 3
+        )
+
+        var blocks: [OmniVoiceDACUpBlock] = []
+        var currentChannels = hiddenSize
+        for stride in upsamplingRatios {
+            let outChannels = currentChannels / 2
+            blocks.append(OmniVoiceDACUpBlock(
+                inputChannels: currentChannels,
+                outputChannels: outChannels,
+                stride: stride,
+                kernelSize: config.kernelSize
+            ))
+            currentChannels = outChannels
+        }
+        self._block.wrappedValue = blocks
+
+        self._snake1.wrappedValue = snakeAlpha(channels: currentChannels)
+        self._conv2.wrappedValue = OmniVoiceConv1d(
+            inChannels: currentChannels,
+            outChannels: 1,
+            kernelSize: 7,
+            stride: 1,
+            padding: 3
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv1(x)
+        print("[OmniVoice Dec] conv1 out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
+        for (i, b) in block.enumerated() {
+            h = b(h)
+            print("[OmniVoice Dec] upBlock \(i) out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
+        }
+        h = snake1.callAsFunction(h)
+        print("[OmniVoice Dec] snake1 out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
+        h = conv2(h)
+        // Python _adjust_dac_decoder removes final Tanh; keep output unbounded
+        print("[OmniVoice Dec] conv2 out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
+        return h
+    }
+}
+
+/// Residual Vector Quantization with projection layers (Higgs Audio V2 style).
+public final class OmniVoiceRVQQuantizer: Module {
+    @ModuleInfo(key: "quantizers") var quantizers: [OmniVoiceSingleQuantizer]
+    let outputDim: Int
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        let nQuantizers = config.nCodebooks
+        let codebookSize = config.codebookSize
+        let codebookDim = config.codebookDim
+        let inputDim = config.decoderHiddenSize  // 1024, matching project_in weight shape [64, 1024]
+        self.outputDim = config.decoderHiddenSize  // 1024
+
+        var qs: [OmniVoiceSingleQuantizer] = []
+        for _ in 0..<nQuantizers {
+            qs.append(OmniVoiceSingleQuantizer(
+                inputDim: inputDim,
+                outputDim: outputDim,
+                codebookSize: codebookSize,
+                codebookDim: codebookDim
+            ))
+        }
+        self._quantizers.wrappedValue = qs
+    }
+
+    /// Quantize: [B, D, T] -> (codes [B, n_quantizers, T], quantized [B, outputDim, T])
+    /// Note: D must be 1024 (decoderHiddenSize). The caller must pre-project if needed.
+    func callAsFunction(_ z: MLXArray) -> (MLXArray, MLXArray) {
+        // z is [B, C, L] (NCL) where C = 1024
+        let batchSize = z.shape[0]
+        let seqLen = z.shape[2]
+        let nQuantizers = quantizers.count
+
+        var allCodes: [MLXArray] = []
+        var quantized = MLXArray.zeros([batchSize, outputDim, seqLen])
+
+        for qIdx in 0..<nQuantizers {
+            let q = quantizers[qIdx]
+            let codebook = q.codebook.embed
+            let codebookSize = codebook.shape[0]
+            let codebookDim = codebook.shape[1]
+
+            // Project input to codebook dimension
+            // z is [B, C, L] (NCL), Linear expects [B, L, C] (NLC)
+            let zNLC = z.transposed(0, 2, 1)  // [B, L, C]
+            let zProjNLC = q.projectIn(zNLC)  // [B, L, codebookDim]
+            let zProj = zProjNLC.transposed(0, 2, 1)  // [B, codebookDim, L]
+
+            // [B, codebookDim, T] -> [B, T, codebookDim] for distance computation
+            let zPermute = zProj.transposed(0, 2, 1)
+            let zFlat = zPermute.reshaped([batchSize * seqLen, codebookDim])
+
+            // Compute distances: [B*T, K]
+            let diff = zFlat.reshaped([zFlat.shape[0], 1, codebookDim])
+                - codebook.reshaped([1, codebookSize, codebookDim])
+            let dist = MLX.sum(diff * diff, axis: -1)
+
+            // Nearest codebook index
+            let codes = MLX.argMin(dist, axis: -1)  // [B*T]
+            let codes2d = codes.reshaped([batchSize, seqLen])
+            allCodes.append(codes2d)
+
+            // Gather quantized vectors and project to output dimension
+            let qVecs = MLX.take(codebook, codes, axis: 0)  // [B*T, codebookDim]
+            let qOut = q.projectOut(qVecs)  // [B*T, outputDim]
+            let q3d = qOut.reshaped([batchSize, seqLen, -1]).transposed(0, 2, 1)
+
+            quantized = quantized + q3d
+        }
+
+        let codes = MLX.stacked(allCodes, axis: 1)  // [B, n_quantizers, T]
+        return (codes, quantized)
+    }
+
+    /// Decode: [B, n_quantizers, T] -> [B, outputDim, T]
+    func decode(_ codes: MLXArray) -> MLXArray {
+        let batchSize = codes.shape[0]
+        let nQuantizers = codes.shape[1]
+        let seqLen = codes.shape[2]
+
+        var quantized = MLXArray.zeros([batchSize, outputDim, seqLen])
+
+        for qIdx in 0..<nQuantizers {
+            let q = quantizers[qIdx]
+            let codebook = q.codebook.embed
+            let cbCodes = codes[0..., qIdx, 0...]  // [B, T]
+            let flatCodes = cbCodes.reshaped([-1])  // [B*T]
+
+            let qVecs = MLX.take(codebook, flatCodes, axis: 0)
+            let qOut = q.projectOut(qVecs)
+            let q3d = qOut.reshaped([batchSize, seqLen, -1]).transposed(0, 2, 1)
+
+            quantized = quantized + q3d
+        }
+
+        return quantized
+    }
+}
+
+// MARK: - OmniVoice Higgs Audio Tokenizer
+
+/// Audio tokenizer for OmniVoice: DAC encoder/decoder with RVQ quantization.
+public final class OmniVoiceAudioTokenizer: Module {
+    let config: OmniVoiceAudioTokenizerConfig
+
+    @ModuleInfo(key: "acoustic_encoder") var acousticEncoder: OmniVoiceDACAcousticEncoder
+    @ModuleInfo(key: "acoustic_decoder") var acousticDecoder: OmniVoiceDACAcousticDecoder
+    @ModuleInfo(key: "quantizer") var quantizer: OmniVoiceRVQQuantizer
+    @ModuleInfo(key: "fc2") var fc2: MLXNN.Linear
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        self.config = config
+
+        self._acousticEncoder.wrappedValue = OmniVoiceDACAcousticEncoder(config: config)
+        self._acousticDecoder.wrappedValue = OmniVoiceDACAcousticDecoder(config: config)
+        self._quantizer.wrappedValue = OmniVoiceRVQQuantizer(config: config)
+
+        // fc2 projects quantized features (decoderHiddenSize) to decoder input (encoderHiddenSize * 4)
+        self._fc2.wrappedValue = MLXNN.Linear(
+            inputDimensions: config.decoderHiddenSize,
+            outputDimensions: config.encoderHiddenSize * 4
+        )
+    }
+
+    /// Encode audio waveform to discrete tokens.
+    /// - Parameter audio: [samples] or [1, samples]
+    /// - Returns: [num_codebooks, seq_len]
+    public func encode(_ audio: MLXArray) throws -> MLXArray {
+        var wav = audio
+        if wav.ndim == 1 {
+            // [T] -> [1, 1, T]  (batch, channels, length) NCL
+            wav = wav.reshaped([1, 1, -1])
+        } else if wav.ndim == 2 {
+            // [B, T] -> [B, 1, T]
+            wav = wav.reshaped([wav.shape[0], 1, wav.shape[1]])
+        } else if wav.ndim == 3 && wav.shape[1] > wav.shape[2] {
+            // NLC [B, L, C] -> NCL [B, C, L]
+            wav = wav.transposed(0, 2, 1)
+        }
+
+        // Encoder: [B, 1, T] -> [B, D, T'] where D=256
+        let z = acousticEncoder(wav)
+
+        // Project encoder output (256) to quantizer input dimension (1024)
+        // fc2 is Linear(1024→256), weight shape [256, 1024]. To reverse: x @ W = [B,T',256] @ [256,1024] = [B,T',1024]
+        let zNLC = z.transposed(0, 2, 1)  // [B, T', 256]
+        let zProjectedNLC = MLX.matmul(zNLC, fc2.weight)  // [B, T', 1024]
+        let zProjected = zProjectedNLC.transposed(0, 2, 1)  // [B, 1024, T']
+
+        // RVQ: [B, D, T'] -> (codes [B, n_codebooks, T'], quantized [B, D, T'])
+        let (codes, _) = quantizer(zProjected)
+
+        // Temporary diagnostic: encode->decode roundtrip to isolate vocoder issues
+        do {
+            let decoded = try self.decode(codes[0])
+            let tempDir = FileManager.default.temporaryDirectory
+            let originalURL = tempDir.appendingPathComponent("omnivoice_tokenizer_roundtrip_original.wav")
+            let decodedURL = tempDir.appendingPathComponent("omnivoice_tokenizer_roundtrip_decoded.wav")
+            try AudioUtils.writeWavFile(samples: wav[0].asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: originalURL)
+            try AudioUtils.writeWavFile(samples: decoded.asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: decodedURL)
+            print("[OmniVoiceAudioTokenizer] DIAGNOSTIC: saved original to \(originalURL.path)")
+            print("[OmniVoiceAudioTokenizer] DIAGNOSTIC: saved roundtrip to \(decodedURL.path)")
+        } catch {
+            print("[OmniVoiceAudioTokenizer] DIAGNOSTIC: roundtrip save failed: \(error)")
+        }
+
+        // Return [n_codebooks, T'] (squeeze batch dim)
+        return codes[0]
+    }
+
+    /// Decode discrete tokens back to audio waveform.
+    /// - Parameter tokens: [num_codebooks, seq_len]
+    /// - Returns: [samples]
+    public func decode(_ tokens: MLXArray) throws -> MLXArray {
+        // Add batch dim: [n_codebooks, T] -> [1, n_codebooks, T]
+        let batchedTokens = tokens.reshaped([1, tokens.shape[0], tokens.shape[1]])
+
+        // RVQ decode: [1, n_codebooks, T] -> [1, D, T] where D=1024
+        let z = quantizer.decode(batchedTokens)
+        print("[OmniVoice Decode] after quantizer.decode: shape=\(z.shape), min=\(z.min().item(Float.self)), max=\(z.max().item(Float.self)), mean=\(z.mean().item(Float.self))")
+
+        // fc2 project: [1, D, T] -> [1, D', T] where D'=256
+        // fc2.weight shape is [256, 1024] (outputDim x inputDim)
+        // Decode uses: fc2(zNLC) = zNLC @ W.T + b where zNLC=[B,T,1024], W.T=[1024,256], b=[256]
+        let zNLC = z.transposed(0, 2, 1)  // [B, T, 1024]
+        let hNLC = MLX.matmul(zNLC, fc2.weight.transposed(1, 0))  // [B, T, 256]
+        let h = (hNLC + (fc2.bias ?? MLXArray.zeros([1]))).transposed(0, 2, 1)  // [B, 256, T]
+        print("[OmniVoice Decode] after fc2: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
+
+        // Verify decoder conv1 weight shape at runtime
+        let paramDict = Dictionary(uniqueKeysWithValues: acousticDecoder.parameters().flattened())
+        if let w = paramDict["conv1.weight"] {
+            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv1.weight: shape=\(w.shape), min=\(w.min().item(Float.self)), max=\(w.max().item(Float.self))")
+        } else {
+            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv1.weight: MISSING")
+        }
+        if let w = paramDict["conv2.weight"] {
+            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv2.weight: shape=\(w.shape), min=\(w.min().item(Float.self)), max=\(w.max().item(Float.self))")
+        } else {
+            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv2.weight: MISSING")
+        }
+
+        // Decoder: [1, D', T] -> [1, 1, T']
+        let audio = acousticDecoder(h)
+        print("[OmniVoice Decode] after acousticDecoder: shape=\(audio.shape), min=\(audio.min().item(Float.self)), max=\(audio.max().item(Float.self)), mean=\(audio.mean().item(Float.self))")
+
+        return audio.reshaped([-1])
+    }
+
+    /// Sanitize and remap checkpoint weights for the audio tokenizer.
+    /// Mirrors Python HiggsAudioTokenizer.sanitize logic, but skips conv
+    /// weight transposes because Swift's OmniVoiceConv1d/ConvTranspose1d
+    /// already handle PyTorch-to-MLX layout conversion internally.
+    func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result: [String: MLXArray] = [:]
+        let keepPrefixes = [
+            "acoustic_encoder.",
+            "acoustic_decoder.",
+            "quantizer.",
+            "fc2.",
+        ]
+        let keepExact: Set<String> = []
+        // Semantic-path weights (semantic_model/encoder_semantic/fc) are dropped
+        // until the HuBERT semantic encoder is ported — they are only needed for
+        // voice cloning, not for decode.
+        let dropPrefixes = ["decoder_semantic.", "fc1.", "semantic_model.", "encoder_semantic.", "fc."]
+        let dropSuffixes = [".embed_avg", ".cluster_size", ".inited"]
+
+        for (var k, var v) in weights {
+            // Explicit drops
+            if dropPrefixes.contains(where: { k.hasPrefix($0) }) { continue }
+            if !keepPrefixes.contains(where: { k.hasPrefix($0) }) && !keepExact.contains(k) { continue }
+            if dropSuffixes.contains(where: { k.hasSuffix($0) }) { continue }
+
+            // === Acoustic path weight transforms ===
+            if k.hasPrefix("acoustic_encoder.") || k.hasPrefix("acoustic_decoder.") || k.hasPrefix("quantizer.") || k.hasPrefix("fc2.") {
+                // Python uses nn.Embedding with key "weight"; Swift uses MLXArray with key "embed"
+                if k.hasSuffix(".codebook.weight") {
+                    k = String(k.dropLast("weight".count)) + "embed"
+                }
+                // NOTE: checkpoint alpha is [1,1,C] for NLC; Swift DAC uses NCL,
+                // so we reshape at runtime in snakeAlpha.callAsFunction instead.
+                // NOTE: we do NOT transpose 3D conv weights here because
+                // OmniVoiceConv1d and OmniVoiceConvTranspose1d already
+                // transpose from PyTorch [out,in,k] / [in,out,k] to MLX
+                // [out,k,in] at runtime.
+            }
+
+            result[k] = v
+        }
+        return result
+    }
+
+    public static func fromPretrained(
+        repoID: String,
+        cache: HubCache = .default
+    ) async throws -> OmniVoiceAudioTokenizer {
+        guard let repo = Repo.ID(rawValue: repoID) else {
+            throw AudioGenerationError.invalidInput("Invalid repository ID: \(repoID)")
+        }
+
+        let configURL = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repo,
+            requiredExtension: "json",
+            additionalMatchingPatterns: ["audio_tokenizer/config.json"]
+        ).appendingPathComponent("audio_tokenizer/config.json")
+
+        let configData = try Data(contentsOf: configURL)
+
+        // Load tokenizer weights first to infer actual n_codebooks
+        let weightsURL = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repo,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["audio_tokenizer/model.safetensors"]
+        ).appendingPathComponent("audio_tokenizer/model.safetensors")
+        let rawWeights = try MLX.loadArrays(url: weightsURL)
+        let inferredNCodebooks = Self.inferNCodebooks(from: rawWeights) ?? 9
+
+        var configDict = try JSONSerialization.jsonObject(with: configData) as! [String: Any]
+        
+        // Pull in nested acoustic_model_config values if present
+        if let acoustic = configDict["acoustic_model_config"] as? [String: Any] {
+            for key in ["codebook_size", "codebook_dim", "n_codebooks", "hop_length", "sampling_rate",
+                        "downsampling_ratios", "upsampling_ratios", "encoder_hidden_size",
+                        "decoder_hidden_size", "kernel_size"] {
+                if configDict[key] == nil, let val = acoustic[key] {
+                    configDict[key] = val
+                }
+            }
+        }
+        
+        if let currentNum = configDict["n_codebooks"] as? Int, currentNum != inferredNCodebooks {
+            print("[OmniVoiceAudioTokenizer] INFO: overriding n_codebooks from \(currentNum) to \(inferredNCodebooks) to match checkpoint")
+            configDict["n_codebooks"] = inferredNCodebooks
+        } else if configDict["n_codebooks"] == nil {
+            print("[OmniVoiceAudioTokenizer] INFO: setting n_codebooks to \(inferredNCodebooks) from checkpoint")
+            configDict["n_codebooks"] = inferredNCodebooks
+        }
+        let patchedConfigData = try JSONSerialization.data(withJSONObject: configDict)
+        let config = try JSONDecoder().decode(OmniVoiceAudioTokenizerConfig.self, from: patchedConfigData)
+
+        let tokenizer = OmniVoiceAudioTokenizer(config: config)
+        let weights = tokenizer.sanitize(weights: rawWeights)
+
+        // Verify weight coverage before loading
+        let moduleParams = Dictionary(uniqueKeysWithValues: tokenizer.parameters().flattened())
+        let weightKeys = Set(weights.keys)
+        let paramKeys = Set(moduleParams.keys)
+        let missing = paramKeys.subtracting(weightKeys).sorted()
+        let extra = weightKeys.subtracting(paramKeys).sorted()
+        if !missing.isEmpty {
+            print("[OmniVoiceAudioTokenizer] WARNING: \(missing.count) parameters missing from checkpoint: \(missing.prefix(10))")
+        }
+        if !extra.isEmpty {
+            print("[OmniVoiceAudioTokenizer] WARNING: \(extra.count) extra keys in checkpoint: \(extra.prefix(10))")
+        }
+        
+        // Test: load all tokenizer weights in float32 to rule out bfloat16 precision issues
+        let float32Weights = weights.mapValues { $0.asType(.float32) }
+        try tokenizer.update(parameters: ModuleParameters.unflattened(float32Weights), verify: .noUnusedKeys)
+        eval(tokenizer)
+        print("[OmniVoiceAudioTokenizer] INFO: loaded all weights as float32 for precision test")
+
+        return tokenizer
+    }
+
+    private static func inferNCodebooks(from weights: [String: MLXArray]) -> Int? {
+        var maxIdx = -1
+        for key in weights.keys {
+            if key.hasPrefix("quantizer.quantizers."), key.contains(".codebook.") {
+                let suffix = key.dropFirst("quantizer.quantizers.".count)
+                if let dotIdx = suffix.firstIndex(of: ".") {
+                    let numStr = suffix.prefix(upTo: dotIdx)
+                    if let idx = Int(numStr), idx > maxIdx {
+                        maxIdx = idx
+                    }
+                }
+            }
+        }
+        return maxIdx >= 0 ? maxIdx + 1 : nil
+    }
+}
+

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -374,79 +374,20 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
 
         let layerIds = MLXArray((0..<numCodebooks).map { Int32($0) }).reshaped([1, numCodebooks, 1])
 
-        // Diagnostic: test backbone reconstruction on reference audio tokens
-        if let refTok = refAudioTokens {
-            let refLen = min(refTok.shape[1], targetLen)
-            let refPrefix = refTok[0..., 0..<refLen]
-            let refPadding = MLXArray.full([numCodebooks, targetLen - refLen], values: MLXArray(Int32(config.audioMaskId)))
-            let refTarget = MLX.concatenated([refPrefix, refPadding], axis: 1).reshaped([1, numCodebooks, targetLen])
-            let prefix = inputIds[0..., 0..., 0..<prefixLen]
-            let diagInputIds = MLX.concatenated([prefix, refTarget], axis: 2)
-            
-            // Step-by-step diagnostic to isolate where predictions break
-            let diagEmbeds = prepareEmbedInputs(inputIds: diagInputIds, audioMask: audioMask)
-            print("[OmniVoice DIAG] embeds: shape=\(diagEmbeds.shape), min=\(diagEmbeds.min().item(Float.self)), max=\(diagEmbeds.max().item(Float.self)), mean=\(diagEmbeds.mean().item(Float.self))")
-            
-            let diagHidden = llm.forwardWithEmbeddings(inputsEmbeds: diagEmbeds, cache: nil, mask: .none).asType(.float32)
-            print("[OmniVoice DIAG] hidden: shape=\(diagHidden.shape), min=\(diagHidden.min().item(Float.self)), max=\(diagHidden.max().item(Float.self)), mean=\(diagHidden.mean().item(Float.self))")
-            
-            var diagLogitsList: [MLXArray] = []
-            for (i, head) in audioHeads.enumerated() {
-                let hLogits = head(diagHidden)  // [B, S, V]
-                let hReshaped = hLogits.reshaped([diagHidden.shape[0], diagHidden.shape[1], 1, config.audioVocabSize])
-                diagLogitsList.append(hReshaped)
-            }
-            let diagLogits = MLX.concatenated(diagLogitsList, axis: 2).asType(.float32)
-            print("[OmniVoice DIAG] logits: shape=\(diagLogits.shape), min=\(diagLogits.min().item(Float.self)), max=\(diagLogits.max().item(Float.self)), mean=\(diagLogits.mean().item(Float.self))")
-            
-            let diagTargetLogits = diagLogits[0, (condLength - targetLen)..<condLength, 0..., 0...]
-            let diagTargetLogitsBatch = diagTargetLogits.transposed(1, 0, 2).reshaped([1, numCodebooks, targetLen, config.audioVocabSize])
-            let diagPreds = MLX.argMax(diagTargetLogitsBatch, axis: -1)[0]
-            let refForCompare = refTarget[0..., 0..., 0..<refLen]
-            let predForCompare = diagPreds[0..., 0..<refLen]
-            let match = (refForCompare .== predForCompare).sum().item(Int32.self)
-            let total = refLen * numCodebooks
-            print("[OmniVoice] DIAGNOSTIC: backbone reconstruction accuracy on ref audio = \(match)/\(total) (\(String(format: "%.1f", Float(match)/Float(total)*100))%)")
-            
-            // Extra diagnostic: print top-1 token distribution for first codebook
-            let firstCbPreds = predForCompare[0, 0...].asArray(Int32.self)
-            let uniquePreds = Dictionary(grouping: firstCbPreds, by: { $0 }).mapValues { $0.count }
-            let topPreds = uniquePreds.sorted { $0.value > $1.value }.prefix(5)
-            print("[OmniVoice DIAG] first codebook top-5 predicted tokens: \(Array(topPreds))")
-        }
-
         // 7. Iterative diffusion generation
         for step in 0..<numSteps {
             let k = schedule[step]
             if k <= 0 { continue }
 
-            // Separate forward passes for cond and uncond to avoid custom batch mask issues
+            // Separate forward passes for cond and uncond (bidirectional attention)
             let condLogits = forward(
                 inputIds: inputIds,
-                audioMask: audioMask,
-                attentionMask: .none
+                audioMask: audioMask
             ).asType(.float32)
             let uLogitsFull = forward(
                 inputIds: uncondInputIds,
-                audioMask: uncondAudioMask,
-                attentionMask: .none
+                audioMask: uncondAudioMask
             ).asType(.float32)
-
-            // Diagnostic: print logits statistics on step 0
-            if step == 0 {
-                let cMin = condLogits.min().item(Float.self)
-                let cMax = condLogits.max().item(Float.self)
-                let cMean = condLogits.mean().item(Float.self)
-                let cAnyNaN = isNaN(condLogits).any().item(Bool.self)
-                let cAnyInf = isInf(condLogits).any().item(Bool.self)
-                let uMin = uLogitsFull.min().item(Float.self)
-                let uMax = uLogitsFull.max().item(Float.self)
-                let uMean = uLogitsFull.mean().item(Float.self)
-                let uAnyNaN = isNaN(uLogitsFull).any().item(Bool.self)
-                let uAnyInf = isInf(uLogitsFull).any().item(Bool.self)
-                print("[OmniVoice] Step 0 cond logits: min=\(cMin), max=\(cMax), mean=\(cMean), hasNaN=\(cAnyNaN), hasInf=\(cAnyInf)")
-                print("[OmniVoice] Step 0 uncond logits: min=\(uMin), max=\(uMax), mean=\(uMean), hasNaN=\(uAnyNaN), hasInf=\(uAnyInf)")
-            }
 
             // Extract target region logits
             let cLogits = condLogits[0, (condLength - targetLen)..<condLength, 0..., 0...]
@@ -477,25 +418,6 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             let mask = tokens[0] .!= Int32(config.audioMaskId)
             let maskInf = MLX.where(mask, MLXArray(Float(-Float.infinity)), finalScores).asType(.float32)
 
-            // Parity-debug trace: dump step-0 scoring internals
-            if step == 0, ProcessInfo.processInfo.environment["OMNIVOICE_TRACE"] != nil {
-                try? FileManager.default.createDirectory(
-                    atPath: "/tmp/ov-trace-swift", withIntermediateDirectories: true)
-                try? MLX.save(
-                    arrays: [
-                        "pred_tokens": predTokens[0].asType(.int32),
-                        "scores": scores[0].asType(.float32),
-                        "final_scores": finalScores.reshaped([numCodebooks, targetLen]).asType(.float32),
-                        "input_ids": inputIds[0].asType(.int32),
-                        "audio_mask": audioMask.asType(.int32),
-                        "uncond_input_ids": uncondInputIds[0].asType(.int32),
-                        "uncond_audio_mask": uncondAudioMask.asType(.int32),
-                        "c_logits": cLogitsBatch.asType(.float32),
-                        "u_logits": uLogitsBatch.asType(.float32),
-                    ],
-                    url: URL(fileURLWithPath: "/tmp/ov-trace-swift/step00-internals.safetensors"))
-            }
-
             // Flatten for top-k selection
             let flatScores = maskInf.reshaped([-1])
             let flatTokens = tokens[0].reshaped([-1])
@@ -522,16 +444,6 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             uncondInputIds = tokens  // uncond is just the target region
 
             eval(inputIds, uncondInputIds, tokens)
-
-            // Parity-debug trace: dump per-step tokens when OMNIVOICE_TRACE is set
-            if ProcessInfo.processInfo.environment["OMNIVOICE_TRACE"] != nil {
-                let dir = "/tmp/ov-trace-swift"
-                try? FileManager.default.createDirectory(
-                    atPath: dir, withIntermediateDirectories: true)
-                try? MLX.save(
-                    arrays: ["tokens": tokens[0], "k": MLXArray(Int32(k))],
-                    url: URL(fileURLWithPath: String(format: "%@/step%02d.safetensors", dir, step)))
-            }
         }
 
         // Safeguard: fill any remaining mask tokens with a final deterministic prediction
@@ -569,50 +481,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             outputTokens = MLX.where(remainingMask, MLXArray.zeros(outputTokens.shape, type: Int32.self), outputTokens)
         }
         
-        // Diagnostic: print token statistics to debug noise issues
-        let tokenVals = outputTokens.asArray(Int32.self)
-        let uniqueVals = Set(tokenVals)
-        let maskCount = tokenVals.filter { $0 == Int32(config.audioMaskId) }.count
-        print("[OmniVoice] Token stats: min=\(uniqueVals.min() ?? -1), max=\(uniqueVals.max() ?? -1), unique=\(uniqueVals.count), maskRemaining=\(maskCount)")
-
-        // Diagnostic: bypass diffusion and decode refAudioTokens directly if available
-        if let refTok = refAudioTokens {
-            do {
-                let refDecoded = try audioTok.decode(refTok)
-                let tempDir = FileManager.default.temporaryDirectory
-                let refURL = tempDir.appendingPathComponent("omnivoice_diagnostic_ref_direct.wav")
-                try AudioUtils.writeWavFile(samples: refDecoded.asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: refURL)
-                print("[OmniVoice] DIAGNOSTIC: saved direct ref decode to \(refURL.path)")
-            } catch {
-                print("[OmniVoice] DIAGNOSTIC: ref direct decode failed: \(error)")
-            }
-        }
-
         let audio = try audioTok.decode(outputTokens)
-        
-        // Diagnostic: print vocoder output statistics
-        let audioMin = audio.min().item(Float.self)
-        let audioMax = audio.max().item(Float.self)
-        let audioMean = audio.mean().item(Float.self)
-        let audioNaN = isNaN(audio).any().item(Bool.self)
-        let audioInf = isInf(audio).any().item(Bool.self)
-        print("[OmniVoice] Vocoder decode stats: min=\(audioMin), max=\(audioMax), mean=\(audioMean), hasNaN=\(audioNaN), hasInf=\(audioInf)")
-
-        // Temporary diagnostics: save intermediate audio to temp directory
-        do {
-            let tempDir = FileManager.default.temporaryDirectory
-            let rawURL = tempDir.appendingPathComponent("omnivoice_diagnostic_raw.wav")
-            let finalURL = tempDir.appendingPathComponent("omnivoice_diagnostic_final.wav")
-            let rawSamples = audio.asArray(Float.self)
-            try AudioUtils.writeWavFile(samples: rawSamples, sampleRate: Double(config.sampleRate), fileURL: rawURL)
-            print("[OmniVoice] DIAGNOSTIC: saved raw vocoder output to \(rawURL.path)")
-            let processed = postProcessAudio(audio, refRms: nil, postprocessOutput: ovParameters.postprocessOutput)
-            try AudioUtils.writeWavFile(samples: processed.asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: finalURL)
-            print("[OmniVoice] DIAGNOSTIC: saved post-processed audio to \(finalURL.path)")
-            return processed
-        } catch {
-            print("[OmniVoice] DIAGNOSTIC: failed to save wav: \(error)")
-        }
 
         // 9. Post-process
         return postProcessAudio(audio, refRms: nil, postprocessOutput: ovParameters.postprocessOutput)
@@ -917,10 +786,11 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         if !extra.isEmpty {
             print("[OmniVoiceModel] WARNING: \(extra.count) extra keys after sanitize: \(extra.prefix(10))")
         }
+        // Weights run as float32: the diffusion loop is sensitive to logit
+        // precision and the reference checkpoint ships fp32 (no-op there).
         let float32Weights = sanitizedWeights.mapValues { $0.asType(.float32) }
         try model.update(parameters: ModuleParameters.unflattened(float32Weights), verify: .noUnusedKeys)
         eval(model)
-        print("[OmniVoiceModel] INFO: loaded TTS model weights as float32 for precision test")
 
         // Load text tokenizer
         model.tokenizer = try await AutoTokenizer.from(modelFolder: {
@@ -1326,16 +1196,11 @@ public final class OmniVoiceDACAcousticEncoder: Module {
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         var h = conv1(x)
-        print("[OmniVoice Encoder] after conv1: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
-        for (i, b) in block.enumerated() {
+        for b in block {
             h = b(h)
-            print("[OmniVoice Encoder] after downBlock \(i): shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
         }
         h = snake1.callAsFunction(h)
-        print("[OmniVoice Encoder] after snake1: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
-        h = conv2(h)
-        print("[OmniVoice Encoder] after conv2: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
-        return h
+        return conv2(h)
     }
 }
 
@@ -1385,17 +1250,12 @@ public final class OmniVoiceDACAcousticDecoder: Module {
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         var h = conv1(x)
-        print("[OmniVoice Dec] conv1 out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
-        for (i, b) in block.enumerated() {
+        for b in block {
             h = b(h)
-            print("[OmniVoice Dec] upBlock \(i) out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
         }
         h = snake1.callAsFunction(h)
-        print("[OmniVoice Dec] snake1 out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
-        h = conv2(h)
-        // Python _adjust_dac_decoder removes final Tanh; keep output unbounded
-        print("[OmniVoice Dec] conv2 out: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self))")
-        return h
+        // Python _adjust_dac_decoder removes the final Tanh; keep output unbounded
+        return conv2(h)
     }
 }
 
@@ -1550,20 +1410,6 @@ public final class OmniVoiceAudioTokenizer: Module {
         // RVQ: [B, D, T'] -> (codes [B, n_codebooks, T'], quantized [B, D, T'])
         let (codes, _) = quantizer(zProjected)
 
-        // Temporary diagnostic: encode->decode roundtrip to isolate vocoder issues
-        do {
-            let decoded = try self.decode(codes[0])
-            let tempDir = FileManager.default.temporaryDirectory
-            let originalURL = tempDir.appendingPathComponent("omnivoice_tokenizer_roundtrip_original.wav")
-            let decodedURL = tempDir.appendingPathComponent("omnivoice_tokenizer_roundtrip_decoded.wav")
-            try AudioUtils.writeWavFile(samples: wav[0].asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: originalURL)
-            try AudioUtils.writeWavFile(samples: decoded.asArray(Float.self), sampleRate: Double(config.sampleRate), fileURL: decodedURL)
-            print("[OmniVoiceAudioTokenizer] DIAGNOSTIC: saved original to \(originalURL.path)")
-            print("[OmniVoiceAudioTokenizer] DIAGNOSTIC: saved roundtrip to \(decodedURL.path)")
-        } catch {
-            print("[OmniVoiceAudioTokenizer] DIAGNOSTIC: roundtrip save failed: \(error)")
-        }
-
         // Return [n_codebooks, T'] (squeeze batch dim)
         return codes[0]
     }
@@ -1577,7 +1423,6 @@ public final class OmniVoiceAudioTokenizer: Module {
 
         // RVQ decode: [1, n_codebooks, T] -> [1, D, T] where D=1024
         let z = quantizer.decode(batchedTokens)
-        print("[OmniVoice Decode] after quantizer.decode: shape=\(z.shape), min=\(z.min().item(Float.self)), max=\(z.max().item(Float.self)), mean=\(z.mean().item(Float.self))")
 
         // fc2 project: [1, D, T] -> [1, D', T] where D'=256
         // fc2.weight shape is [256, 1024] (outputDim x inputDim)
@@ -1585,24 +1430,9 @@ public final class OmniVoiceAudioTokenizer: Module {
         let zNLC = z.transposed(0, 2, 1)  // [B, T, 1024]
         let hNLC = MLX.matmul(zNLC, fc2.weight.transposed(1, 0))  // [B, T, 256]
         let h = (hNLC + (fc2.bias ?? MLXArray.zeros([1]))).transposed(0, 2, 1)  // [B, 256, T]
-        print("[OmniVoice Decode] after fc2: shape=\(h.shape), min=\(h.min().item(Float.self)), max=\(h.max().item(Float.self)), mean=\(h.mean().item(Float.self))")
-
-        // Verify decoder conv1 weight shape at runtime
-        let paramDict = Dictionary(uniqueKeysWithValues: acousticDecoder.parameters().flattened())
-        if let w = paramDict["conv1.weight"] {
-            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv1.weight: shape=\(w.shape), min=\(w.min().item(Float.self)), max=\(w.max().item(Float.self))")
-        } else {
-            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv1.weight: MISSING")
-        }
-        if let w = paramDict["conv2.weight"] {
-            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv2.weight: shape=\(w.shape), min=\(w.min().item(Float.self)), max=\(w.max().item(Float.self))")
-        } else {
-            print("[OmniVoice Decode] RUNTIME CHECK acousticDecoder.conv2.weight: MISSING")
-        }
 
         // Decoder: [1, D', T] -> [1, 1, T']
         let audio = acousticDecoder(h)
-        print("[OmniVoice Decode] after acousticDecoder: shape=\(audio.shape), min=\(audio.min().item(Float.self)), max=\(audio.max().item(Float.self)), mean=\(audio.mean().item(Float.self))")
 
         return audio.reshaped([-1])
     }
@@ -1715,11 +1545,10 @@ public final class OmniVoiceAudioTokenizer: Module {
             print("[OmniVoiceAudioTokenizer] WARNING: \(extra.count) extra keys in checkpoint: \(extra.prefix(10))")
         }
         
-        // Test: load all tokenizer weights in float32 to rule out bfloat16 precision issues
+        // Codec weights run as float32 (reference checkpoint ships fp32).
         let float32Weights = weights.mapValues { $0.asType(.float32) }
         try tokenizer.update(parameters: ModuleParameters.unflattened(float32Weights), verify: .noUnusedKeys)
         eval(tokenizer)
-        print("[OmniVoiceAudioTokenizer] INFO: loaded all weights as float32 for precision test")
 
         return tokenizer
     }

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -1396,53 +1396,32 @@ public final class OmniVoiceRVQQuantizer: Module {
         self._quantizers.wrappedValue = qs
     }
 
-    /// Quantize: [B, D, T] -> (codes [B, n_quantizers, T], quantized [B, outputDim, T])
-    /// Note: D must be 1024 (decoderHiddenSize). The caller must pre-project if needed.
-    func callAsFunction(_ z: MLXArray) -> (MLXArray, MLXArray) {
-        // z is [B, C, L] (NCL) where C = 1024
-        let batchSize = z.shape[0]
-        let seqLen = z.shape[2]
-        let nQuantizers = quantizers.count
+    /// Encode: [B, T, D] (NLC) -> [B, T, n_quantizers] int32 via greedy
+    /// residual quantization (parity with the Python
+    /// ResidualVectorQuantizer.encode: each stage quantizes the residual left
+    /// by the previous stages, not the original input).
+    func encode(_ z: MLXArray) -> MLXArray {
+        var residual = z
+        var tokens: [MLXArray] = []
 
-        var allCodes: [MLXArray] = []
-        var quantized = MLXArray.zeros([batchSize, outputDim, seqLen])
+        for q in quantizers {
+            let codebook = q.codebook.embed  // [K, codebookDim]
+            let zq = q.projectIn(residual)  // [B, T, codebookDim]
 
-        for qIdx in 0..<nQuantizers {
-            let q = quantizers[qIdx]
-            let codebook = q.codebook.embed
-            let codebookSize = codebook.shape[0]
-            let codebookDim = codebook.shape[1]
+            // Squared distances to each codebook entry: [B, T, K]
+            let dists =
+                MLX.sum(zq * zq, axis: -1, keepDims: true)
+                + MLX.sum(codebook * codebook, axis: -1)
+                - 2 * MLX.matmul(zq, codebook.transposed(1, 0))
+            let idx = MLX.argMin(dists, axis: -1).asType(.int32)  // [B, T]
+            tokens.append(idx)
 
-            // Project input to codebook dimension
-            // z is [B, C, L] (NCL), Linear expects [B, L, C] (NLC)
-            let zNLC = z.transposed(0, 2, 1)  // [B, L, C]
-            let zProjNLC = q.projectIn(zNLC)  // [B, L, codebookDim]
-            let zProj = zProjNLC.transposed(0, 2, 1)  // [B, codebookDim, L]
-
-            // [B, codebookDim, T] -> [B, T, codebookDim] for distance computation
-            let zPermute = zProj.transposed(0, 2, 1)
-            let zFlat = zPermute.reshaped([batchSize * seqLen, codebookDim])
-
-            // Compute distances: [B*T, K]
-            let diff = zFlat.reshaped([zFlat.shape[0], 1, codebookDim])
-                - codebook.reshaped([1, codebookSize, codebookDim])
-            let dist = MLX.sum(diff * diff, axis: -1)
-
-            // Nearest codebook index
-            let codes = MLX.argMin(dist, axis: -1)  // [B*T]
-            let codes2d = codes.reshaped([batchSize, seqLen])
-            allCodes.append(codes2d)
-
-            // Gather quantized vectors and project to output dimension
-            let qVecs = MLX.take(codebook, codes, axis: 0)  // [B*T, codebookDim]
-            let qOut = q.projectOut(qVecs)  // [B*T, outputDim]
-            let q3d = qOut.reshaped([batchSize, seqLen, -1]).transposed(0, 2, 1)
-
-            quantized = quantized + q3d
+            let qVecs = MLX.take(codebook, idx.reshaped([-1]), axis: 0)  // [B*T, codebookDim]
+            let recon = q.projectOut(qVecs).reshaped(residual.shape)  // [B, T, D]
+            residual = residual - recon
         }
 
-        let codes = MLX.stacked(allCodes, axis: 1)  // [B, n_quantizers, T]
-        return (codes, quantized)
+        return MLX.stacked(tokens, axis: -1)  // [B, T, n_quantizers]
     }
 
     /// Decode: [B, n_quantizers, T] -> [B, outputDim, T]
@@ -1481,7 +1460,15 @@ public final class OmniVoiceAudioTokenizer: Module {
     @ModuleInfo(key: "quantizer") var quantizer: OmniVoiceRVQQuantizer
     @ModuleInfo(key: "fc2") var fc2: MLXNN.Linear
 
-    init(config: OmniVoiceAudioTokenizerConfig) {
+    // Encode path (voice cloning): HuBERT semantic features fused with the
+    // acoustic features. Only present when the checkpoint ships
+    // semantic_model.* weights (the full mlx-community/OmniVoice does;
+    // the bf16 variant is stripped).
+    @ModuleInfo(key: "semantic_model") var semanticModel: OmniVoiceHubertModel?
+    @ModuleInfo(key: "encoder_semantic") var encoderSemantic: OmniVoiceSemanticEncoder?
+    @ModuleInfo(key: "fc") var fc: MLXNN.Linear?
+
+    init(config: OmniVoiceAudioTokenizerConfig, includeSemantic: Bool = false) {
         self.config = config
 
         self._acousticEncoder.wrappedValue = OmniVoiceDACAcousticEncoder(config: config)
@@ -1493,12 +1480,47 @@ public final class OmniVoiceAudioTokenizer: Module {
             inputDimensions: config.decoderHiddenSize,
             outputDimensions: config.encoderHiddenSize * 4
         )
+
+        if includeSemantic {
+            self._semanticModel.wrappedValue = OmniVoiceHubertModel(config: config)
+            self._encoderSemantic.wrappedValue = OmniVoiceSemanticEncoder(config: config)
+            // fc fuses [acoustic 256 | semantic hidden] -> quantizer input
+            let fusionDim = config.hiddenSize + config.encoderHiddenSize * 4
+            self._fc.wrappedValue = MLXNN.Linear(
+                inputDimensions: fusionDim, outputDimensions: fusionDim
+            )
+        } else {
+            self._semanticModel.wrappedValue = nil
+            self._encoderSemantic.wrappedValue = nil
+            self._fc.wrappedValue = nil
+        }
     }
 
-    /// Encode audio waveform to discrete tokens.
-    /// - Parameter audio: [samples] or [1, samples]
+    /// Stride factor mapping HuBERT frame rate (16 kHz / 320 = 50 fps) onto the
+    /// acoustic frame rate (24 kHz / 960 = 25 fps).
+    private var semanticDownsampleFactor: Int {
+        let hubertFPS = Double(config.semanticSampleRate) / Double(config.downsampleFactor)
+        let acousticFPS = Double(config.sampleRate) / Double(config.hopLength)
+        return max(1, Int((hubertFPS / acousticFPS).rounded()))
+    }
+
+    /// Encode audio waveform to discrete tokens (parity with the Python
+    /// HiggsAudioTokenizer.encode):
+    ///   1. acoustic_encoder on the 24 kHz waveform -> [B, Ta, 256]
+    ///   2. sinc-resample to 16 kHz, pad downsample_factor/2, HuBERT
+    ///      (mean of all hidden states), stride-slice to 25 fps,
+    ///      encoder_semantic CNN -> [B, Ts, hidden]
+    ///   3. concat [acoustic | semantic] -> fc -> residual RVQ encode
+    /// - Parameter audio: [samples] or [1, samples] at 24 kHz
     /// - Returns: [num_codebooks, seq_len]
     public func encode(_ audio: MLXArray) throws -> MLXArray {
+        guard let semanticModel, let encoderSemantic, let fc else {
+            throw AudioGenerationError.modelNotInitialized(
+                "audio tokenizer checkpoint lacks the semantic encode path (semantic_model.*) "
+                    + "required for voice cloning; use the full mlx-community/OmniVoice checkpoint"
+            )
+        }
+
         var wav = audio
         if wav.ndim == 1 {
             // [T] -> [1, 1, T]  (batch, channels, length) NCL
@@ -1510,21 +1532,52 @@ public final class OmniVoiceAudioTokenizer: Module {
             // NLC [B, L, C] -> NCL [B, C, L]
             wav = wav.transposed(0, 2, 1)
         }
+        let wav32 = wav.asType(.float32)
+        let batchSize = wav32.shape[0]
 
-        // Encoder: [B, 1, T] -> [B, D, T'] where D=256
-        let z = acousticEncoder(wav)
+        // 1. Acoustic features: [B, 1, T] -> [B, 256, Ta] (NCL) -> [B, Ta, 256]
+        let acoustic = acousticEncoder(wav32).transposed(0, 2, 1)
 
-        // Project encoder output (256) to quantizer input dimension (1024)
-        // fc2 is Linear(1024→256), weight shape [256, 1024]. To reverse: x @ W = [B,T',256] @ [256,1024] = [B,T',1024]
-        let zNLC = z.transposed(0, 2, 1)  // [B, T', 256]
-        let zProjectedNLC = MLX.matmul(zNLC, fc2.weight)  // [B, T', 1024]
-        let zProjected = zProjectedNLC.transposed(0, 2, 1)  // [B, 1024, T']
+        // 2. Semantic features. Sinc resampling matches torchaudio
+        //    (AVAudioConverter does not); HuBERT input is padded by
+        //    downsample_factor/2 on both sides.
+        var resampled: [[Float]] = []
+        for b in 0..<batchSize {
+            let samples = wav32[b, 0].asArray(Float.self)
+            resampled.append(
+                omniVoiceSincResample(
+                    samples, from: config.sampleRate, to: config.semanticSampleRate))
+        }
+        let targetLen = resampled.map(\.count).min() ?? 0
+        let hubertPad = config.downsampleFactor / 2
+        var flat = [Float]()
+        flat.reserveCapacity(batchSize * (targetLen + 2 * hubertPad))
+        for r in resampled {
+            flat.append(contentsOf: [Float](repeating: 0, count: hubertPad))
+            flat.append(contentsOf: r[0..<targetLen])
+            flat.append(contentsOf: [Float](repeating: 0, count: hubertPad))
+        }
+        let audio16k = MLXArray(flat).reshaped([batchSize, targetLen + 2 * hubertPad])
 
-        // RVQ: [B, D, T'] -> (codes [B, n_codebooks, T'], quantized [B, D, T'])
-        let (codes, _) = quantizer(zProjected)
+        var semantic = semanticModel.meanHiddenStates(audio16k)  // [B, Th, hidden]
+        let dsf = semanticDownsampleFactor
+        if dsf > 1 {
+            let indices = MLXArray(
+                Swift.stride(from: 0, to: semantic.shape[1], by: dsf).map(Int32.init))
+            semantic = MLX.take(semantic, indices, axis: 1)
+        }
+        semantic = encoderSemantic(semantic)  // [B, Ts, hidden]
 
-        // Return [n_codebooks, T'] (squeeze batch dim)
-        return codes[0]
+        // 3. Fuse, project, quantize.
+        let timeSteps = min(acoustic.shape[1], semantic.shape[1])
+        let fused = MLX.concatenated(
+            [acoustic[0..., 0..<timeSteps, 0...], semantic[0..., 0..<timeSteps, 0...]],
+            axis: -1
+        )
+        let codes = quantizer.encode(fc(fused))  // [B, T, n_codebooks]
+
+        // Return [n_codebooks, T] (squeeze batch dim)
+        return codes[0].transposed(1, 0)
     }
 
     /// Decode discrete tokens back to audio waveform.
@@ -1561,16 +1614,18 @@ public final class OmniVoiceAudioTokenizer: Module {
             "acoustic_decoder.",
             "quantizer.",
             "fc2.",
+            "semantic_model.",
+            "encoder_semantic.",
         ]
-        let keepExact: Set<String> = []
-        // Semantic-path weights (semantic_model/encoder_semantic/fc) are dropped
-        // until the HuBERT semantic encoder is ported — they are only needed for
-        // voice cloning, not for decode.
-        let dropPrefixes = ["decoder_semantic.", "fc1.", "semantic_model.", "encoder_semantic.", "fc."]
+        let keepExact: Set<String> = ["fc.weight", "fc.bias"]
+        let dropPrefixes = ["decoder_semantic.", "fc1."]
+        let dropExact: Set<String> = ["semantic_model.masked_spec_embed"]
         let dropSuffixes = [".embed_avg", ".cluster_size", ".inited"]
 
-        for (var k, var v) in weights {
+        for (key, v) in weights {
+            var k = key
             // Explicit drops
+            if dropExact.contains(k) { continue }
             if dropPrefixes.contains(where: { k.hasPrefix($0) }) { continue }
             if !keepPrefixes.contains(where: { k.hasPrefix($0) }) && !keepExact.contains(k) { continue }
             if dropSuffixes.contains(where: { k.hasSuffix($0) }) { continue }
@@ -1587,6 +1642,20 @@ public final class OmniVoiceAudioTokenizer: Module {
                 // OmniVoiceConv1d and OmniVoiceConvTranspose1d already
                 // transpose from PyTorch [out,in,k] / [in,out,k] to MLX
                 // [out,k,in] at runtime.
+            }
+
+            // === Semantic path (HuBERT) ===
+            // Remap parametrized weight-norm keys; conv weights keep the
+            // PyTorch [out, in/groups, K] layout (transposed at runtime by
+            // OmniVoiceSemanticConv1d / OmniVoiceWeightNormConv1d).
+            if k.hasPrefix("semantic_model.") {
+                if k.contains(".parametrizations.weight.original0") {
+                    k = k.replacingOccurrences(
+                        of: ".parametrizations.weight.original0", with: ".weight_g")
+                } else if k.contains(".parametrizations.weight.original1") {
+                    k = k.replacingOccurrences(
+                        of: ".parametrizations.weight.original1", with: ".weight_v")
+                }
             }
 
             result[k] = v
@@ -1620,7 +1689,7 @@ public final class OmniVoiceAudioTokenizer: Module {
         let inferredNCodebooks = Self.inferNCodebooks(from: rawWeights) ?? 9
 
         var configDict = try JSONSerialization.jsonObject(with: configData) as! [String: Any]
-        
+
         // Pull in nested acoustic_model_config values if present
         if let acoustic = configDict["acoustic_model_config"] as? [String: Any] {
             for key in ["codebook_size", "codebook_dim", "n_codebooks", "hop_length", "sampling_rate",
@@ -1631,7 +1700,17 @@ public final class OmniVoiceAudioTokenizer: Module {
                 }
             }
         }
-        
+
+        // Pull in nested semantic_model_config (HuBERT) values if present
+        if let semantic = configDict["semantic_model_config"] as? [String: Any] {
+            for key in ["hidden_size", "num_hidden_layers", "num_attention_heads",
+                        "intermediate_size", "conv_dim", "conv_kernel", "conv_stride"] {
+                if configDict[key] == nil, let val = semantic[key] {
+                    configDict[key] = val
+                }
+            }
+        }
+
         if let currentNum = configDict["n_codebooks"] as? Int, currentNum != inferredNCodebooks {
             print("[OmniVoiceAudioTokenizer] INFO: overriding n_codebooks from \(currentNum) to \(inferredNCodebooks) to match checkpoint")
             configDict["n_codebooks"] = inferredNCodebooks
@@ -1642,7 +1721,10 @@ public final class OmniVoiceAudioTokenizer: Module {
         let patchedConfigData = try JSONSerialization.data(withJSONObject: configDict)
         let config = try JSONDecoder().decode(OmniVoiceAudioTokenizerConfig.self, from: patchedConfigData)
 
-        let tokenizer = OmniVoiceAudioTokenizer(config: config)
+        // The semantic encode path (voice cloning) is only built when the
+        // checkpoint actually ships its weights (the bf16 release is stripped).
+        let includeSemantic = rawWeights.keys.contains { $0.hasPrefix("semantic_model.") }
+        let tokenizer = OmniVoiceAudioTokenizer(config: config, includeSemantic: includeSemantic)
         let weights = tokenizer.sanitize(weights: rawWeights)
 
         // Verify weight coverage before loading

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceConfig.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceConfig.swift
@@ -1,0 +1,240 @@
+import Foundation
+import MLXLMCommon
+
+// MARK: - LLM Config (nested within OmniVoice config)
+
+public struct OmniVoiceLLMConfig: Codable, Sendable {
+    var architectures: [String]
+    var attentionBias: Bool
+    var attentionDropout: Float
+    var bosTokenId: Int
+    var chunkSizeFeedForward: Int
+    var dtype: String
+    var eosTokenId: Int
+    var headDim: Int
+    var hiddenAct: String
+    var hiddenSize: Int
+    var initializerRange: Float
+    var intermediateSize: Int
+    var isEncoderDecoder: Bool
+    var layerTypes: [String]
+    var maxPositionEmbeddings: Int
+    var maxWindowLayers: Int
+    var modelType: String
+    var numAttentionHeads: Int
+    var numHiddenLayers: Int
+    var numKeyValueHeads: Int
+    var rmsNormEps: Float
+    var ropeTheta: Float
+    var ropeType: String
+    var tieWordEmbeddings: Bool
+    var useCache: Bool
+    var vocabSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case architectures
+        case attentionBias = "attention_bias"
+        case attentionDropout = "attention_dropout"
+        case bosTokenId = "bos_token_id"
+        case chunkSizeFeedForward = "chunk_size_feed_forward"
+        case dtype
+        case eosTokenId = "eos_token_id"
+        case headDim = "head_dim"
+        case hiddenAct = "hidden_act"
+        case hiddenSize = "hidden_size"
+        case initializerRange = "initializer_range"
+        case intermediateSize = "intermediate_size"
+        case isEncoderDecoder = "is_encoder_decoder"
+        case layerTypes = "layer_types"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case maxWindowLayers = "max_window_layers"
+        case modelType = "model_type"
+        case numAttentionHeads = "num_attention_heads"
+        case numHiddenLayers = "num_hidden_layers"
+        case numKeyValueHeads = "num_key_value_heads"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeTheta = "rope_theta"
+        case ropeType = "rope_type"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case useCache = "use_cache"
+        case vocabSize = "vocab_size"
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        architectures = try c.decodeIfPresent([String].self, forKey: .architectures) ?? ["Qwen3ForCausalLM"]
+        attentionBias = try c.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        attentionDropout = try c.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? 0.0
+        bosTokenId = try c.decodeIfPresent(Int.self, forKey: .bosTokenId) ?? 151643
+        chunkSizeFeedForward = try c.decodeIfPresent(Int.self, forKey: .chunkSizeFeedForward) ?? 0
+        dtype = try c.decodeIfPresent(String.self, forKey: .dtype) ?? "float32"
+        eosTokenId = try c.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 151645
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 128
+        hiddenAct = try c.decodeIfPresent(String.self, forKey: .hiddenAct) ?? "silu"
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1024
+        initializerRange = try c.decodeIfPresent(Float.self, forKey: .initializerRange) ?? 0.02
+        intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 3072
+        isEncoderDecoder = try c.decodeIfPresent(Bool.self, forKey: .isEncoderDecoder) ?? false
+        layerTypes = try c.decodeIfPresent([String].self, forKey: .layerTypes) ?? []
+        maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 40960
+        maxWindowLayers = try c.decodeIfPresent(Int.self, forKey: .maxWindowLayers) ?? 28
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "qwen3"
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 16
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 28
+        numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 8
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        ropeType = try c.decodeIfPresent(String.self, forKey: .ropeType) ?? "default"
+        tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+        useCache = try c.decodeIfPresent(Bool.self, forKey: .useCache) ?? true
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 151676
+    }
+}
+
+// MARK: - Audio Tokenizer Config
+
+public struct OmniVoiceAudioTokenizerConfig: Codable, Sendable {
+    // Acoustic model (DAC) config
+    var codebookSize: Int
+    var codebookDim: Int
+    var nCodebooks: Int
+    var hopLength: Int
+    var samplingRate: Int
+    var downsamplingRatios: [Int]
+    var upsamplingRatios: [Int]
+    var encoderHiddenSize: Int
+    var decoderHiddenSize: Int
+    var kernelSize: Int
+
+    // Hubert semantic config
+    var hiddenSize: Int
+    var numHiddenLayers: Int
+    var numAttentionHeads: Int
+    var intermediateSize: Int
+    var convDim: [Int]
+    var convKernel: [Int]
+    var convStride: [Int]
+
+    // General
+    var sampleRate: Int
+    var semanticSampleRate: Int
+    var downsampleFactor: Int
+
+    enum CodingKeys: String, CodingKey {
+        case codebookSize = "codebook_size"
+        case codebookDim = "codebook_dim"
+        case nCodebooks = "n_codebooks"
+        case hopLength = "hop_length"
+        case samplingRate = "sampling_rate"
+        case downsamplingRatios = "downsampling_ratios"
+        case upsamplingRatios = "upsampling_ratios"
+        case encoderHiddenSize = "encoder_hidden_size"
+        case decoderHiddenSize = "decoder_hidden_size"
+        case kernelSize = "kernel_size"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case intermediateSize = "intermediate_size"
+        case convDim = "conv_dim"
+        case convKernel = "conv_kernel"
+        case convStride = "conv_stride"
+        case sampleRate = "sample_rate"
+        case semanticSampleRate = "semantic_sample_rate"
+        case downsampleFactor = "downsample_factor"
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        codebookSize = try c.decodeIfPresent(Int.self, forKey: .codebookSize) ?? 1024
+        codebookDim = try c.decodeIfPresent(Int.self, forKey: .codebookDim) ?? 64
+        nCodebooks = try c.decodeIfPresent(Int.self, forKey: .nCodebooks) ?? 9
+        hopLength = try c.decodeIfPresent(Int.self, forKey: .hopLength) ?? 960
+        samplingRate = try c.decodeIfPresent(Int.self, forKey: .samplingRate) ?? 16000
+        downsamplingRatios = try c.decodeIfPresent([Int].self, forKey: .downsamplingRatios) ?? [8, 5, 4, 2, 3]
+        upsamplingRatios = try c.decodeIfPresent([Int].self, forKey: .upsamplingRatios) ?? [8, 5, 4, 2, 3]
+        encoderHiddenSize = try c.decodeIfPresent(Int.self, forKey: .encoderHiddenSize) ?? 64
+        decoderHiddenSize = try c.decodeIfPresent(Int.self, forKey: .decoderHiddenSize) ?? 1024
+        kernelSize = try c.decodeIfPresent(Int.self, forKey: .kernelSize) ?? 3
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 768
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 12
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 12
+        intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 3072
+        convDim = try c.decodeIfPresent([Int].self, forKey: .convDim) ?? [512, 512, 512, 512, 512, 512, 512]
+        convKernel = try c.decodeIfPresent([Int].self, forKey: .convKernel) ?? [10, 3, 3, 3, 3, 2, 2]
+        convStride = try c.decodeIfPresent([Int].self, forKey: .convStride) ?? [5, 2, 2, 2, 2, 2, 2]
+        sampleRate = try c.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 24000
+        semanticSampleRate = try c.decodeIfPresent(Int.self, forKey: .semanticSampleRate) ?? 16000
+        downsampleFactor = try c.decodeIfPresent(Int.self, forKey: .downsampleFactor) ?? 320
+    }
+}
+
+// MARK: - Top-level OmniVoice Config
+
+public struct OmniVoiceConfig: Codable, Sendable {
+    var modelType: String
+    var architectures: [String]
+    var dtype: String
+
+    // LLM backbone config
+    var llmConfig: OmniVoiceLLMConfig
+
+    // Audio codebook settings
+    var audioCodebookWeights: [Int]
+    var audioMaskId: Int
+    var audioVocabSize: Int
+
+    // Token IDs
+    var bosTokenId: Int?
+    var eosTokenId: Int
+    var padTokenId: Int
+
+    // Audio codebook
+    var numAudioCodebook: Int
+
+    // Quantization
+    var quantization: BaseConfiguration.Quantization?
+    var perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architectures
+        case dtype
+        case llmConfig = "llm_config"
+        case audioCodebookWeights = "audio_codebook_weights"
+        case audioMaskId = "audio_mask_id"
+        case audioVocabSize = "audio_vocab_size"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+        case numAudioCodebook = "num_audio_codebook"
+        case quantization
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "omnivoice"
+        architectures = try c.decodeIfPresent([String].self, forKey: .architectures) ?? ["OmniVoice"]
+        dtype = try c.decodeIfPresent(String.self, forKey: .dtype) ?? "bfloat16"
+        llmConfig = try c.decode(OmniVoiceLLMConfig.self, forKey: .llmConfig)
+        audioCodebookWeights = try c.decodeIfPresent([Int].self, forKey: .audioCodebookWeights) ?? [8, 8, 8, 6, 6, 4, 4, 2, 2]  // 9 codebooks
+        audioMaskId = try c.decodeIfPresent(Int.self, forKey: .audioMaskId) ?? 1024
+        audioVocabSize = try c.decodeIfPresent(Int.self, forKey: .audioVocabSize) ?? 1025
+        bosTokenId = try c.decodeIfPresent(Int.self, forKey: .bosTokenId)
+        eosTokenId = try c.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 151645
+        padTokenId = try c.decodeIfPresent(Int.self, forKey: .padTokenId) ?? 151643
+        numAudioCodebook = try c.decodeIfPresent(Int.self, forKey: .numAudioCodebook) ?? 9  // Match tokenizer nCodebooks
+
+        // Try global quantization
+        let baseConfig = try? BaseConfiguration(from: decoder)
+        quantization = try c.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantization)
+        if quantization == nil {
+            quantization = try? BaseConfiguration.Quantization(from: decoder)
+        }
+        perLayerQuantization = baseConfig?.perLayerQuantization
+    }
+
+    /// The expected sample rate for output audio.
+    public var sampleRate: Int {
+        24000
+    }
+}

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceGenerateParameters.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceGenerateParameters.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Generation parameters specific to OmniVoice diffusion-based TTS.
+///
+/// These parameters control the diffusion process, voice characteristics,
+/// and output quality. They supplement the standard `GenerateParameters`
+/// (temperature, topP, maxTokens) from MLXLMCommon.
+public struct OmniVoiceGenerateParameters: Sendable {
+    // MARK: - Diffusion Parameters
+
+    /// Number of diffusion steps (default: 32).
+    /// Higher values produce better quality but slower generation.
+    /// Range: 8-64, typical: 16-32
+    public var numStep: Int
+
+    /// Classifier-free guidance scale (default: 2.0).
+    /// Controls how strongly the model follows the text prompt.
+    /// Higher values = more faithful to prompt but potentially less natural.
+    /// Range: 1.0-5.0, typical: 1.5-3.0
+    public var guidanceScale: Float
+
+    // MARK: - Speech Characteristics
+
+    /// Speech speed factor (default: 1.0).
+    /// Values > 1.0 produce faster speech, < 1.0 produces slower speech.
+    /// Range: 0.5-2.0, typical: 0.8-1.2
+    public var speed: Float
+
+    /// Fixed output duration in seconds (optional).
+    /// If set, overrides the model's duration estimation.
+    /// The speed factor is automatically adjusted to match while preserving language-aware pacing.
+    public var duration: Float?
+
+    /// Time shift parameter for diffusion (default: 0.1).
+    /// Controls the temporal dynamics of the diffusion process.
+    /// Lower values = smoother transitions, higher values = more variation.
+    public var tShift: Float
+
+    // MARK: - Output Processing
+
+    /// Whether to denoise output audio (default: true).
+    /// Applies normalization and noise reduction to the generated audio.
+    public var denoise: Bool
+
+    /// Whether to postprocess output audio (default: true).
+    /// Applies final quality improvements to the generated waveform.
+    public var postprocessOutput: Bool
+
+    // MARK: - Advanced Parameters
+
+    /// Layer penalty factor for diffusion (default: 5.0).
+    /// Controls the influence of different network layers on the output.
+    /// Higher values emphasize deeper layer representations.
+    public var layerPenaltyFactor: Float
+
+    /// Position temperature for codebook sampling (default: 5.0).
+    /// Controls the randomness of positional aspects in generation.
+    /// Higher values = more variation in timing/prosody.
+    public var positionTemperature: Float
+
+    /// Class temperature for codebook sampling (default: 0.0).
+    /// Controls the randomness of phoneme/class selection.
+    /// Lower values = more deterministic, higher values = more variation.
+    public var classTemperature: Float
+
+    // MARK: - Initialization
+
+    public init(
+        numStep: Int = 32,
+        guidanceScale: Float = 2.0,
+        speed: Float = 1.0,
+        duration: Float? = nil,
+        tShift: Float = 0.1,
+        denoise: Bool = true,
+        postprocessOutput: Bool = true,
+        layerPenaltyFactor: Float = 5.0,
+        positionTemperature: Float = 5.0,
+        classTemperature: Float = 0.0
+    ) {
+        self.numStep = numStep
+        self.guidanceScale = guidanceScale
+        self.speed = speed
+        self.duration = duration
+        self.tShift = tShift
+        self.denoise = denoise
+        self.postprocessOutput = postprocessOutput
+        self.layerPenaltyFactor = layerPenaltyFactor
+        self.positionTemperature = positionTemperature
+        self.classTemperature = classTemperature
+    }
+
+    /// Default parameters optimized for fast generation.
+    public static var fast: OmniVoiceGenerateParameters {
+        OmniVoiceGenerateParameters(
+            numStep: 16,
+            guidanceScale: 1.5,
+            speed: 1.0,
+            tShift: 0.1,
+            denoise: true,
+            postprocessOutput: true,
+            layerPenaltyFactor: 5.0,
+            positionTemperature: 5.0,
+            classTemperature: 0.0
+        )
+    }
+
+    /// Default parameters optimized for high quality generation.
+    public static var highQuality: OmniVoiceGenerateParameters {
+        OmniVoiceGenerateParameters(
+            numStep: 64,
+            guidanceScale: 2.5,
+            speed: 1.0,
+            tShift: 0.1,
+            denoise: true,
+            postprocessOutput: true,
+            layerPenaltyFactor: 5.0,
+            positionTemperature: 5.0,
+            classTemperature: 0.0
+        )
+    }
+}

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceSemantic.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceSemantic.swift
@@ -1,0 +1,460 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+// MARK: - HiggsAudioV2 semantic encode path (HuBERT + SemanticEncoder)
+//
+// Port of mlx_audio (Python):
+//   - mlx_audio/stt/models/wav2vec/wav2vec.py  (Wav2Vec2Model, model_type=hubert)
+//   - mlx_audio/codec/models/higgs_audio/semantic.py  (SemanticEncoder)
+//   - mlx_audio/codec/models/higgs_audio/higgs_audio.py  (_sinc_resample, encode fusion)
+//
+// All modules run channels-last (NLC) and store conv weights in the
+// checkpoint's PyTorch layout [out, in/groups, K], transposing at call time
+// (same convention as OmniVoiceConv1d, minus the NCL round-trips).
+
+// MARK: - Conv primitive (PyTorch weight layout, NLC data)
+
+final class OmniVoiceSemanticConv1d: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray  // PyTorch [out, in/groups, K]
+    @ModuleInfo(key: "bias") var bias: MLXArray?
+
+    let strideVal: Int
+    let paddingVal: Int
+    let dilationVal: Int
+    let groupsVal: Int
+
+    init(
+        inChannels: Int,
+        outChannels: Int,
+        kernelSize: Int,
+        stride: Int = 1,
+        padding: Int = 0,
+        dilation: Int = 1,
+        groups: Int = 1,
+        bias: Bool = true
+    ) {
+        self.strideVal = stride
+        self.paddingVal = padding
+        self.dilationVal = dilation
+        self.groupsVal = groups
+
+        let scale = sqrt(1.0 / Float(inChannels * kernelSize))
+        self._weight.wrappedValue = MLXRandom.uniform(
+            low: -scale, high: scale, [outChannels, inChannels / groups, kernelSize]
+        )
+        self._bias.wrappedValue = bias ? MLXArray.zeros([outChannels]) : nil
+    }
+
+    /// x: [B, T, C_in] -> [B, T', C_out]
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let w = weight.transposed(0, 2, 1).asType(.float32)  // [out, K, in/groups]
+        var h = MLX.conv1d(
+            x.asType(.float32), w,
+            stride: strideVal, padding: paddingVal, dilation: dilationVal, groups: groupsVal
+        )
+        if let b = bias {
+            h = h + b.asType(.float32)
+        }
+        return h.asType(x.dtype)
+    }
+}
+
+// MARK: - HuBERT feature extractor
+
+/// One conv layer of the HuBERT feature extractor. Layer 0 carries a
+/// per-channel GroupNorm under the (misleading) checkpoint key `layer_norm`.
+final class OmniVoiceHubertConvLayer: Module {
+    @ModuleInfo(key: "conv") var conv: OmniVoiceSemanticConv1d
+    @ModuleInfo(key: "layer_norm") var groupNorm: GroupNorm?
+
+    init(inDim: Int, outDim: Int, kernel: Int, stride: Int, bias: Bool, useGroupNorm: Bool) {
+        self._conv.wrappedValue = OmniVoiceSemanticConv1d(
+            inChannels: inDim, outChannels: outDim, kernelSize: kernel,
+            stride: stride, bias: bias
+        )
+        self._groupNorm.wrappedValue =
+            useGroupNorm
+            ? GroupNorm(groupCount: outDim, dimensions: outDim, affine: true, pytorchCompatible: true)
+            : nil
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv(x)
+        if let groupNorm {
+            h = groupNorm(h)
+        }
+        return gelu(h)
+    }
+}
+
+final class OmniVoiceHubertFeatureExtractor: Module {
+    @ModuleInfo(key: "conv_layers") var convLayers: [OmniVoiceHubertConvLayer]
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        var layers: [OmniVoiceHubertConvLayer] = []
+        for i in 0..<config.convDim.count {
+            layers.append(
+                OmniVoiceHubertConvLayer(
+                    inDim: i == 0 ? 1 : config.convDim[i - 1],
+                    outDim: config.convDim[i],
+                    kernel: config.convKernel[i],
+                    stride: config.convStride[i],
+                    bias: false,
+                    useGroupNorm: i == 0  // feat_extract_norm == "group"
+                ))
+        }
+        self._convLayers.wrappedValue = layers
+    }
+
+    /// x: [B, T] waveform -> [B, T', conv_dim[-1]]
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x.expandedDimensions(axis: -1)  // [B, T, 1]
+        for layer in convLayers {
+            h = layer(h)
+        }
+        return h
+    }
+}
+
+final class OmniVoiceHubertFeatureProjection: Module {
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo(key: "projection") var projection: Linear
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        let convOut = config.convDim.last ?? 512
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: convOut, eps: 1e-5)
+        self._projection.wrappedValue = Linear(convOut, config.hiddenSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        projection(layerNorm(x))
+    }
+}
+
+// MARK: - HuBERT encoder
+
+/// Weight-normed grouped conv (PyTorch weight_norm(dim=2) layout):
+///   weight_g: [1, 1, K], weight_v: [out, in/groups, K]
+final class OmniVoiceWeightNormConv1d: Module {
+    @ModuleInfo(key: "weight_g") var weightG: MLXArray
+    @ModuleInfo(key: "weight_v") var weightV: MLXArray
+    @ModuleInfo(key: "bias") var bias: MLXArray
+
+    let kernelSize: Int
+    let paddingVal: Int
+    let groupsVal: Int
+
+    init(dim: Int, kernelSize: Int, padding: Int, groups: Int) {
+        self.kernelSize = kernelSize
+        self.paddingVal = padding
+        self.groupsVal = groups
+        self._weightG.wrappedValue = MLXArray.ones([1, 1, kernelSize])
+        self._weightV.wrappedValue = MLXRandom.uniform(
+            low: -0.01, high: 0.01, [dim, dim / groups, kernelSize]
+        )
+        self._bias.wrappedValue = MLXArray.zeros([dim])
+    }
+
+    /// x: [B, T, C] -> [B, T', C]
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // MLX layout [out, K, in/groups]; weight-norm over all axes except K.
+        let v = weightV.transposed(0, 2, 1).asType(.float32)
+        let g = weightG.transposed(0, 2, 1).asType(.float32)
+        let norm = MLX.sqrt(MLX.sum(v * v, axes: [0, 2], keepDims: true))
+        let w = g * v / norm
+
+        var h = MLX.conv1d(
+            x.asType(.float32), w,
+            stride: 1, padding: paddingVal, groups: groupsVal
+        )
+        h = h + bias.asType(.float32)
+        return h.asType(x.dtype)
+    }
+}
+
+/// Weight-normed grouped positional conv embedding (kernel 128, groups 16),
+/// followed by even-kernel same-pad trim and GELU.
+final class OmniVoiceHubertPositionalConvEmbedding: Module {
+    @ModuleInfo(key: "conv") var conv: OmniVoiceWeightNormConv1d
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        // num_conv_pos_embeddings = 128, num_conv_pos_embedding_groups = 16
+        self._conv.wrappedValue = OmniVoiceWeightNormConv1d(
+            dim: config.hiddenSize, kernelSize: 128, padding: 64, groups: 16
+        )
+    }
+
+    /// x: [B, T, D] -> [B, T, D]
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv(x)
+        // SamePadLayer: even kernel emits one extra frame; drop the last.
+        h = h[0..., 0..<(h.shape[1] - 1), 0...]
+        return gelu(h)
+    }
+}
+
+final class OmniVoiceHubertAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    let numHeads: Int
+    let headDim: Int
+    let scaling: Float
+
+    init(dim: Int, numHeads: Int) {
+        self.numHeads = numHeads
+        self.headDim = dim / numHeads
+        self.scaling = pow(Float(headDim), -0.5)
+        self._qProj.wrappedValue = Linear(dim, dim)
+        self._kProj.wrappedValue = Linear(dim, dim)
+        self._vProj.wrappedValue = Linear(dim, dim)
+        self._outProj.wrappedValue = Linear(dim, dim)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (B, T, D) = (x.shape[0], x.shape[1], x.shape[2])
+        func shaped(_ t: MLXArray) -> MLXArray {
+            t.reshaped([B, T, numHeads, headDim]).transposed(0, 2, 1, 3)
+        }
+        let q = shaped(qProj(x) * scaling)
+        let k = shaped(kProj(x))
+        let v = shaped(vProj(x))
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: 1.0, mask: .none
+        )
+        return outProj(attn.transposed(0, 2, 1, 3).reshaped([B, T, D]))
+    }
+}
+
+final class OmniVoiceHubertFeedForward: Module {
+    @ModuleInfo(key: "intermediate_dense") var intermediateDense: Linear
+    @ModuleInfo(key: "output_dense") var outputDense: Linear
+
+    init(dim: Int, intermediate: Int) {
+        self._intermediateDense.wrappedValue = Linear(dim, intermediate)
+        self._outputDense.wrappedValue = Linear(intermediate, dim)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        outputDense(gelu(intermediateDense(x)))
+    }
+}
+
+/// Post-norm transformer layer (do_stable_layer_norm = false).
+final class OmniVoiceHubertEncoderLayer: Module {
+    @ModuleInfo(key: "attention") var attention: OmniVoiceHubertAttention
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo(key: "feed_forward") var feedForward: OmniVoiceHubertFeedForward
+    @ModuleInfo(key: "final_layer_norm") var finalLayerNorm: LayerNorm
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        self._attention.wrappedValue = OmniVoiceHubertAttention(
+            dim: config.hiddenSize, numHeads: config.numAttentionHeads
+        )
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: 1e-5)
+        self._feedForward.wrappedValue = OmniVoiceHubertFeedForward(
+            dim: config.hiddenSize, intermediate: config.intermediateSize
+        )
+        self._finalLayerNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: 1e-5)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = layerNorm(x + attention(x))
+        h = finalLayerNorm(h + feedForward(h))
+        return h
+    }
+}
+
+final class OmniVoiceHubertEncoder: Module {
+    @ModuleInfo(key: "pos_conv_embed") var posConvEmbed: OmniVoiceHubertPositionalConvEmbedding
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo(key: "layers") var layers: [OmniVoiceHubertEncoderLayer]
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        self._posConvEmbed.wrappedValue = OmniVoiceHubertPositionalConvEmbedding(config: config)
+        self._layerNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: 1e-5)
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in
+            OmniVoiceHubertEncoderLayer(config: config)
+        }
+    }
+
+    /// Returns all hidden states: the post-layernorm input plus each layer
+    /// output (num_hidden_layers + 1 entries).
+    func hiddenStates(_ x: MLXArray) -> [MLXArray] {
+        var h = layerNorm(x + posConvEmbed(x))
+        var all: [MLXArray] = [h]
+        for layer in layers {
+            h = layer(h)
+            all.append(h)
+        }
+        return all
+    }
+}
+
+/// HuBERT model matching the `semantic_model.*` checkpoint keys.
+final class OmniVoiceHubertModel: Module {
+    @ModuleInfo(key: "feature_extractor") var featureExtractor: OmniVoiceHubertFeatureExtractor
+    @ModuleInfo(key: "feature_projection") var featureProjection: OmniVoiceHubertFeatureProjection
+    @ModuleInfo(key: "encoder") var encoder: OmniVoiceHubertEncoder
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        self._featureExtractor.wrappedValue = OmniVoiceHubertFeatureExtractor(config: config)
+        self._featureProjection.wrappedValue = OmniVoiceHubertFeatureProjection(config: config)
+        self._encoder.wrappedValue = OmniVoiceHubertEncoder(config: config)
+    }
+
+    /// x: [B, T] 16 kHz waveform -> mean over all hidden states, [B, T', hidden]
+    /// (HiggsAudioV2 averages the full hidden-state stack, not just the last.)
+    func meanHiddenStates(_ x: MLXArray) -> MLXArray {
+        let features = featureExtractor(x)
+        let projected = featureProjection(features)
+        let all = encoder.hiddenStates(projected)
+        return MLX.mean(MLX.stacked(all, axis: 0), axis: 0)
+    }
+}
+
+// MARK: - SemanticEncoder (post-HuBERT CNN)
+
+final class OmniVoiceSemanticResidualUnit: Module {
+    @ModuleInfo(key: "conv1") var conv1: OmniVoiceSemanticConv1d
+    @ModuleInfo(key: "conv2") var conv2: OmniVoiceSemanticConv1d
+
+    init(dim: Int, dilation: Int = 1, kernelSize: Int = 3) {
+        let pad = (kernelSize - 1) * dilation / 2
+        self._conv1.wrappedValue = OmniVoiceSemanticConv1d(
+            inChannels: dim, outChannels: dim, kernelSize: kernelSize,
+            padding: pad, dilation: dilation, bias: false
+        )
+        self._conv2.wrappedValue = OmniVoiceSemanticConv1d(
+            inChannels: dim, outChannels: dim, kernelSize: 1, bias: false
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = elu(x)
+        y = conv1(y)
+        y = elu(y)
+        y = conv2(y)
+        return x + y
+    }
+}
+
+final class OmniVoiceSemanticConvBlock: Module {
+    @ModuleInfo(key: "res_units") var resUnits: [OmniVoiceSemanticResidualUnit]
+    @ModuleInfo(key: "conv") var conv: OmniVoiceSemanticConv1d
+
+    init(dim: Int, stride: Int, dilation: Int, kernelSize: Int, unitKernelSize: Int) {
+        self._resUnits.wrappedValue = [
+            OmniVoiceSemanticResidualUnit(dim: dim, dilation: dilation, kernelSize: unitKernelSize),
+            OmniVoiceSemanticResidualUnit(dim: dim, dilation: dilation, kernelSize: unitKernelSize),
+        ]
+        self._conv.wrappedValue = OmniVoiceSemanticConv1d(
+            inChannels: dim, outChannels: dim, kernelSize: kernelSize,
+            stride: stride, padding: (kernelSize - 1) / 2, bias: true
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for unit in resUnits {
+            h = unit(h)
+        }
+        return conv(h)
+    }
+}
+
+/// SemanticEncoder matching the `encoder_semantic.*` checkpoint keys.
+/// Input/output: [B, T, hidden] (strides are [1, 1] — no downsampling).
+final class OmniVoiceSemanticEncoder: Module {
+    @ModuleInfo(key: "conv") var conv: OmniVoiceSemanticConv1d
+    @ModuleInfo(key: "conv_blocks") var convBlocks: [OmniVoiceSemanticConvBlock]
+
+    init(config: OmniVoiceAudioTokenizerConfig) {
+        let dim = config.hiddenSize
+        let kernel = config.kernelSize
+        self._conv.wrappedValue = OmniVoiceSemanticConv1d(
+            inChannels: dim, outChannels: dim, kernelSize: kernel,
+            padding: (kernel - 1) / 2, bias: false
+        )
+        // strides/dilations/channel_ratios are [1, 1] for this checkpoint.
+        self._convBlocks.wrappedValue = (0..<2).map { _ in
+            OmniVoiceSemanticConvBlock(
+                dim: dim, stride: 1, dilation: 1,
+                kernelSize: kernel, unitKernelSize: config.kernelSize
+            )
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv(x)
+        for block in convBlocks {
+            h = block(h)
+        }
+        return h
+    }
+}
+
+// MARK: - Sinc resampling (torchaudio sinc_interp_hann parity)
+
+/// Resample using Hann-windowed sinc interpolation. Numerical port of
+/// `_sinc_resample` in mlx_audio higgs_audio (which itself matches
+/// torchaudio.functional.resample). Required for parity with the Python
+/// semantic encode path — AVAudioConverter resampling does NOT match.
+func omniVoiceSincResample(
+    _ waveform: [Float],
+    from origFreq: Int,
+    to newFreq: Int,
+    lowpassFilterWidth: Int = 6,
+    rolloff: Double = 0.99
+) -> [Float] {
+    if origFreq == newFreq { return waveform }
+
+    func gcd(_ a: Int, _ b: Int) -> Int { b == 0 ? a : gcd(b, a % b) }
+    let g = gcd(origFreq, newFreq)
+    let origR = origFreq / g
+    let newR = newFreq / g
+
+    let baseFreq = Double(min(origR, newR)) * rolloff
+    let width = Int(ceil(Double(lowpassFilterWidth * origR) / baseFreq))
+
+    // kernel[phase][k], k in 0..<(2*width + origR)
+    let kTaps = 2 * width + origR
+    var kernel = [[Float]](repeating: [Float](repeating: 0, count: kTaps), count: newR)
+    for phase in 0..<newR {
+        for k in 0..<kTaps {
+            let idx = Double(-width + k) / Double(origR)
+            var t = (-Double(phase) / Double(newR) + idx) * baseFreq
+            t = min(max(t, -Double(lowpassFilterWidth)), Double(lowpassFilterWidth))
+            let window = pow(cos(t * Double.pi / Double(lowpassFilterWidth) / 2), 2)
+            let tPi = t * Double.pi
+            let sinc = tPi == 0 ? 1.0 : sin(tPi) / tPi
+            kernel[phase][k] = Float(sinc * window * (baseFreq / Double(origR)))
+        }
+    }
+
+    let length = waveform.count
+    var padded = [Float](repeating: 0, count: width + length + width + origR)
+    padded.replaceSubrange(width..<(width + length), with: waveform)
+
+    let outLen = Int(ceil(Double(length * newR) / Double(origR)))
+    var result = [Float](repeating: 0, count: outLen)
+    for phase in 0..<newR {
+        let taps = kernel[phase]
+        var pos = phase
+        var start = 0
+        while pos < outLen {
+            var acc: Float = 0
+            for k in 0..<kTaps {
+                acc += padded[start + k] * taps[k]
+            }
+            result[pos] = acc
+            pos += newR
+            start += origR
+        }
+    }
+    return result
+}

--- a/Sources/MLXAudioTTS/Models/OmniVoice/README.md
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/README.md
@@ -1,6 +1,6 @@
 # OmniVoice
 
-Swift/MLX port of [k2-fsa/OmniVoice](https://huggingface.co/k2-fsa/OmniVoice), a multilingual zero-shot TTS model: a bidirectional diffusion LM over a Qwen3 backbone (28 layers, 1024 hidden) generating 8 RVQ codebooks at 24 kHz, decoded by a HiggsAudioV2 acoustic codec.
+Swift/MLX port of [k2-fsa/OmniVoice](https://huggingface.co/k2-fsa/OmniVoice), a multilingual zero-shot TTS model: a bidirectional diffusion LM over a Qwen3 backbone (28 layers, 1024 hidden) generating 9 RVQ codebooks at 24 kHz, decoded by a HiggsAudioV2 acoustic codec.
 
 ## Weights
 
@@ -37,11 +37,11 @@ Generation knobs live in `OmniVoiceGenerateParameters` (`numStep`, `guidanceScal
 
 - **Auto voice** (`voice: nil`) — works
 - **Voice design** (`voice: "female, low pitch, ..."`) — works
-- **Voice cloning** (`refAudio` + `refText`) — incomplete: the HiggsAudioV2
-  semantic encode path (HuBERT + SemanticEncoder + fusion projection) is not
-  ported yet, so reference audio is tokenized through an acoustic-only
-  approximation and the cloned voice will not match the reference. Semantic
-  weights are dropped at load time until the port lands.
+- **Voice cloning** (`refAudio` + `refText`) — works. Reference audio is
+  encoded through the full HiggsAudioV2 semantic path (HuBERT + SemanticEncoder
+  + fusion projection + residual RVQ). Requires the full `mlx-community/OmniVoice`
+  checkpoint; the `-bf16` variant strips `semantic_model.*` and cannot encode
+  reference audio.
 
 ## Implementation notes
 

--- a/Sources/MLXAudioTTS/Models/OmniVoice/README.md
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/README.md
@@ -5,10 +5,9 @@ Swift/MLX port of [k2-fsa/OmniVoice](https://huggingface.co/k2-fsa/OmniVoice), a
 ## Weights
 
 Use the full conversion `mlx-community/OmniVoice` (fp32, includes the complete
-audio tokenizer). `mlx-community/OmniVoice-bf16` ships a stripped tokenizer
-(no `semantic_model.*` weights) and a different fused embedding layout; both
-layouts are supported by the loader, but the stripped tokenizer cannot encode
-reference audio.
+audio codec). The `mlx-community/OmniVoice-bf16` repo's `audio_tokenizer/` was
+exported without the semantic encode path (no `semantic_model.*` /
+`encoder_semantic.*` weights), so it cannot encode reference audio.
 
 ## Usage
 

--- a/Sources/MLXAudioTTS/Models/OmniVoice/README.md
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/README.md
@@ -1,0 +1,58 @@
+# OmniVoice
+
+Swift/MLX port of [k2-fsa/OmniVoice](https://huggingface.co/k2-fsa/OmniVoice), a multilingual zero-shot TTS model: a bidirectional diffusion LM over a Qwen3 backbone (28 layers, 1024 hidden) generating 8 RVQ codebooks at 24 kHz, decoded by a HiggsAudioV2 acoustic codec.
+
+## Weights
+
+Use the full conversion `mlx-community/OmniVoice` (fp32, includes the complete
+audio tokenizer). `mlx-community/OmniVoice-bf16` ships a stripped tokenizer
+(no `semantic_model.*` weights) and a different fused embedding layout; both
+layouts are supported by the loader, but the stripped tokenizer cannot encode
+reference audio.
+
+## Usage
+
+```swift
+let model = try await TTS.loadModel(modelRepo: "mlx-community/OmniVoice")
+
+// Voice design (instruction)
+let audio = try await model.generate(
+    text: "Hello from OmniVoice on Apple Silicon.",
+    voice: "female, warm, clear voice",
+    refAudio: nil, refText: nil, language: nil,
+    generationParameters: .init()
+)
+```
+
+CLI:
+
+```bash
+swift run mlx-audio-swift-tts --model mlx-community/OmniVoice \
+    --text "Hello!" --voice "male, british accent" --output out.wav
+```
+
+Generation knobs live in `OmniVoiceGenerateParameters` (`numStep`, `guidanceScale`, `speed`, `positionTemperature`, `tShift`, ...). Defaults match the Python reference (`num_steps=32`, `guidance_scale=2.0`).
+
+## Modes
+
+- **Auto voice** (`voice: nil`) — works
+- **Voice design** (`voice: "female, low pitch, ..."`) — works
+- **Voice cloning** (`refAudio` + `refText`) — incomplete: the HiggsAudioV2
+  semantic encode path (HuBERT + SemanticEncoder + fusion projection) is not
+  ported yet, so reference audio is tokenized through an acoustic-only
+  approximation and the cloned voice will not match the reference. Semantic
+  weights are dropped at load time until the port lands.
+
+## Implementation notes
+
+- The backbone runs **bidirectional attention** (NAR diffusion); no causal
+  mask is ever applied, matching the Python reference.
+- The `<|denoise|>` style token is emitted only when reference audio is
+  present (`denoise=has_ref` in the reference implementation).
+- Timestep schedule and per-step unmask counts mirror
+  `mlx_audio/tts/models/omnivoice/generation.py`; the final step reveals all
+  remaining masked positions.
+- Checkpoints with fused `audio_embeddings.weight` / `audio_heads.weight`
+  (`[C*V, H]`) are split into per-codebook tensors during sanitize;
+  `codebook_layer_offsets` is dropped (not needed — embeddings are indexed
+  per codebook).

--- a/Sources/MLXAudioTTS/Models/Qwen3/Config.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Config.swift
@@ -10,11 +10,12 @@ import MLXLMCommon
 
 // MARK: - Configuration
 
+/// Qwen3 configuration for MLXAudio.
+/// Based on mlx-swift-lm Qwen3Configuration with TTS-specific additions.
 public struct Qwen3Configuration: Codable, Sendable {
     var hiddenSize: Int
     var hiddenLayers: Int
     var intermediateSize: Int
-    var eosTokenId: Int
     var attentionHeads: Int
     var rmsNormEps: Float
     var vocabularySize: Int
@@ -27,11 +28,11 @@ public struct Qwen3Configuration: Codable, Sendable {
     var tieWordEmbeddings = false
     var maxPositionEmbeddings: Int = 32768
     var sampleRate: Int = 24_000
+    var eosTokenId: Int = 151645
     var tokenizer_name: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case hiddenSize = "hidden_size"
-        case eosTokenId = "eos_token_id"
         case hiddenLayers = "num_hidden_layers"
         case intermediateSize = "intermediate_size"
         case attentionHeads = "num_attention_heads"
@@ -44,58 +45,70 @@ public struct Qwen3Configuration: Codable, Sendable {
         case tieWordEmbeddings = "tie_word_embeddings"
         case maxPositionEmbeddings = "max_position_embeddings"
         case sampleRate = "sample_rate"
+        case eosTokenId = "eos_token_id"
         case tokenizer_name = "tokenizer_name"
-        
     }
 
     public init(from decoder: Swift.Decoder) throws {
-        // custom implementation to handle optional keys with required values
-        let container: KeyedDecodingContainer<Qwen3Configuration.CodingKeys> =
-            try decoder.container(
-                keyedBy: Qwen3Configuration.CodingKeys.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        self.hiddenSize = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.hiddenSize)
-        self.eosTokenId = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.eosTokenId)
-        self.hiddenLayers = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.hiddenLayers)
-        self.intermediateSize = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.intermediateSize)
-        
-        self.attentionHeads = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.attentionHeads)
-        self.rmsNormEps = try container.decode(
-            Float.self, forKey: Qwen3Configuration.CodingKeys.rmsNormEps)
-        self.vocabularySize = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.vocabularySize)
-        self.kvHeads = try container.decode(Int.self, forKey: Qwen3Configuration.CodingKeys.kvHeads)
-        self.ropeTheta =
-            try container.decodeIfPresent(
-                Float.self, forKey: Qwen3Configuration.CodingKeys.ropeTheta)
-            ?? 1_000_000
-        self.headDim = try container.decode(
-            Int.self, forKey: Qwen3Configuration.CodingKeys.headDim)
-        self.ropeScaling = try container.decodeIfPresent(
-            [String: StringOrNumber].self, forKey: Qwen3Configuration.CodingKeys.ropeScaling)
-        self.tieWordEmbeddings =
-            try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
-        self.maxPositionEmbeddings =
-            try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32768
-        
+        self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        self.hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)
+        self.intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        self.attentionHeads = try container.decode(Int.self, forKey: .attentionHeads)
+        self.rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+        self.vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
+        self.kvHeads = try container.decode(Int.self, forKey: .kvHeads)
+        self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        self.headDim = try container.decode(Int.self, forKey: .headDim)
+        self.ropeScaling = try container.decodeIfPresent([String: StringOrNumber].self, forKey: .ropeScaling)
+        self.tieWordEmbeddings = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+        self.maxPositionEmbeddings = try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32768
         self.sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 24_000
-        self.tokenizer_name = try container.decodeIfPresent(String.self, forKey: .tokenizer_name) ?? nil
-        
-        // MARK: - Decode Quantization
+        self.eosTokenId = try container.decodeIfPresent(Int.self, forKey: .eosTokenId) ?? 151645
+        self.tokenizer_name = try container.decodeIfPresent(String.self, forKey: .tokenizer_name)
+
         let baseConfig = try? BaseConfiguration(from: decoder)
         self.perLayerQuantization = baseConfig?.perLayerQuantization
     }
-    
+
+    public init(
+        hiddenSize: Int,
+        hiddenLayers: Int,
+        intermediateSize: Int,
+        attentionHeads: Int,
+        kvHeads: Int,
+        headDim: Int,
+        vocabularySize: Int,
+        rmsNormEps: Float,
+        ropeTheta: Float,
+        ropeScaling: [String: StringOrNumber]? = nil,
+        tieWordEmbeddings: Bool = false,
+        sampleRate: Int = 24_000,
+        eosTokenId: Int = 151645
+    ) {
+        self.hiddenSize = hiddenSize
+        self.hiddenLayers = hiddenLayers
+        self.intermediateSize = intermediateSize
+        self.attentionHeads = attentionHeads
+        self.kvHeads = kvHeads
+        self.headDim = headDim
+        self.vocabularySize = vocabularySize
+        self.rmsNormEps = rmsNormEps
+        self.ropeTheta = ropeTheta
+        self.ropeScaling = ropeScaling
+        self.tieWordEmbeddings = tieWordEmbeddings
+        self.sampleRate = sampleRate
+        self.eosTokenId = eosTokenId
+        self.maxPositionEmbeddings = 40960
+        self.quantization = nil
+        self.perLayerQuantization = nil
+        self.tokenizer_name = nil
+    }
+
     public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        
         try container.encode(hiddenSize, forKey: .hiddenSize)
-        try container.encode(eosTokenId, forKey: .eosTokenId)
         try container.encode(hiddenLayers, forKey: .hiddenLayers)
         try container.encode(intermediateSize, forKey: .intermediateSize)
         try container.encode(attentionHeads, forKey: .attentionHeads)
@@ -108,7 +121,7 @@ public struct Qwen3Configuration: Codable, Sendable {
         try container.encode(tieWordEmbeddings, forKey: .tieWordEmbeddings)
         try container.encode(maxPositionEmbeddings, forKey: .maxPositionEmbeddings)
         try container.encode(sampleRate, forKey: .sampleRate)
+        try container.encode(eosTokenId, forKey: .eosTokenId)
         try container.encodeIfPresent(tokenizer_name, forKey: .tokenizer_name)
-        
     }
 }

--- a/Sources/MLXAudioTTS/Models/Qwen3/Config.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Config.swift
@@ -85,7 +85,8 @@ public struct Qwen3Configuration: Codable, Sendable {
         ropeScaling: [String: StringOrNumber]? = nil,
         tieWordEmbeddings: Bool = false,
         sampleRate: Int = 24_000,
-        eosTokenId: Int = 151645
+        eosTokenId: Int = 151645,
+        maxPositionEmbeddings: Int = 32768
     ) {
         self.hiddenSize = hiddenSize
         self.hiddenLayers = hiddenLayers
@@ -100,7 +101,7 @@ public struct Qwen3Configuration: Codable, Sendable {
         self.tieWordEmbeddings = tieWordEmbeddings
         self.sampleRate = sampleRate
         self.eosTokenId = eosTokenId
-        self.maxPositionEmbeddings = 40960
+        self.maxPositionEmbeddings = maxPositionEmbeddings
         self.quantization = nil
         self.perLayerQuantization = nil
         self.tokenizer_name = nil

--- a/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
@@ -228,8 +228,7 @@ public class Qwen3TransformerBlock: Module {
         var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
         let h = x + r
         r = mlp(postAttentionLayerNorm(h))
-        let out = h + r
-        return out
+        return h + r
     }
 }
 
@@ -245,7 +244,7 @@ public class Qwen3ModelInner: Module {
         _embedTokens.wrappedValue = Embedding(
             embeddingCount: args.vocabularySize, dimensions: args.hiddenSize)
 
-        self.layers = (0 ..< args.hiddenLayers)
+        self.layers = (0..<args.hiddenLayers)
             .map { _ in
                 Qwen3TransformerBlock(args)
             }
@@ -283,7 +282,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
     public init(_ args: Qwen3Configuration) {
         self.configuration = args
         self.vocabularySize = args.vocabularySize
-        self.kvHeads = (0 ..< args.hiddenLayers).map { _ in args.kvHeads }
+        self.kvHeads = (0..<args.hiddenLayers).map { _ in args.kvHeads }
         self.model = Qwen3ModelInner(args)
 
         if !args.tieWordEmbeddings {

--- a/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
@@ -2,7 +2,7 @@
 //  Qwen3.swift
 //  MLXAudio
 //
-//  Created by Prince Canuma on 29/12/2025.
+//  Based on mlx-swift-lm Qwen3 model with TTS extensions.
 //
 
 import Foundation
@@ -14,7 +14,6 @@ import MLXNN
 import MLXAudioCodecs
 import MLXAudioCore
 import Combine
-
 
 // MARK: - VyvoTTS special token IDs (Qwen3-based tokenizer)
 let tokenizerLength = 151669
@@ -29,72 +28,44 @@ let endOfAI = tokenizerLength + 6  // 151675
 let padTokenId = tokenizerLength + 7  // 151676
 let audioTokensStart = tokenizerLength + 10  // 151679
 
-// MARK: - Type Aliases (using shared types from MLXAudioCore)
-
+// MARK: - Type Aliases
 public typealias Qwen3Error = AudioGenerationError
 public typealias Qwen3GenerationInfo = AudioGenerationInfo
 public typealias Qwen3Generation = AudioGeneration
 
 // MARK: - Decode
-
-/// Decode audio codes in chunks to reduce memory spikes.
-/// Uses Float array accumulation instead of MLXArray concatenation for efficiency.
-///
-/// - Parameters:
-///   - codeList: Flat list of audio codes (7 codes per group)
-///   - snacModel: The SNAC decoder model
-///   - chunkSize: Number of code groups to decode at once (default 128)
-/// - Returns: Decoded audio as MLXArray
 func decodeAudioFromCodes(codeList: [Int], snacModel: SNAC, chunkSize: Int = 50) -> MLXArray {
     let numGroups = (codeList.count + 1) / 7
-
-    // For small inputs, decode all at once
     if numGroups <= chunkSize {
         let result = decodeAudioChunk(codeList: codeList, snacModel: snacModel)
         eval(result)
         return result
     }
-
-    // Pre-allocate output buffer (441 samples per group at 24kHz)
     let estimatedSamples = numGroups * snacModel.hopLength
     var audioSamples = ContiguousArray<Float>()
     audioSamples.reserveCapacity(estimatedSamples)
-
-    // Decode in large chunk
     var groupStart = 0
     while groupStart < numGroups {
         let groupEnd = min(groupStart + chunkSize, numGroups)
         let codeStart = groupStart * 7
         let codeEnd = groupEnd * 7
-
         let chunkCodes = Array(codeList[codeStart..<min(codeEnd, codeList.count)])
-
         let audioChunk = decodeAudioChunk(codeList: chunkCodes, snacModel: snacModel)
         eval(audioChunk)
-
         audioSamples.append(contentsOf: audioChunk.asArray(Float.self))
-
-        // Clear GPU memory after each chunk
         Memory.clearCache()
-
         groupStart = groupEnd
     }
-
-
     return MLXArray(Array(audioSamples))
 }
 
-/// Decode a single chunk of audio codes (internal helper)
 private func decodeAudioChunk(codeList: [Int], snacModel: SNAC) -> MLXArray {
     var layer1: [Int] = []
     var layer2: [Int] = []
     var layer3: [Int] = []
-
     let numGroups = (codeList.count + 1) / 7
-
     for i in 0..<numGroups {
         let baseIdx = 7 * i
-
         layer1.append(codeList[baseIdx])
         layer2.append(codeList[baseIdx + 1] - 4096)
         layer3.append(codeList[baseIdx + 2] - (2 * 4096))
@@ -103,33 +74,23 @@ private func decodeAudioChunk(codeList: [Int], snacModel: SNAC) -> MLXArray {
         layer3.append(codeList[baseIdx + 5] - (5 * 4096))
         layer3.append(codeList[baseIdx + 6] - (6 * 4096))
     }
-
     let codes = [
         MLXArray(layer1).expandedDimensions(axis: 0),
         MLXArray(layer2).expandedDimensions(axis: 0),
         MLXArray(layer3).expandedDimensions(axis: 0)
     ]
-
-    // SNAC decode returns [batch, channels, samples] - squeeze batch and channel dims
     let audioHat = snacModel.decode(codes).squeezed()
     return audioHat
 }
 
 func encodeAudioToCodes(audio: MLXArray, snacModel: SNAC) -> MLXArray {
-    // Add batch and channel dimensions: [samples] -> [1, 1, samples]
-    let audioExpanded = audio
-        .expandedDimensions(axis: 0)
-        .expandedDimensions(axis: 0)
-
+    let audioExpanded = audio.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
     let codes = snacModel.encode(audioExpanded)
-
     let layer1 = codes[0].squeezed(axis: 0).asArray(Int.self)
     let layer2 = codes[1].squeezed(axis: 0).asArray(Int.self)
     let layer3 = codes[2].squeezed(axis: 0).asArray(Int.self)
-
     var codeList: [Int] = []
     let numGroups = layer1.count
-
     for i in 0..<numGroups {
         codeList.append(layer1[i])
         codeList.append(layer2[2 * i] + 4096)
@@ -139,13 +100,11 @@ func encodeAudioToCodes(audio: MLXArray, snacModel: SNAC) -> MLXArray {
         codeList.append(layer3[4 * i + 2] + 5 * 4096)
         codeList.append(layer3[4 * i + 3] + 6 * 4096)
     }
-
     return MLXArray(codeList).expandedDimensions(axis: 0)
 }
 
 // MARK: - Attention
-
-public class Attention: Module {
+public class Qwen3Attention: Module {
     let args: Qwen3Configuration
     let scale: Float
 
@@ -169,32 +128,30 @@ public class Attention: Module {
         let headDim = args.headDim
         self.scale = pow(Float(headDim), -0.5)
 
-        self._wq.wrappedValue = Linear(dim, heads * headDim, bias: false)
-        self._wk.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
-        self._wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
-        self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
+        _wq.wrappedValue = Linear(dim, heads * headDim, bias: false)
+        _wk.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
+        _wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
+        _wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
-        self._qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
-        self._kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
+        _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
+        _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
 
         let ropeScale: Float
         if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-        let factor = ropeScaling["factor"]
+            let factor = ropeScaling["factor"]
         {
             if let v = factor.asFloat() {
                 ropeScale = 1 / v
             } else {
-                fatalError("ropeScaling.factor must be a Float")
+                fatalError("ropeScaling.factor must be a float")
             }
         } else {
             ropeScale = 1
         }
 
         self.rope = RoPE(
-            dimensions: headDim, traditional: false, base: args.ropeTheta, scale: ropeScale
-        )
-
-
+            dimensions: headDim, traditional: false, base: args.ropeTheta,
+            scale: ropeScale)
     }
 
     public func callAsFunction(
@@ -210,65 +167,59 @@ public class Attention: Module {
         keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-
         if let cache {
             queries = rope(queries, offset: cache.offset)
             keys = rope(keys, offset: cache.offset)
-            // Update cache and get full key/value history
-            (keys, values) = cache.update(keys: keys, values: values)
         } else {
             queries = rope(queries)
             keys = rope(keys)
         }
 
-        let output = MLXFast.scaledDotProductAttention(
+        let output = attentionWithCacheUpdate(
             queries: queries,
             keys: keys,
             values: values,
+            cache: cache,
             scale: scale,
             mask: mask
-        ).transposed(0, 2, 1, 3).reshaped(B, L, -1)
-
-        return wo(
-            output
         )
-    }
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
 
+        return wo(output)
+    }
 }
 
-
-// MARK: - MLP
-
-private class MLP: Module {
+public class Qwen3MLP: Module, UnaryLayer {
     @ModuleInfo(key: "gate_proj") var gate: Linear
     @ModuleInfo(key: "down_proj") var down: Linear
     @ModuleInfo(key: "up_proj") var up: Linear
 
     public init(dimensions: Int, hiddenDimensions: Int) {
-        self._gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
-        self._down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
-        self._up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        _gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        _down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
+        _up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
-        return down(silu(gate(x)) * up(x))
+        down(silu(gate(x)) * up(x))
     }
 }
 
-
-private class TransformerBlock: Module {
-    @ModuleInfo(key: "self_attn") var attention: Attention
-    let mlp: MLP
+public class Qwen3TransformerBlock: Module {
+    @ModuleInfo(key: "self_attn") var attention: Qwen3Attention
+    let mlp: Qwen3MLP
 
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
 
     public init(_ args: Qwen3Configuration) {
-        self._attention.wrappedValue = Attention(args)
-        self.mlp = MLP(dimensions: args.hiddenSize, hiddenDimensions: args.intermediateSize)
-        self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
-        self._postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
-
+        _attention.wrappedValue = Qwen3Attention(args)
+        self.mlp = Qwen3MLP(dimensions: args.hiddenSize, hiddenDimensions: args.intermediateSize)
+        _inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
     }
 
     public func callAsFunction(
@@ -277,32 +228,28 @@ private class TransformerBlock: Module {
         var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
         let h = x + r
         r = mlp(postAttentionLayerNorm(h))
-        return h + r
+        let out = h + r
+        return out
     }
-
-
 }
 
-
-private class Qwen3ModelInner: Module {
+public class Qwen3ModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
-    fileprivate let layers: [TransformerBlock]
+    fileprivate let layers: [Qwen3TransformerBlock]
     let norm: RMSNorm
 
     public init(_ args: Qwen3Configuration) {
         precondition(args.vocabularySize > 0)
 
-        self._embedTokens.wrappedValue = Embedding(
-            embeddingCount: args.vocabularySize,
-            dimensions: args.hiddenSize
-        )
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: args.vocabularySize, dimensions: args.hiddenSize)
 
-        self.layers = (0..<args.hiddenLayers)
-            .map { _ in TransformerBlock(args) }
-
+        self.layers = (0 ..< args.hiddenLayers)
+            .map { _ in
+                Qwen3TransformerBlock(args)
+            }
         self.norm = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
-
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
@@ -318,78 +265,57 @@ private class Qwen3ModelInner: Module {
     }
 }
 
-
 public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel, @unchecked Sendable {
-
     public let vocabularySize: Int
     public let kvHeads: [Int]
     public var tokenizer: Tokenizers.Tokenizer?
     public var _snacModel: SNAC?
 
-    private let model: Qwen3ModelInner
-
+    public let model: Qwen3ModelInner
     let configuration: Qwen3Configuration
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
-    // KVCacheDimensionProvider conformance
     public var numLayers: Int {
         return self.configuration.hiddenLayers
     }
 
-    public init(_ args: Qwen3Configuration){
+    public init(_ args: Qwen3Configuration) {
         self.configuration = args
         self.vocabularySize = args.vocabularySize
-        self.kvHeads = (0..<args.hiddenLayers).map {_ in args.kvHeads}
+        self.kvHeads = (0 ..< args.hiddenLayers).map { _ in args.kvHeads }
         self.model = Qwen3ModelInner(args)
 
         if !args.tieWordEmbeddings {
-            self._lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
+            _lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
         }
     }
 
-    /// Parse a single row of tokens on CPU
     public func parseOutputRow(_ tokens: [Int32]) -> [Int] {
         let tokensI = tokens.map(Int.init)
-
-        // Find start index: first try START_OF_SPEECH (use lastIndex for latest occurrence)
         var startIdx: Int? = tokensI.lastIndex(of: startOfSpeech)
-
-        // If not found, look for START_OF_AI and find first audio token after it
         if startIdx == nil, let soaIdx = tokensI.lastIndex(of: startOfAI) {
             if let firstAudio = tokensI[(soaIdx + 1)...].firstIndex(where: { $0 >= audioTokensStart }) {
                 startIdx = firstAudio - 1
             }
         }
-
-        // Slice from start index
         let slice = (startIdx != nil) ? Array(tokensI[(startIdx! + 1)...]) : tokensI
-
-        // Filter out END_OF_SPEECH tokens
         let filtered = slice.filter { $0 != endOfSpeech }
-
-        // Trim to multiple of 7
         let newLen = (filtered.count / 7) * 7
         guard newLen > 0 else { return [] }
-
-        // Subtract audioTokensStart
         return filtered.prefix(newLen).map { $0 - audioTokensStart }
     }
 
-    /// Parse output tokens for multiple batch rows using CPU-based parsing.
     public func parseOutputBatch(_ tokensPerBatch: [[Int32]]) -> [[Int]] {
         return tokensPerBatch.map { parseOutputRow($0) }
     }
 
-    /// Legacy parseOutput for MLXArray input (kept for compatibility).
     public func parseOutput(_ inputIds: MLXArray) -> [[Int]] {
         var codeLists: [[Int]] = []
-
         for i in 0..<inputIds.shape[0] {
             let row = inputIds[i].asArray(Int32.self)
             codeLists.append(parseOutputRow(row))
         }
-
         return codeLists
     }
 
@@ -399,24 +325,20 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         refAudio: MLXArray? = nil,
         refText: String? = nil
     ) -> (MLXArray, MLXArray) {
-
         var refAudioCodes: [Int32]? = nil
         var refTranscriptIds: [Int32]? = nil
 
         if let refAudio = refAudio, let refText = refText {
             print("\u{001B}[93mWARNING: Audio cloning doesn't work reliably on this model.\u{001B}[0m")
-
             guard let snacModel = self._snacModel else {
                 fatalError("SNAC model not loaded. Call post_load_hook first.")
             }
-
             let codes = encodeAudioToCodes(audio: refAudio, snacModel: snacModel)
             let codesArray = (codes + audioTokensStart).asArray(Int32.self)
             refAudioCodes = codesArray
             refTranscriptIds = tokenizer!.encode(text: refText).map { Int32($0) }
         }
 
-        // Apply voice prefix if provided
         let modifiedPrompts: [String]
         if let voice = voice {
             modifiedPrompts = prompts.map { "\(voice): \($0)" }
@@ -424,57 +346,42 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             modifiedPrompts = prompts
         }
 
-        // Encode all prompts to CPU arrays first (avoid multiple MLXArray creations)
         let encodedPrompts: [[Int32]] = modifiedPrompts.map { prompt in
             tokenizer!.encode(text: prompt).map { Int32($0) }
         }
 
-        // Find max length for padding
         let maxPromptLen = encodedPrompts.map { $0.count }.max() ?? 0
-
-        // Build all input IDs on CPU, then create single MLXArray
         var allBatchIds: [[Int32]] = []
 
         for encodedPrompt in encodedPrompts {
             var sequence: [Int32] = []
-
-            // Add padding if needed (at the start)
             let paddingLen = maxPromptLen - encodedPrompt.count
             if paddingLen > 0 {
                 sequence.append(contentsOf: [Int32](repeating: Int32(padTokenId), count: paddingLen))
             }
-
-            // Add reference audio and transcript if provided
             if let refCodes = refAudioCodes, let refTranscript = refTranscriptIds {
-                // [START_OF_HUMAN] + transcript + [END_OF_TEXT, END_OF_HUMAN]
                 sequence.append(Int32(startOfHuman))
                 sequence.append(contentsOf: refTranscript)
                 sequence.append(Int32(endOfText))
                 sequence.append(Int32(endOfHuman))
-                // [START_OF_AI, START_OF_SPEECH] + audio codes + [END_OF_SPEECH, END_OF_AI]
                 sequence.append(Int32(startOfAI))
                 sequence.append(Int32(startOfSpeech))
                 sequence.append(contentsOf: refCodes)
                 sequence.append(Int32(endOfSpeech))
                 sequence.append(Int32(endOfAI))
             }
-
-            // Add prompt: [START_OF_HUMAN] + prompt + [END_OF_TEXT, END_OF_HUMAN]
             sequence.append(Int32(startOfHuman))
             sequence.append(contentsOf: encodedPrompt)
             sequence.append(Int32(endOfText))
             sequence.append(Int32(endOfHuman))
-
             allBatchIds.append(sequence)
         }
 
-        // Pad all sequences to same length and create single MLXArray
         let maxLen = allBatchIds.map { $0.count }.max() ?? 0
         var flattenedIds: [Int32] = []
         flattenedIds.reserveCapacity(allBatchIds.count * maxLen)
 
         for var sequence in allBatchIds {
-            // Pad to maxLen if needed
             let padCount = maxLen - sequence.count
             if padCount > 0 {
                 sequence.insert(contentsOf: [Int32](repeating: Int32(padTokenId), count: padCount), at: 0)
@@ -482,26 +389,38 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             flattenedIds.append(contentsOf: sequence)
         }
 
-        // Single MLXArray creation from CPU data
         let batchSize = allBatchIds.count
         let finalBatchInputIds = MLXArray(flattenedIds).reshaped([batchSize, maxLen])
-
-        // Create attention mask (1 for real tokens, 0 for pad tokens)
         let batchMask = finalBatchInputIds .!= Int32(padTokenId)
-
         return (finalBatchInputIds, batchMask)
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         var out = model(inputs, cache: cache)
-
         if let lmHead {
             out = lmHead(out)
         } else {
             out = model.embedTokens.asLinear(out)
         }
-
         return out
+    }
+
+    public func forwardWithEmbeddings(
+        inputsEmbeds: MLXArray,
+        cache: [KVCache]? = nil,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil
+    ) -> MLXArray {
+        var h = inputsEmbeds
+        let resolvedMask: MLXFast.ScaledDotProductAttentionMaskMode = mask ?? .none
+        for (i, layer) in model.layers.enumerated() {
+            h = layer(h, mask: resolvedMask, cache: cache?[i])
+        }
+        h = model.norm(h)
+        return h
+    }
+
+    public func getEmbeddings(for inputIds: MLXArray) -> MLXArray {
+        return model.embedTokens(inputIds)
     }
 
     public var sampleRate: Int {
@@ -523,7 +442,6 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         if configuration.tieWordEmbeddings {
             weights["lm_head.weight"] = nil
         }
-
         return weights
     }
 
@@ -578,22 +496,6 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         )
     }
 
-    // MARK: - Generation using MLXLMCommon evaluate pattern
-
-    /// Generate audio from text using MLXLMCommon's evaluate-style token generation.
-    ///
-    /// This follows the pattern from MLXLMCommon's `generate` function with:
-    /// - Configurable sampling (temperature, top-p)
-    /// - Repetition penalty via LogitProcessor
-    /// - KV cache for efficient generation
-    ///
-    /// - Parameters:
-    ///   - text: The text to synthesize
-    ///   - voice: Optional voice identifier (e.g., "en-us-1")
-    ///   - refAudio: Optional reference audio for voice cloning
-    ///   - refText: Optional transcription of the reference audio
-    ///   - parameters: Generation parameters (temperature, topP, maxTokens, etc.)
-    /// - Returns: Generated audio as MLXArray
     public func generate(
         text: String,
         voice: String? = nil,
@@ -615,7 +517,6 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             throw Qwen3Error.modelNotInitialized("Tokenizer not loaded")
         }
 
-        // Prepare input
         let prompt = text.replacingOccurrences(of: "\\n", with: "\n")
             .replacingOccurrences(of: "\\t", with: "\t")
 
@@ -626,59 +527,45 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             refText: refText
         )
 
-        // Create sampler and processor from parameters
         let sampler = parameters.sampler()
         var processor = parameters.processor()
 
-        // Initialize prompt tokens for processor
         let promptTokens = inputIds.squeezed(axis: 0)
         processor?.prompt(promptTokens)
 
-        // Create KV cache
         var cache = cache
         if cache == nil {
             cache = self.makeCache()
         }
 
         let maxTokens = parameters.maxTokens ?? 1200
-
         let promptTokensList = inputIds.squeezed(axis: 0).asArray(Int32.self)
-
         var generatedOnly = ContiguousArray<Int32>()
         generatedOnly.reserveCapacity(maxTokens)
 
-        // Prefill: process the prompt, slice immediately to [1, V]
         var logits = self(inputIds, cache: cache)
-        logits = logits[0..., -1, 0...]  // [1, V] - avoid keeping [1, L, V]
+        logits = logits[0..., -1, 0...]
         eval(logits)
 
-        // Generate tokens
         for _ in 0..<maxTokens {
             try Task.checkCancellation()
             let tokenValue: Int = autoreleasepool {
                 var lastLogits = logits
                 lastLogits = processor?.process(logits: lastLogits) ?? lastLogits
-
                 let nextToken = sampler.sample(logits: lastLogits)
                 processor?.didSample(token: nextToken)
-
                 let value = nextToken.item(Int.self)
-
                 if value != endOfSpeech {
                     let nextTokenExpanded = nextToken.reshaped([1, 1])
                     logits = self(nextTokenExpanded, cache: cache)
-                    logits = logits[0..., -1, 0...]  // [1, V]
+                    logits = logits[0..., -1, 0...]
                     eval(logits)
                 }
-
                 return value
             }
-
             if tokenValue == endOfSpeech {
                 break
             }
-
-            // Only store generated tokens (not prompt)
             generatedOnly.append(Int32(tokenValue))
         }
 
@@ -690,35 +577,16 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         fullTokens.reserveCapacity(promptTokensList.count + generatedOnly.count)
         fullTokens.append(contentsOf: promptTokensList)
         fullTokens.append(contentsOf: generatedOnly)
-
-        // Parse output to audio codes using CPU-based parsing
         let codeList = parseOutputRow(Array(fullTokens))
-
         guard !codeList.isEmpty else {
             throw Qwen3Error.generationFailed("No audio codes generated")
         }
-
-        // Decode audio using SNAC
         let audio = decodeAudioFromCodes(codeList: codeList, snacModel: snacModel)
         audio.eval()
-
-        // Clear SNAC decoder intermediates
         Memory.clearCache()
-
         return audio
     }
 
-    /// Generate audio with streaming token output.
-    ///
-    /// Returns an AsyncThrowingStream that yields generation events including tokens and final audio.
-    ///
-    /// - Parameters:
-    ///   - text: The text to synthesize
-    ///   - voice: Optional voice name/style identifier
-    ///   - refAudio: Optional reference audio for voice cloning
-    ///   - refText: Optional transcription of the reference audio
-    ///   - parameters: Generation parameters
-    /// - Returns: AsyncThrowingStream of Qwen3Generation events
     public func generateStream(
         text: String,
         voice: String? = nil,
@@ -745,48 +613,33 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                 guard self.tokenizer != nil else {
                     throw Qwen3Error.modelNotInitialized("Tokenizer not loaded")
                 }
-                
                 let prompt = text.replacingOccurrences(of: "\\n", with: "\n")
                     .replacingOccurrences(of: "\\t", with: "\t")
-                
                 let (inputIds, _) = self.prepareInputIds(
                     prompts: [prompt],
                     voice: voice,
                     refAudio: refAudio,
                     refText: refText
                 )
-                
                 let sampler = parameters.sampler()
                 var processor = parameters.processor()
-                
                 let promptTokens = inputIds.squeezed(axis: 0)
                 processor?.prompt(promptTokens)
                 var cache = cache
                 if cache == nil {
                     cache = self.makeCache()
                 }
-                
                 let maxTokens = parameters.maxTokens ?? 1200
-                
-                // DEDUP: Pull prompt tokens ONCE to CPU - this is your anchor
                 let promptTokensList = inputIds.squeezed(axis: 0).asArray(Int32.self)
-                
-                // Store only generated tokens (not prompt tokens) - dedup approach
                 var generatedTokens = ContiguousArray<Int32>()
                 generatedTokens.reserveCapacity(maxTokens)
-                
                 let startTime = Date()
-                
-                // Prefill: process the prompt, slice immediately to [1, V]
                 var tokenCount: Int = 0
                 var logits = self(inputIds, cache: cache)
-                logits = logits[0..., -1, 0...]  // [1, V] - avoid keeping [1, L, V]
+                logits = logits[0..., -1, 0...]
                 eval(logits)
                 let prefillTime = Date().timeIntervalSince(startTime)
-                
                 let generateStartTime = Date()
-                
-                // Generate tokens
                 for _ in 0..<maxTokens {
                     try Task.checkCancellation()
                     
@@ -794,58 +647,39 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                     let tokenValue: Int = autoreleasepool {
                         var lastLogits = logits
                         lastLogits = processor?.process(logits: lastLogits) ?? lastLogits
-                        
                         let nextToken = sampler.sample(logits: lastLogits)
                         processor?.didSample(token: nextToken)
-                        
                         let value = nextToken.item(Int.self)
-                        
-                        // Forward pass with cache
                         if value != endOfSpeech {
                             let nextTokenExpanded = nextToken.reshaped([1, 1])
                             logits = self(nextTokenExpanded, cache: cache)
-                            logits = logits[0..., -1, 0...]  // [1, V]
+                            logits = logits[0..., -1, 0...]
                             eval(logits)
                         }
-                        
                         return value
                     }
-                    
                     tokenCount += 1
-                    
                     continuation.yield(.token(tokenValue))
-                    
                     if tokenValue == endOfSpeech {
                         break
                     }
-                    
                     generatedTokens.append(Int32(tokenValue))
                 }
-                
                 Memory.clearCache()
                 try Task.checkCancellation()
                 
                 let generateTime = Date().timeIntervalSince(generateStartTime)
-                
-                // Reconstruct full tokens only once at the end for parsing
                 var fullTokens = ContiguousArray<Int32>()
                 fullTokens.reserveCapacity(promptTokensList.count + generatedTokens.count)
                 fullTokens.append(contentsOf: promptTokensList)
                 fullTokens.append(contentsOf: generatedTokens)
-                
-                // Parse output to audio codes using CPU-based parsing
                 let codeList = self.parseOutputRow(Array(fullTokens))
-                
                 guard !codeList.isEmpty else {
                     throw Qwen3Error.generationFailed("No audio codes generated")
                 }
-                
                 let audio = decodeAudioFromCodes(codeList: codeList, snacModel: snacModel)
                 audio.eval()
-                
                 Memory.clearCache()
-                
-                // Yield completion info
                 let info = Qwen3GenerationInfo(
                     promptTokenCount: inputIds.shape[1],
                     generationTokenCount: tokenCount,
@@ -855,10 +689,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                     peakMemoryUsage: Double(Memory.peakMemory) / 1e9
                 )
                 continuation.yield(.info(info))
-                
-                // Yield final audio
                 continuation.yield(.audio(audio))
-                
                 continuation.finish()
             } catch {
                 continuation.finish(throwing: error)
@@ -872,22 +703,17 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         _ modelRepo: String,
         cache: HubCache = .default
     ) async throws -> Qwen3Model {
-        // Check for HF token in environment (macOS) or Info.plist (iOS)
         let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
             ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
-
         guard let repoID = Repo.ID(rawValue: modelRepo) else {
             throw NSError(domain: "Qwen3Model", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelRepo)"])
         }
-
-        // Check if model is already fully cached (has weight files)
         let modelDir = try await ModelUtils.resolveOrDownloadModel(
             repoID: repoID,
             requiredExtension: ".safetensors",
             hfToken: hfToken,
             cache: cache
         )
-
         return try await fromModelDirectory(modelDir)
     }
 
@@ -898,28 +724,16 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         let configPath = modelDir.appendingPathComponent("config.json")
         let configData = try Data(contentsOf: configPath)
         let config = try JSONDecoder().decode(Qwen3Configuration.self, from: configData)
-
         let perLayerQuantization = config.perLayerQuantization
-
         let model = Qwen3Model(config)
-
-
-        // Load weights from safetensors
         let weights = try loadWeights(from: modelDir)
-
         let sanitizedWeights = model.sanitize(weights: weights)
-
-        // Quantize if needed
-
         if perLayerQuantization != nil {
             print("Applying quantizaiton from config...")
-
             if let perLayerQuant = perLayerQuantization {
                 print(" Per-layer: \(perLayerQuant)")
             }
-
             quantize(model: model) { path, module in
-                // Only quantize if scales exist for this layer
                 if weights["\(path).scales"] != nil {
                     return perLayerQuantization?.quantization(layer: path)?.asTuple
                 } else {
@@ -927,14 +741,9 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                 }
             }
         }
-
-
-
         try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
-
         try await model.post_load_hook(model: model, modelDir: modelDir, cache: cache)
-
         return model
     }
 }
@@ -943,7 +752,6 @@ func loadWeights(from directory: URL) throws -> [String: MLXArray] {
     let fileManager = FileManager.default
     let files = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
     let safetensorFiles = files.filter { $0.pathExtension == "safetensors" }
-
     var weights: [String: MLXArray] = [:]
     for file in safetensorFiles {
         let fileWeights = try MLX.loadArrays(url: file)

--- a/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
+++ b/Sources/MLXAudioTTS/Models/Qwen3/Qwen3.swift
@@ -28,44 +28,71 @@ let endOfAI = tokenizerLength + 6  // 151675
 let padTokenId = tokenizerLength + 7  // 151676
 let audioTokensStart = tokenizerLength + 10  // 151679
 
-// MARK: - Type Aliases
+// MARK: - Type Aliases (using shared types from MLXAudioCore)
+
 public typealias Qwen3Error = AudioGenerationError
 public typealias Qwen3GenerationInfo = AudioGenerationInfo
 public typealias Qwen3Generation = AudioGeneration
 
 // MARK: - Decode
+
+/// Decode audio codes in chunks to reduce memory spikes.
+/// Uses Float array accumulation instead of MLXArray concatenation for efficiency.
+///
+/// - Parameters:
+///   - codeList: Flat list of audio codes (7 codes per group)
+///   - snacModel: The SNAC decoder model
+///   - chunkSize: Number of code groups to decode at once (default 128)
+/// - Returns: Decoded audio as MLXArray
 func decodeAudioFromCodes(codeList: [Int], snacModel: SNAC, chunkSize: Int = 50) -> MLXArray {
     let numGroups = (codeList.count + 1) / 7
+
+    // For small inputs, decode all at once
     if numGroups <= chunkSize {
         let result = decodeAudioChunk(codeList: codeList, snacModel: snacModel)
         eval(result)
         return result
     }
+
+    // Pre-allocate output buffer (441 samples per group at 24kHz)
     let estimatedSamples = numGroups * snacModel.hopLength
     var audioSamples = ContiguousArray<Float>()
     audioSamples.reserveCapacity(estimatedSamples)
+
+    // Decode in large chunk
     var groupStart = 0
     while groupStart < numGroups {
         let groupEnd = min(groupStart + chunkSize, numGroups)
         let codeStart = groupStart * 7
         let codeEnd = groupEnd * 7
+
         let chunkCodes = Array(codeList[codeStart..<min(codeEnd, codeList.count)])
+
         let audioChunk = decodeAudioChunk(codeList: chunkCodes, snacModel: snacModel)
         eval(audioChunk)
+
         audioSamples.append(contentsOf: audioChunk.asArray(Float.self))
+
+        // Clear GPU memory after each chunk
         Memory.clearCache()
+
         groupStart = groupEnd
     }
+
     return MLXArray(Array(audioSamples))
 }
 
+/// Decode a single chunk of audio codes (internal helper)
 private func decodeAudioChunk(codeList: [Int], snacModel: SNAC) -> MLXArray {
     var layer1: [Int] = []
     var layer2: [Int] = []
     var layer3: [Int] = []
+
     let numGroups = (codeList.count + 1) / 7
+
     for i in 0..<numGroups {
         let baseIdx = 7 * i
+
         layer1.append(codeList[baseIdx])
         layer2.append(codeList[baseIdx + 1] - 4096)
         layer3.append(codeList[baseIdx + 2] - (2 * 4096))
@@ -74,23 +101,33 @@ private func decodeAudioChunk(codeList: [Int], snacModel: SNAC) -> MLXArray {
         layer3.append(codeList[baseIdx + 5] - (5 * 4096))
         layer3.append(codeList[baseIdx + 6] - (6 * 4096))
     }
+
     let codes = [
         MLXArray(layer1).expandedDimensions(axis: 0),
         MLXArray(layer2).expandedDimensions(axis: 0),
         MLXArray(layer3).expandedDimensions(axis: 0)
     ]
+
+    // SNAC decode returns [batch, channels, samples] - squeeze batch and channel dims
     let audioHat = snacModel.decode(codes).squeezed()
     return audioHat
 }
 
 func encodeAudioToCodes(audio: MLXArray, snacModel: SNAC) -> MLXArray {
-    let audioExpanded = audio.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    // Add batch and channel dimensions: [samples] -> [1, 1, samples]
+    let audioExpanded = audio
+        .expandedDimensions(axis: 0)
+        .expandedDimensions(axis: 0)
+
     let codes = snacModel.encode(audioExpanded)
+
     let layer1 = codes[0].squeezed(axis: 0).asArray(Int.self)
     let layer2 = codes[1].squeezed(axis: 0).asArray(Int.self)
     let layer3 = codes[2].squeezed(axis: 0).asArray(Int.self)
+
     var codeList: [Int] = []
     let numGroups = layer1.count
+
     for i in 0..<numGroups {
         codeList.append(layer1[i])
         codeList.append(layer2[2 * i] + 4096)
@@ -100,6 +137,7 @@ func encodeAudioToCodes(audio: MLXArray, snacModel: SNAC) -> MLXArray {
         codeList.append(layer3[4 * i + 2] + 5 * 4096)
         codeList.append(layer3[4 * i + 3] + 6 * 4096)
     }
+
     return MLXArray(codeList).expandedDimensions(axis: 0)
 }
 
@@ -275,6 +313,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
+    // KVCacheDimensionProvider conformance
     public var numLayers: Int {
         return self.configuration.hiddenLayers
     }
@@ -290,31 +329,48 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         }
     }
 
+    /// Parse a single row of tokens on CPU
     public func parseOutputRow(_ tokens: [Int32]) -> [Int] {
         let tokensI = tokens.map(Int.init)
+
+        // Find start index: first try START_OF_SPEECH (use lastIndex for latest occurrence)
         var startIdx: Int? = tokensI.lastIndex(of: startOfSpeech)
+
+        // If not found, look for START_OF_AI and find first audio token after it
         if startIdx == nil, let soaIdx = tokensI.lastIndex(of: startOfAI) {
             if let firstAudio = tokensI[(soaIdx + 1)...].firstIndex(where: { $0 >= audioTokensStart }) {
                 startIdx = firstAudio - 1
             }
         }
+
+        // Slice from start index
         let slice = (startIdx != nil) ? Array(tokensI[(startIdx! + 1)...]) : tokensI
+
+        // Filter out END_OF_SPEECH tokens
         let filtered = slice.filter { $0 != endOfSpeech }
+
+        // Trim to multiple of 7
         let newLen = (filtered.count / 7) * 7
         guard newLen > 0 else { return [] }
+
+        // Subtract audioTokensStart
         return filtered.prefix(newLen).map { $0 - audioTokensStart }
     }
 
+    /// Parse output tokens for multiple batch rows using CPU-based parsing.
     public func parseOutputBatch(_ tokensPerBatch: [[Int32]]) -> [[Int]] {
         return tokensPerBatch.map { parseOutputRow($0) }
     }
 
+    /// Legacy parseOutput for MLXArray input (kept for compatibility).
     public func parseOutput(_ inputIds: MLXArray) -> [[Int]] {
         var codeLists: [[Int]] = []
+
         for i in 0..<inputIds.shape[0] {
             let row = inputIds[i].asArray(Int32.self)
             codeLists.append(parseOutputRow(row))
         }
+
         return codeLists
     }
 
@@ -324,20 +380,24 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         refAudio: MLXArray? = nil,
         refText: String? = nil
     ) -> (MLXArray, MLXArray) {
+
         var refAudioCodes: [Int32]? = nil
         var refTranscriptIds: [Int32]? = nil
 
         if let refAudio = refAudio, let refText = refText {
             print("\u{001B}[93mWARNING: Audio cloning doesn't work reliably on this model.\u{001B}[0m")
+
             guard let snacModel = self._snacModel else {
                 fatalError("SNAC model not loaded. Call post_load_hook first.")
             }
+
             let codes = encodeAudioToCodes(audio: refAudio, snacModel: snacModel)
             let codesArray = (codes + audioTokensStart).asArray(Int32.self)
             refAudioCodes = codesArray
             refTranscriptIds = tokenizer!.encode(text: refText).map { Int32($0) }
         }
 
+        // Apply voice prefix if provided
         let modifiedPrompts: [String]
         if let voice = voice {
             modifiedPrompts = prompts.map { "\(voice): \($0)" }
@@ -345,42 +405,57 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             modifiedPrompts = prompts
         }
 
+        // Encode all prompts to CPU arrays first (avoid multiple MLXArray creations)
         let encodedPrompts: [[Int32]] = modifiedPrompts.map { prompt in
             tokenizer!.encode(text: prompt).map { Int32($0) }
         }
 
+        // Find max length for padding
         let maxPromptLen = encodedPrompts.map { $0.count }.max() ?? 0
+
+        // Build all input IDs on CPU, then create single MLXArray
         var allBatchIds: [[Int32]] = []
 
         for encodedPrompt in encodedPrompts {
             var sequence: [Int32] = []
+
+            // Add padding if needed (at the start)
             let paddingLen = maxPromptLen - encodedPrompt.count
             if paddingLen > 0 {
                 sequence.append(contentsOf: [Int32](repeating: Int32(padTokenId), count: paddingLen))
             }
+
+            // Add reference audio and transcript if provided
             if let refCodes = refAudioCodes, let refTranscript = refTranscriptIds {
+                // [START_OF_HUMAN] + transcript + [END_OF_TEXT, END_OF_HUMAN]
                 sequence.append(Int32(startOfHuman))
                 sequence.append(contentsOf: refTranscript)
                 sequence.append(Int32(endOfText))
                 sequence.append(Int32(endOfHuman))
+                // [START_OF_AI, START_OF_SPEECH] + audio codes + [END_OF_SPEECH, END_OF_AI]
                 sequence.append(Int32(startOfAI))
                 sequence.append(Int32(startOfSpeech))
                 sequence.append(contentsOf: refCodes)
                 sequence.append(Int32(endOfSpeech))
                 sequence.append(Int32(endOfAI))
             }
+
+            // Add prompt: [START_OF_HUMAN] + prompt + [END_OF_TEXT, END_OF_HUMAN]
             sequence.append(Int32(startOfHuman))
             sequence.append(contentsOf: encodedPrompt)
             sequence.append(Int32(endOfText))
             sequence.append(Int32(endOfHuman))
+
             allBatchIds.append(sequence)
         }
 
+        // Pad all sequences to same length and create single MLXArray
         let maxLen = allBatchIds.map { $0.count }.max() ?? 0
         var flattenedIds: [Int32] = []
         flattenedIds.reserveCapacity(allBatchIds.count * maxLen)
 
         for var sequence in allBatchIds {
+            // Pad to maxLen if needed
             let padCount = maxLen - sequence.count
             if padCount > 0 {
                 sequence.insert(contentsOf: [Int32](repeating: Int32(padTokenId), count: padCount), at: 0)
@@ -388,19 +463,25 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             flattenedIds.append(contentsOf: sequence)
         }
 
+        // Single MLXArray creation from CPU data
         let batchSize = allBatchIds.count
         let finalBatchInputIds = MLXArray(flattenedIds).reshaped([batchSize, maxLen])
+
+        // Create attention mask (1 for real tokens, 0 for pad tokens)
         let batchMask = finalBatchInputIds .!= Int32(padTokenId)
+
         return (finalBatchInputIds, batchMask)
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         var out = model(inputs, cache: cache)
+
         if let lmHead {
             out = lmHead(out)
         } else {
             out = model.embedTokens.asLinear(out)
         }
+
         return out
     }
 
@@ -495,6 +576,22 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         )
     }
 
+    // MARK: - Generation using MLXLMCommon evaluate pattern
+
+    /// Generate audio from text using MLXLMCommon's evaluate-style token generation.
+    ///
+    /// This follows the pattern from MLXLMCommon's `generate` function with:
+    /// - Configurable sampling (temperature, top-p)
+    /// - Repetition penalty via LogitProcessor
+    /// - KV cache for efficient generation
+    ///
+    /// - Parameters:
+    ///   - text: The text to synthesize
+    ///   - voice: Optional voice identifier (e.g., "en-us-1")
+    ///   - refAudio: Optional reference audio for voice cloning
+    ///   - refText: Optional transcription of the reference audio
+    ///   - parameters: Generation parameters (temperature, topP, maxTokens, etc.)
+    /// - Returns: Generated audio as MLXArray
     public func generate(
         text: String,
         voice: String? = nil,
@@ -516,6 +613,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             throw Qwen3Error.modelNotInitialized("Tokenizer not loaded")
         }
 
+        // Prepare input
         let prompt = text.replacingOccurrences(of: "\\n", with: "\n")
             .replacingOccurrences(of: "\\t", with: "\t")
 
@@ -526,45 +624,59 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
             refText: refText
         )
 
+        // Create sampler and processor from parameters
         let sampler = parameters.sampler()
         var processor = parameters.processor()
 
+        // Initialize prompt tokens for processor
         let promptTokens = inputIds.squeezed(axis: 0)
         processor?.prompt(promptTokens)
 
+        // Create KV cache
         var cache = cache
         if cache == nil {
             cache = self.makeCache()
         }
 
         let maxTokens = parameters.maxTokens ?? 1200
+
         let promptTokensList = inputIds.squeezed(axis: 0).asArray(Int32.self)
+
         var generatedOnly = ContiguousArray<Int32>()
         generatedOnly.reserveCapacity(maxTokens)
 
+        // Prefill: process the prompt, slice immediately to [1, V]
         var logits = self(inputIds, cache: cache)
-        logits = logits[0..., -1, 0...]
+        logits = logits[0..., -1, 0...]  // [1, V] - avoid keeping [1, L, V]
         eval(logits)
 
+        // Generate tokens
         for _ in 0..<maxTokens {
             try Task.checkCancellation()
             let tokenValue: Int = autoreleasepool {
                 var lastLogits = logits
                 lastLogits = processor?.process(logits: lastLogits) ?? lastLogits
+
                 let nextToken = sampler.sample(logits: lastLogits)
                 processor?.didSample(token: nextToken)
+
                 let value = nextToken.item(Int.self)
+
                 if value != endOfSpeech {
                     let nextTokenExpanded = nextToken.reshaped([1, 1])
                     logits = self(nextTokenExpanded, cache: cache)
-                    logits = logits[0..., -1, 0...]
+                    logits = logits[0..., -1, 0...]  // [1, V]
                     eval(logits)
                 }
+
                 return value
             }
+
             if tokenValue == endOfSpeech {
                 break
             }
+
+            // Only store generated tokens (not prompt)
             generatedOnly.append(Int32(tokenValue))
         }
 
@@ -576,16 +688,35 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         fullTokens.reserveCapacity(promptTokensList.count + generatedOnly.count)
         fullTokens.append(contentsOf: promptTokensList)
         fullTokens.append(contentsOf: generatedOnly)
+
+        // Parse output to audio codes using CPU-based parsing
         let codeList = parseOutputRow(Array(fullTokens))
+
         guard !codeList.isEmpty else {
             throw Qwen3Error.generationFailed("No audio codes generated")
         }
+
+        // Decode audio using SNAC
         let audio = decodeAudioFromCodes(codeList: codeList, snacModel: snacModel)
         audio.eval()
+
+        // Clear SNAC decoder intermediates
         Memory.clearCache()
+
         return audio
     }
 
+    /// Generate audio with streaming token output.
+    ///
+    /// Returns an AsyncThrowingStream that yields generation events including tokens and final audio.
+    ///
+    /// - Parameters:
+    ///   - text: The text to synthesize
+    ///   - voice: Optional voice name/style identifier
+    ///   - refAudio: Optional reference audio for voice cloning
+    ///   - refText: Optional transcription of the reference audio
+    ///   - parameters: Generation parameters
+    /// - Returns: AsyncThrowingStream of Qwen3Generation events
     public func generateStream(
         text: String,
         voice: String? = nil,
@@ -612,73 +743,107 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                 guard self.tokenizer != nil else {
                     throw Qwen3Error.modelNotInitialized("Tokenizer not loaded")
                 }
+
                 let prompt = text.replacingOccurrences(of: "\\n", with: "\n")
                     .replacingOccurrences(of: "\\t", with: "\t")
+
                 let (inputIds, _) = self.prepareInputIds(
                     prompts: [prompt],
                     voice: voice,
                     refAudio: refAudio,
                     refText: refText
                 )
+
                 let sampler = parameters.sampler()
                 var processor = parameters.processor()
+
                 let promptTokens = inputIds.squeezed(axis: 0)
                 processor?.prompt(promptTokens)
                 var cache = cache
                 if cache == nil {
                     cache = self.makeCache()
                 }
+
                 let maxTokens = parameters.maxTokens ?? 1200
+
+                // DEDUP: Pull prompt tokens ONCE to CPU - this is your anchor
                 let promptTokensList = inputIds.squeezed(axis: 0).asArray(Int32.self)
+
+                // Store only generated tokens (not prompt tokens) - dedup approach
                 var generatedTokens = ContiguousArray<Int32>()
                 generatedTokens.reserveCapacity(maxTokens)
+
                 let startTime = Date()
+
+                // Prefill: process the prompt, slice immediately to [1, V]
                 var tokenCount: Int = 0
                 var logits = self(inputIds, cache: cache)
-                logits = logits[0..., -1, 0...]
+                logits = logits[0..., -1, 0...]  // [1, V] - avoid keeping [1, L, V]
                 eval(logits)
                 let prefillTime = Date().timeIntervalSince(startTime)
+
                 let generateStartTime = Date()
+
+                // Generate tokens
                 for _ in 0..<maxTokens {
                     try Task.checkCancellation()
-                    
+
                     // Extract token value and advance - minimize intermediate tensor lifetime
                     let tokenValue: Int = autoreleasepool {
                         var lastLogits = logits
                         lastLogits = processor?.process(logits: lastLogits) ?? lastLogits
+
                         let nextToken = sampler.sample(logits: lastLogits)
                         processor?.didSample(token: nextToken)
+
                         let value = nextToken.item(Int.self)
+
+                        // Forward pass with cache
                         if value != endOfSpeech {
                             let nextTokenExpanded = nextToken.reshaped([1, 1])
                             logits = self(nextTokenExpanded, cache: cache)
-                            logits = logits[0..., -1, 0...]
+                            logits = logits[0..., -1, 0...]  // [1, V]
                             eval(logits)
                         }
+
                         return value
                     }
+
                     tokenCount += 1
+
                     continuation.yield(.token(tokenValue))
+
                     if tokenValue == endOfSpeech {
                         break
                     }
+
                     generatedTokens.append(Int32(tokenValue))
                 }
+
                 Memory.clearCache()
                 try Task.checkCancellation()
-                
+
                 let generateTime = Date().timeIntervalSince(generateStartTime)
+
+                // Reconstruct full tokens only once at the end for parsing
                 var fullTokens = ContiguousArray<Int32>()
                 fullTokens.reserveCapacity(promptTokensList.count + generatedTokens.count)
                 fullTokens.append(contentsOf: promptTokensList)
                 fullTokens.append(contentsOf: generatedTokens)
+
+                // Parse output to audio codes using CPU-based parsing
                 let codeList = self.parseOutputRow(Array(fullTokens))
+
                 guard !codeList.isEmpty else {
                     throw Qwen3Error.generationFailed("No audio codes generated")
                 }
+
                 let audio = decodeAudioFromCodes(codeList: codeList, snacModel: snacModel)
                 audio.eval()
+
                 Memory.clearCache()
+
+                // Yield completion info
                 let info = Qwen3GenerationInfo(
                     promptTokenCount: inputIds.shape[1],
                     generationTokenCount: tokenCount,
@@ -688,7 +853,10 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                     peakMemoryUsage: Double(Memory.peakMemory) / 1e9
                 )
                 continuation.yield(.info(info))
+
+                // Yield final audio
                 continuation.yield(.audio(audio))
+
                 continuation.finish()
             } catch {
                 continuation.finish(throwing: error)
@@ -702,17 +870,22 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         _ modelRepo: String,
         cache: HubCache = .default
     ) async throws -> Qwen3Model {
+        // Check for HF token in environment (macOS) or Info.plist (iOS)
         let hfToken: String? = ProcessInfo.processInfo.environment["HF_TOKEN"]
             ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+
         guard let repoID = Repo.ID(rawValue: modelRepo) else {
             throw NSError(domain: "Qwen3Model", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelRepo)"])
         }
+
+        // Check if model is already fully cached (has weight files)
         let modelDir = try await ModelUtils.resolveOrDownloadModel(
             repoID: repoID,
             requiredExtension: ".safetensors",
             hfToken: hfToken,
             cache: cache
         )
+
         return try await fromModelDirectory(modelDir)
     }
 
@@ -724,15 +897,24 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
         let configData = try Data(contentsOf: configPath)
         let config = try JSONDecoder().decode(Qwen3Configuration.self, from: configData)
         let perLayerQuantization = config.perLayerQuantization
+
         let model = Qwen3Model(config)
+
+        // Load weights from safetensors
         let weights = try loadWeights(from: modelDir)
+
         let sanitizedWeights = model.sanitize(weights: weights)
+
+        // Quantize if needed
         if perLayerQuantization != nil {
             print("Applying quantizaiton from config...")
+
             if let perLayerQuant = perLayerQuantization {
                 print(" Per-layer: \(perLayerQuant)")
             }
+
             quantize(model: model) { path, module in
+                // Only quantize if scales exist for this layer
                 if weights["\(path).scales"] != nil {
                     return perLayerQuantization?.quantization(layer: path)?.asTuple
                 } else {
@@ -740,6 +922,7 @@ public class Qwen3Model: Module, KVCacheDimensionProvider, SpeechGenerationModel
                 }
             }
         }
+
         try model.update(parameters: ModuleParameters.unflattened(sanitizedWeights), verify: .all)
         eval(model)
         try await model.post_load_hook(model: model, modelDir: modelDir, cache: cache)

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -194,6 +194,12 @@ public enum TTS {
                 pretrained: { try await KokoroModel.fromPretrained($0, textProcessor: processor, cache: $1) },
                 local: { modelDir, _ in try await KokoroModel.fromModelDirectory(modelDir, textProcessor: processor) }
             )
+        case "omnivoice":
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await OmniVoiceModel.fromPretrained($0, cache: $1) }
+            )
         default:
             throw TTSModelError.unsupportedModelType(resolvedType)
         }
@@ -298,6 +304,9 @@ public enum TTS {
         }
         if lower.contains("kokoro") {
             return "kokoro"
+        }
+        if lower.contains("omnivoice") {
+            return "omnivoice"
         }
         return nil
     }

--- a/Sources/Tools/mlx-audio-swift-tts/App.swift
+++ b/Sources/Tools/mlx-audio-swift-tts/App.swift
@@ -522,7 +522,7 @@ struct CLI {
     }
 
     static func printUsage() {
-        let exe = (CommandLine.arguments.first as NSString?)?.lastPathComponent ?? "marvis-tts-cli"
+        let exe = (CommandLine.arguments.first as NSString?)?.lastPathComponent ?? "mlx-audio-swift-tts"
         print("""
         Usage:
           \(exe) --text "Hello world" [--voice conversational_b] [--model <hf-repo>] [--output <path>] [--ref_audio <path>] [--ref_text <string>] [--max_tokens <int>] [--temperature <float>] [--top_p <float>] [--timestamps] [--benchmark]

--- a/Tests/OmniVoiceTests.swift
+++ b/Tests/OmniVoiceTests.swift
@@ -1,0 +1,458 @@
+// Test OmniVoice model loading and generation
+//
+// Run with:
+//   swift test --filter OmniVoiceTests
+//   MLXAUDIO_ENABLE_NETWORK_TESTS=1 swift test --filter OmniVoiceTests
+
+import Testing
+import MLX
+import Foundation
+import AVFoundation
+
+@testable import MLXAudioCore
+@testable import MLXAudioTTS
+@testable import MLXLMCommon
+
+@Suite("OmniVoice Configuration Tests")
+struct OmniVoiceConfigTests {
+
+    @Test func testConfigDecodesFromJSON() throws {
+        let json = """
+        {
+            "architectures": ["OmniVoice"],
+            "audio_codebook_weights": [8, 8, 6, 6, 4, 4, 2, 2],
+            "audio_mask_id": 1024,
+            "audio_vocab_size": 1025,
+            "bos_token_id": null,
+            "dtype": "bfloat16",
+            "eos_token_id": 151645,
+            "llm_config": {
+                "architectures": ["Qwen3ForCausalLM"],
+                "attention_bias": false,
+                "attention_dropout": 0.0,
+                "bos_token_id": 151643,
+                "chunk_size_feed_forward": 0,
+                "dtype": "float32",
+                "eos_token_id": 151645,
+                "head_dim": 128,
+                "hidden_act": "silu",
+                "hidden_size": 1024,
+                "initializer_range": 0.02,
+                "intermediate_size": 3072,
+                "is_encoder_decoder": false,
+                "layer_types": ["full_attention"],
+                "max_position_embeddings": 40960,
+                "max_window_layers": 28,
+                "model_type": "qwen3",
+                "num_attention_heads": 16,
+                "num_hidden_layers": 28,
+                "num_key_value_heads": 8,
+                "rms_norm_eps": 1e-06,
+                "rope_parameters": {"rope_theta": 1000000, "rope_type": "default"},
+                "tie_word_embeddings": true,
+                "use_cache": true,
+                "vocab_size": 151676
+            },
+            "model_type": "omnivoice",
+            "num_audio_codebook": 8,
+            "pad_token_id": 151643,
+            "transformers_version": "5.3.0"
+        }
+        """.data(using: .utf8)!
+
+        let config = try JSONDecoder().decode(OmniVoiceConfig.self, from: json)
+
+        #expect(config.modelType == "omnivoice")
+        #expect(config.architectures == ["OmniVoice"])
+        #expect(config.audioVocabSize == 1025)
+        #expect(config.audioMaskId == 1024)
+        #expect(config.numAudioCodebook == 8)
+        #expect(config.audioCodebookWeights == [8, 8, 6, 6, 4, 4, 2, 2])
+        #expect(config.eosTokenId == 151645)
+        #expect(config.padTokenId == 151643)
+        #expect(config.sampleRate == 24000)
+
+        // LLM config checks
+        #expect(config.llmConfig.hiddenSize == 1024)
+        #expect(config.llmConfig.numHiddenLayers == 28)
+        #expect(config.llmConfig.numAttentionHeads == 16)
+        #expect(config.llmConfig.numKeyValueHeads == 8)
+        #expect(config.llmConfig.vocabSize == 151676)
+        #expect(config.llmConfig.ropeTheta == 1_000_000)
+    }
+
+    @Test func testGenerateParametersDefaults() {
+        let params = OmniVoiceGenerateParameters()
+
+        #expect(params.numStep == 32)
+        #expect(params.guidanceScale == 2.0)
+        #expect(params.speed == 1.0)
+        #expect(params.duration == nil)
+        #expect(params.tShift == 0.1)
+        #expect(params.denoise == true)
+        #expect(params.postprocessOutput == true)
+        #expect(params.layerPenaltyFactor == 5.0)
+        #expect(params.positionTemperature == 5.0)
+        #expect(params.classTemperature == 0.0)
+    }
+
+    @Test func testFastPreset() {
+        let params = OmniVoiceGenerateParameters.fast
+
+        #expect(params.numStep == 16)
+        #expect(params.guidanceScale == 1.5)
+    }
+
+    @Test func testHighQualityPreset() {
+        let params = OmniVoiceGenerateParameters.highQuality
+
+        #expect(params.numStep == 64)
+        #expect(params.guidanceScale == 2.5)
+    }
+
+    @Test func testCustomParameters() {
+        let params = OmniVoiceGenerateParameters(
+            numStep: 48,
+            guidanceScale: 3.0,
+            speed: 0.8,
+            duration: 5.0,
+            tShift: 0.2,
+            denoise: false,
+            postprocessOutput: false,
+            layerPenaltyFactor: 3.0,
+            positionTemperature: 3.0,
+            classTemperature: 0.5
+        )
+
+        #expect(params.numStep == 48)
+        #expect(params.guidanceScale == 3.0)
+        #expect(params.speed == 0.8)
+        #expect(params.duration == 5.0)
+        #expect(params.tShift == 0.2)
+        #expect(params.denoise == false)
+        #expect(params.postprocessOutput == false)
+        #expect(params.layerPenaltyFactor == 3.0)
+        #expect(params.positionTemperature == 3.0)
+        #expect(params.classTemperature == 0.5)
+    }
+}
+
+@Suite("OmniVoice TTS Factory Tests")
+struct OmniVoiceFactoryTests {
+
+    @Test func testTTSResolveModelTypeOmniVoice() {
+        let modelType = TTS.resolveModelType(modelRepo: "mlx-community/OmniVoice-bf16")
+        #expect(modelType == "omnivoice")
+    }
+
+    @Test func testTTSResolveModelTypeOmniVoiceCaseInsensitive() {
+        let modelType = TTS.resolveModelType(modelRepo: "mlx-community/omnivoice-bf16")
+        #expect(modelType == "omnivoice")
+    }
+
+    @Test func testTTSResolveModelTypeOmniVoiceWithPrefix() {
+        let modelType = TTS.resolveModelType(modelRepo: "k2-fsa/OmniVoice")
+        #expect(modelType == "omnivoice")
+    }
+}
+
+@Suite("OmniVoice Model Tests", .serialized)
+struct OmniVoiceModelTests {
+
+    @Test func testModelTypeRegistered() async throws {
+        // Verify that OmniVoice is registered in the TTS factory
+        // This doesn't load the model, just checks the factory
+        let modelType = TTS.resolveModelType(modelRepo: "mlx-community/OmniVoice-bf16")
+        #expect(modelType == "omnivoice")
+    }
+
+    @Test func testAutoVoiceGeneration() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("⚠️ Skipping network OmniVoice test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_OMNIVOICE_REPO"] ?? "mlx-community/OmniVoice-bf16"
+
+        print("Loading OmniVoice model from \(repo)...")
+        let model = try await TTS.loadModel(modelRepo: repo)
+
+        #expect(model.sampleRate == 24000)
+        print("Model loaded successfully with sample rate: \(model.sampleRate)")
+
+        // Test auto voice generation (no ref_audio, no instruct)
+        let text = "Hello, this is a test of OmniVoice text-to-speech."
+        print("Generating audio for: \(text)")
+
+        let generationParams = GenerateParameters(
+            maxTokens: 2048,
+            temperature: 1.0,
+            topP: 0.95,
+            repetitionPenalty: 1.05
+        )
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let audio = try await model.generate(
+            text: text,
+            voice: nil,
+            refAudio: nil,
+            refText: nil,
+            language: "English",
+            generationParameters: generationParams
+        )
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+
+        // Verify output
+        #expect(audio.shape[0] > 0, "Generated audio should have samples")
+        print("Generated \(audio.shape[0]) samples in \(String(format: "%.2f", elapsed))s")
+
+        // Calculate audio duration
+        let duration = Double(audio.shape[0]) / Double(model.sampleRate)
+        print("Audio duration: \(String(format: "%.2f", duration))s")
+        #expect(duration > 0.5, "Audio should be at least 0.5 seconds")
+
+        // Save to temp file for manual verification
+        let tempDir = FileManager.default.temporaryDirectory
+        let outputURL = tempDir.appendingPathComponent("omnivoice_auto_voice_test.wav")
+        try writeWavFile(samples: audio.asArray(Float.self), sampleRate: Double(model.sampleRate), outputURL: outputURL)
+        print("Saved audio to: \(outputURL.path)")
+    }
+
+    @Test func testVoiceDesignGeneration() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("⚠️ Skipping network OmniVoice test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_OMNIVOICE_REPO"] ?? "mlx-community/OmniVoice-bf16"
+
+        print("Loading OmniVoice model from \(repo)...")
+        let model = try await TTS.loadModel(modelRepo: repo)
+
+        // Test voice design generation with instruct
+        let text = "Hello, this is a voice design test."
+        let instruct = "male, British accent"
+        print("Generating audio with instruct: \(instruct)")
+        print("Text: \(text)")
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let audio = try await (model as! OmniVoiceModel).generate(
+            text: text,
+            voice: instruct,
+            ovParameters: OmniVoiceGenerateParameters(
+                numStep: 32,
+                guidanceScale: 2.0,
+                speed: 1.0,
+                tShift: 0.1,
+                denoise: true,
+                postprocessOutput: true
+            )
+        )
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+
+        #expect(audio.shape[0] > 0, "Generated audio should have samples")
+        let duration = Double(audio.shape[0]) / Double(model.sampleRate)
+        print("Generated \(String(format: "%.2f", duration))s of audio in \(String(format: "%.2f", elapsed))s")
+
+        // Save to temp file
+        let tempDir = FileManager.default.temporaryDirectory
+        let outputURL = tempDir.appendingPathComponent("omnivoice_voice_design_test.wav")
+        try writeWavFile(samples: audio.asArray(Float.self), sampleRate: Double(model.sampleRate), outputURL: outputURL)
+        print("Saved audio to: \(outputURL.path)")
+    }
+
+    @Test func testVoiceCloningGeneration() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("⚠️ Skipping network OmniVoice test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_OMNIVOICE_REPO"] ?? "mlx-community/OmniVoice-bf16"
+
+        print("Loading OmniVoice model from \(repo)...")
+        let model = try await TTS.loadModel(modelRepo: repo)
+
+        // Load reference audio from test media
+        let bundle = Bundle.module
+        guard let audioURL = bundle.url(forResource: "intention", withExtension: "wav") else {
+            print("⚠️ Test audio file not found, skipping test")
+            return
+        }
+
+        let (refSampleRate, refAudio) = try loadAudioArray(from: audioURL, sampleRate: model.sampleRate)
+        print("Loaded reference audio: \(refAudio.shape[0]) samples at \(refSampleRate)Hz")
+
+        let text = "This is a voice cloning test."
+        let refText = "intention"  // Simple reference text
+        print("Generating with voice cloning...")
+        print("Text: \(text)")
+        print("Ref text: \(refText)")
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let audio = try await (model as! OmniVoiceModel).generate(
+            text: text,
+            refAudio: refAudio,
+            refText: refText,
+            ovParameters: OmniVoiceGenerateParameters(
+                numStep: 32,
+                guidanceScale: 2.0,
+                speed: 1.0
+            )
+        )
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+
+        #expect(audio.shape[0] > 0, "Generated audio should have samples")
+        let duration = Double(audio.shape[0]) / Double(model.sampleRate)
+        print("Generated \(String(format: "%.2f", duration))s of audio in \(String(format: "%.2f", elapsed))s")
+
+        // Save to temp file
+        let tempDir = FileManager.default.temporaryDirectory
+        let outputURL = tempDir.appendingPathComponent("omnivoice_voice_cloning_test.wav")
+        try writeWavFile(samples: audio.asArray(Float.self), sampleRate: Double(model.sampleRate), outputURL: outputURL)
+        print("Saved audio to: \(outputURL.path)")
+    }
+
+    @Test func testAudioTokenizerRoundTrip() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("⚠️ Skipping network OmniVoice test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_OMNIVOICE_REPO"] ?? "mlx-community/OmniVoice-bf16"
+        print("Loading OmniVoice model from \(repo)...")
+        let model = try await TTS.loadModel(modelRepo: repo)
+        guard let audioTokenizer = (model as? OmniVoiceModel)?.audioTokenizer else {
+            print("⚠️ Audio tokenizer not available")
+            return
+        }
+
+        let bundle = Bundle.module
+        guard let audioURL = bundle.url(forResource: "intention", withExtension: "wav") else {
+            print("⚠️ Test audio file not found, skipping test")
+            return
+        }
+
+        let (refSampleRate, refAudio) = try loadAudioArray(from: audioURL, sampleRate: model.sampleRate)
+        print("Loaded reference audio: \(refAudio.shape[0]) samples at \(refSampleRate)Hz")
+
+        // Encode -> Decode roundtrip to isolate vocoder issues
+        let tokens = try audioTokenizer.encode(refAudio)
+        print("Encoded tokens shape: \(tokens.shape)")
+        let tokenMin = tokens.min().item(Int32.self)
+        let tokenMax = tokens.max().item(Int32.self)
+        print("Token range: min=\(tokenMin), max=\(tokenMax)")
+
+        let decodedAudio = try audioTokenizer.decode(tokens)
+        print("Decoded audio shape: \(decodedAudio.shape)")
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let originalURL = tempDir.appendingPathComponent("omnivoice_roundtrip_original.wav")
+        let decodedURL = tempDir.appendingPathComponent("omnivoice_roundtrip_decoded.wav")
+        try writeWavFile(samples: refAudio.asArray(Float.self), sampleRate: Double(model.sampleRate), outputURL: originalURL)
+        try writeWavFile(samples: decodedAudio.asArray(Float.self), sampleRate: Double(model.sampleRate), outputURL: decodedURL)
+        print("Saved original to: \(originalURL.path)")
+        print("Saved decoded to: \(decodedURL.path)")
+
+        // Simple numeric sanity check: correlation should be positive if the codec is working
+        let originalSamples = refAudio.asArray(Float.self)
+        let decodedSamples = decodedAudio.asArray(Float.self)
+        let minLen = min(originalSamples.count, decodedSamples.count)
+        var dot: Float = 0
+        var origNorm: Float = 0
+        var decNorm: Float = 0
+        for i in 0..<minLen {
+            dot += originalSamples[i] * decodedSamples[i]
+            origNorm += originalSamples[i] * originalSamples[i]
+            decNorm += decodedSamples[i] * decodedSamples[i]
+        }
+        let correlation = dot / (sqrt(origNorm) * sqrt(decNorm) + 1e-8)
+        print("Correlation between original and decoded: \(correlation)")
+        #expect(correlation > 0.1, "Decoded audio should correlate with original; low correlation indicates vocoder bug")
+    }
+
+    @Test func testStreamingGeneration() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("⚠️ Skipping network OmniVoice test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_OMNIVOICE_REPO"] ?? "mlx-community/OmniVoice-bf16"
+
+        print("Loading OmniVoice model from \(repo)...")
+        let model = try await TTS.loadModel(modelRepo: repo)
+
+        let text = "Testing streaming generation."
+        print("Streaming generation for: \(text)")
+
+        let generationParams = GenerateParameters(
+            maxTokens: 2048,
+            temperature: 1.0,
+            topP: 0.95
+        )
+
+        var totalSamples = 0
+        var chunkCount = 0
+        let startTime = CFAbsoluteTimeGetCurrent()
+
+        for try await event in model.generateStream(
+            text: text,
+            voice: nil,
+            refAudio: nil,
+            refText: nil,
+            language: "English",
+            generationParameters: generationParams,
+            streamingInterval: 0.5
+        ) {
+            switch event {
+            case .token(let tokenId):
+                chunkCount += 1
+                if chunkCount % 10 == 0 {
+                    print("Generated \(chunkCount) tokens so far")
+                }
+            case .info(let info):
+                print("Generation info: \(info.summary)")
+            case .audio(let chunk):
+                let samples = chunk.asArray(Float.self)
+                totalSamples += samples.count
+                print("Received audio chunk: \(samples.count) samples (total: \(totalSamples))")
+            }
+        }
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+        print("Streaming completed: \(totalSamples) samples in \(String(format: "%.2f", elapsed))s")
+
+        #expect(totalSamples > 0, "Should have received audio samples")
+
+        // Save streamed audio
+        if totalSamples > 0 {
+            let tempDir = FileManager.default.temporaryDirectory
+            let outputURL = tempDir.appendingPathComponent("omnivoice_streaming_test.wav")
+            // Note: In real test, we'd collect all chunks and save
+            print("Streaming test passed with \(totalSamples) samples")
+        }
+    }
+}
+
+// MARK: - Helper Functions
+
+private func writeWavFile(samples: [Float], sampleRate: Double, outputURL: URL) throws {
+    let frameCount = AVAudioFrameCount(samples.count)
+    guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1),
+          let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount),
+          let channelData = buffer.floatChannelData else {
+        throw NSError(domain: "WavWrite", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create audio buffer"])
+    }
+
+    buffer.frameLength = frameCount
+    for i in 0..<samples.count {
+        channelData[0][i] = samples[i]
+    }
+
+    let audioFile = try AVAudioFile(forWriting: outputURL, settings: format.settings)
+    try audioFile.write(from: buffer)
+}


### PR DESCRIPTION
Adds [OmniVoice](https://huggingface.co/mlx-community/OmniVoice), a multilingual zero-shot TTS model: a bidirectional NAR diffusion LM over a Qwen3 backbone generating 9 RVQ codebooks at 24 kHz, decoded by a HiggsAudioV2 acoustic codec.

### What's included
- **`Sources/MLXAudioTTS/Models/OmniVoice/`** — model, config, generation params, and the HiggsAudioV2 semantic encode path (HuBERT + SemanticEncoder + fusion + residual RVQ).
- **Three modes:** auto voice, voice design (instruction), and **voice cloning** (`refAudio` + `refText`).
- Registered in `TTSModel.swift`; `Tests/OmniVoiceTests.swift` and a model README included.

### Supporting changes
- **Qwen3 (TTS) backbone rebased on the mlx-swift-lm implementation** — this touches the shared `Models/Qwen3` backbone (also used by VyvoTTS); the public API (`fromPretrained`, `generate`) is preserved. Flagging since it's shared code.
- `ModelUtils`: validate model snapshots recursively.

### Notes for reviewers
- Voice cloning requires the full `mlx-community/OmniVoice` checkpoint; the `-bf16` variant strips `semantic_model.*` and the loader rejects encode with a clear error.
- Encode parity vs the Python reference: 199/200 RVQ frames identical (root flips are fp near-ties); cloned-audio timbre similarity (MFCC) to the Python clone of the same prompt: 0.994.