### PR TITLE
docs(omnivoice): bf16 weights now include the complete tokenizer

### DIFF
--- a/Sources/MLXAudioTTS/Models/OmniVoice/README.md
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/README.md
@@ -4,10 +4,12 @@ Swift/MLX port of [k2-fsa/OmniVoice](https://huggingface.co/k2-fsa/OmniVoice), a
 
 ## Weights
 
-Use the full conversion `mlx-community/OmniVoice` (fp32, includes the complete
-audio codec). The `mlx-community/OmniVoice-bf16` repo's `audio_tokenizer/` was
-exported without the semantic encode path (no `semantic_model.*` /
-`encoder_semantic.*` weights), so it cannot encode reference audio.
+Two MLX conversions are available, both with the complete audio codec
+(acoustic **and** semantic encode path), so both support voice cloning:
+
+- `mlx-community/OmniVoice` — fp32.
+- `mlx-community/OmniVoice-bf16` — bfloat16: ~half the size and MLX's native
+  compute dtype on Apple Silicon.
 
 ## Usage
 


### PR DESCRIPTION
`mlx-community/OmniVoice-bf16` has been re-uploaded with the full HiggsAudioV2 audio tokenizer — the semantic encode path (`semantic_model.*` / `encoder_semantic.*`, HuBERT + SemanticEncoder) is now present (527 tokenizer tensors, 237 `semantic_model.*`), matching the fp32 `mlx-community/OmniVoice`.

The earlier bf16 upload predated the finalized converter and had shipped only the acoustic half of the tokenizer, so it couldn't encode reference audio. That's fixed, so the README caveat is now inaccurate.

This updates the **Weights** section to list both conversions as cloning-capable:
- `mlx-community/OmniVoice` — fp32
- `mlx-community/OmniVoice-bf16` — bfloat16, ~half the size and MLX's native compute dtype on Apple Silicon

No code changes — the loader already handles both checkpoints (`OmniVoiceModel.sanitize()` splits the fused fp32 `audio_embeddings`/`audio_heads` per-codebook and passes already-split bf16 through; `semanticModel` is optional).