### PR TITLE
Fill in remaining codecs for parity with mlx-audio

### DIFF
--- a/Sources/MLXAudioCodecs/HiggsAudio/HiggsAudioTokenizer.swift
+++ b/Sources/MLXAudioCodecs/HiggsAudio/HiggsAudioTokenizer.swift
@@ -1,0 +1,457 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXNN
+
+public struct HiggsAudioTokenizerConfig: Codable, Sendable {
+    public var modelType: String
+    public var sampleRate: Int
+    public var codebookSize: Int
+    public var codebookDim: Int
+    public var downsampleFactor: Int
+    public var dacSampleRate: Int
+    public var dacNumCodebooks: Int
+    public var dacEncoderRatios: [Int]
+    public var dacEncoderHidden: Int
+    public var dacDecoderHidden: Int
+
+    public init(
+        modelType: String = "higgs_audio_v2_tokenizer",
+        sampleRate: Int = 24_000,
+        codebookSize: Int = 1_024,
+        codebookDim: Int = 64,
+        downsampleFactor: Int = 320,
+        dacSampleRate: Int = 24_000,
+        dacNumCodebooks: Int = 8,
+        dacEncoderRatios: [Int] = [8, 5, 4, 2, 3],
+        dacEncoderHidden: Int = 64,
+        dacDecoderHidden: Int = 1_024
+    ) {
+        self.modelType = modelType
+        self.sampleRate = sampleRate
+        self.codebookSize = codebookSize
+        self.codebookDim = codebookDim
+        self.downsampleFactor = downsampleFactor
+        self.dacSampleRate = dacSampleRate
+        self.dacNumCodebooks = dacNumCodebooks
+        self.dacEncoderRatios = dacEncoderRatios
+        self.dacEncoderHidden = dacEncoderHidden
+        self.dacDecoderHidden = dacDecoderHidden
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case sampleRate = "sample_rate"
+        case codebookSize = "codebook_size"
+        case codebookDim = "codebook_dim"
+        case downsampleFactor = "downsample_factor"
+        case dacSampleRate = "dac_sample_rate"
+        case dacNumCodebooks = "dac_num_codebooks"
+        case dacEncoderRatios = "dac_encoder_ratios"
+        case dacEncoderHidden = "dac_encoder_hidden"
+        case dacDecoderHidden = "dac_decoder_hidden"
+    }
+}
+
+public enum HiggsAudioTokenizerError: Error, LocalizedError {
+    case missingConfig(URL)
+    case missingWeights(URL)
+    case invalidInput(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingConfig(let url):
+            "Missing Higgs audio tokenizer config at \(url.path)"
+        case .missingWeights(let url):
+            "Missing Higgs audio tokenizer weights at \(url.path)"
+        case .invalidInput(let message):
+            message
+        }
+    }
+}
+
+private func higgsSnake(_ x: MLXArray, alpha: MLXArray) -> MLXArray {
+    let sinValue = sin(alpha * x)
+    return x + (sinValue * sinValue) / (alpha + MLXArray(Float(1e-9)))
+}
+
+private final class HiggsSnake1d: Module {
+    @ModuleInfo var alpha: MLXArray
+
+    init(channels: Int) {
+        _alpha.wrappedValue = MLXArray.ones([1, 1, channels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        higgsSnake(x, alpha: alpha)
+    }
+}
+
+private final class HiggsConv1d: Module {
+    let stride: Int
+    let padding: Int
+    let dilation: Int
+
+    @ModuleInfo var weight: MLXArray
+    @ModuleInfo var bias: MLXArray
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int, stride: Int = 1, padding: Int = 0, dilation: Int = 1) {
+        self.stride = stride
+        self.padding = padding == 0 ? (kernelSize - stride) * dilation / 2 : padding
+        self.dilation = dilation
+        let scale = sqrt(1.0 / Float(inChannels * kernelSize))
+        _weight.wrappedValue = MLXRandom.uniform(low: -scale, high: scale, [outChannels, kernelSize, inChannels])
+        _bias.wrappedValue = MLXArray.zeros([outChannels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        conv1d(x, weight, stride: stride, padding: padding, dilation: dilation) + bias
+    }
+}
+
+private final class HiggsConvTranspose1d: Module {
+    let stride: Int
+    let padding: Int
+    let expectedStride: Int
+
+    @ModuleInfo var weight: MLXArray
+    @ModuleInfo var bias: MLXArray
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int, stride: Int, padding: Int) {
+        self.stride = stride
+        self.padding = padding
+        self.expectedStride = stride
+        let scale = sqrt(1.0 / Float(inChannels * kernelSize))
+        _weight.wrappedValue = MLXRandom.uniform(low: -scale, high: scale, [outChannels, kernelSize, inChannels])
+        _bias.wrappedValue = MLXArray.zeros([outChannels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let expected = x.dim(1) * expectedStride
+        var y = convTransposed1d(x, weight, stride: stride, padding: padding) + bias
+        if y.dim(1) > expected {
+            y = y[0..., 0..<expected, 0...]
+        }
+        return y
+    }
+}
+
+private final class HiggsResidualUnit: Module {
+    @ModuleInfo(key: "snake1") var snake1: HiggsSnake1d
+    @ModuleInfo(key: "conv1") var conv1: HiggsConv1d
+    @ModuleInfo(key: "snake2") var snake2: HiggsSnake1d
+    @ModuleInfo(key: "conv2") var conv2: HiggsConv1d
+
+    init(dim: Int, dilation: Int = 1) {
+        _snake1.wrappedValue = HiggsSnake1d(channels: dim)
+        _conv1.wrappedValue = HiggsConv1d(inChannels: dim, outChannels: dim, kernelSize: 7, dilation: dilation)
+        _snake2.wrappedValue = HiggsSnake1d(channels: dim)
+        _conv2.wrappedValue = HiggsConv1d(inChannels: dim, outChannels: dim, kernelSize: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = snake1(x)
+        y = conv1(y)
+        y = snake2(y)
+        y = conv2(y)
+        let pad = (x.dim(1) - y.dim(1)) / 2
+        let residual = pad > 0 ? x[0..., pad..<(x.dim(1) - pad), 0...] : x
+        return residual + y
+    }
+}
+
+private final class HiggsAcousticEncoderBlock: Module {
+    @ModuleInfo(key: "res_unit1") var resUnit1: HiggsResidualUnit
+    @ModuleInfo(key: "res_unit2") var resUnit2: HiggsResidualUnit
+    @ModuleInfo(key: "res_unit3") var resUnit3: HiggsResidualUnit
+    @ModuleInfo(key: "snake1") var snake1: HiggsSnake1d
+    @ModuleInfo(key: "conv1") var conv1: HiggsConv1d
+
+    init(inDim: Int, outDim: Int, stride: Int) {
+        _resUnit1.wrappedValue = HiggsResidualUnit(dim: inDim, dilation: 1)
+        _resUnit2.wrappedValue = HiggsResidualUnit(dim: inDim, dilation: 3)
+        _resUnit3.wrappedValue = HiggsResidualUnit(dim: inDim, dilation: 9)
+        _snake1.wrappedValue = HiggsSnake1d(channels: inDim)
+        _conv1.wrappedValue = HiggsConv1d(inChannels: inDim, outChannels: outDim, kernelSize: 2 * stride, stride: stride, padding: Int(ceil(Float(stride) / 2.0)))
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = resUnit1(x)
+        y = resUnit2(y)
+        y = resUnit3(y)
+        y = snake1(y)
+        return conv1(y)
+    }
+}
+
+private final class HiggsAcousticDecoderBlock: Module {
+    @ModuleInfo(key: "snake1") var snake1: HiggsSnake1d
+    @ModuleInfo(key: "conv_t1") var convT1: HiggsConvTranspose1d
+    @ModuleInfo(key: "res_unit1") var resUnit1: HiggsResidualUnit
+    @ModuleInfo(key: "res_unit2") var resUnit2: HiggsResidualUnit
+    @ModuleInfo(key: "res_unit3") var resUnit3: HiggsResidualUnit
+
+    init(inDim: Int, outDim: Int, stride: Int) {
+        _snake1.wrappedValue = HiggsSnake1d(channels: inDim)
+        _convT1.wrappedValue = HiggsConvTranspose1d(
+            inChannels: inDim,
+            outChannels: outDim,
+            kernelSize: 2 * stride,
+            stride: stride,
+            padding: stride / 2
+        )
+        _resUnit1.wrappedValue = HiggsResidualUnit(dim: outDim, dilation: 1)
+        _resUnit2.wrappedValue = HiggsResidualUnit(dim: outDim, dilation: 3)
+        _resUnit3.wrappedValue = HiggsResidualUnit(dim: outDim, dilation: 9)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = snake1(x)
+        y = convT1(y)
+        y = resUnit1(y)
+        y = resUnit2(y)
+        y = resUnit3(y)
+        return y
+    }
+}
+
+private final class HiggsAcousticEncoder: Module {
+    private static let strides = [8, 5, 4, 2, 3]
+    private static let channels = [64, 128, 256, 512, 1_024, 2_048]
+
+    @ModuleInfo(key: "conv1") var conv1: HiggsConv1d
+    @ModuleInfo(key: "block") var block: [HiggsAcousticEncoderBlock]
+    @ModuleInfo(key: "snake1") var snake1: HiggsSnake1d
+    @ModuleInfo(key: "conv2") var conv2: HiggsConv1d
+
+    override init() {
+        _conv1.wrappedValue = HiggsConv1d(inChannels: 1, outChannels: 64, kernelSize: 7, padding: 3)
+        _block.wrappedValue = Self.strides.enumerated().map { index, stride in
+            HiggsAcousticEncoderBlock(
+                inDim: Self.channels[index],
+                outDim: Self.channels[index + 1],
+                stride: stride
+            )
+        }
+        _snake1.wrappedValue = HiggsSnake1d(channels: 2_048)
+        _conv2.wrappedValue = HiggsConv1d(inChannels: 2_048, outChannels: 256, kernelSize: 3, padding: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = conv1(x)
+        for block in block {
+            y = block(y)
+        }
+        y = snake1(y)
+        return conv2(y)
+    }
+}
+
+private final class HiggsAcousticDecoder: Module {
+    private static let strides = [8, 5, 4, 2, 3]
+    private static let inChannels = [1_024, 512, 256, 128, 64]
+    private static let outChannels = [512, 256, 128, 64, 32]
+
+    @ModuleInfo(key: "conv1") var conv1: HiggsConv1d
+    @ModuleInfo(key: "block") var block: [HiggsAcousticDecoderBlock]
+    @ModuleInfo(key: "snake1") var snake1: HiggsSnake1d
+    @ModuleInfo(key: "conv2") var conv2: HiggsConv1d
+
+    override init() {
+        _conv1.wrappedValue = HiggsConv1d(inChannels: 256, outChannels: 1_024, kernelSize: 7, padding: 3)
+        _block.wrappedValue = Self.strides.enumerated().map { index, stride in
+            HiggsAcousticDecoderBlock(
+                inDim: Self.inChannels[index],
+                outDim: Self.outChannels[index],
+                stride: stride
+            )
+        }
+        _snake1.wrappedValue = HiggsSnake1d(channels: 32)
+        _conv2.wrappedValue = HiggsConv1d(inChannels: 32, outChannels: 1, kernelSize: 7, padding: 3)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = conv1(x)
+        for block in block {
+            y = block(y)
+        }
+        y = snake1(y)
+        return conv2(y)
+    }
+}
+
+private final class HiggsVectorQuantizer: Module {
+    @ModuleInfo(key: "project_in") var projectIn: Linear
+    @ModuleInfo var codebook: Embedding
+    @ModuleInfo(key: "project_out") var projectOut: Linear
+
+    init(latentDim: Int = 1_024, codebookSize: Int = 1_024, codebookDim: Int = 64) {
+        _projectIn.wrappedValue = Linear(latentDim, codebookDim)
+        _codebook.wrappedValue = Embedding(embeddingCount: codebookSize, dimensions: codebookDim)
+        _projectOut.wrappedValue = Linear(codebookDim, latentDim)
+    }
+
+    func decodeCodes(_ codes: MLXArray) -> MLXArray {
+        projectOut(codebook(codes))
+    }
+
+    func encode(_ z: MLXArray) -> MLXArray {
+        let zq = projectIn(z)
+        let distances = sum(zq * zq, axis: -1, keepDims: true)
+            + sum(codebook.weight * codebook.weight, axis: -1)
+            - 2 * matmul(zq, codebook.weight.T)
+        return argMin(distances, axis: -1).asType(.int32)
+    }
+}
+
+private final class HiggsResidualVectorQuantizer: Module {
+    @ModuleInfo var quantizers: [HiggsVectorQuantizer]
+
+    init(nCodebooks: Int = 8, latentDim: Int = 1_024, codebookSize: Int = 1_024, codebookDim: Int = 64) {
+        _quantizers.wrappedValue = (0..<nCodebooks).map { _ in
+            HiggsVectorQuantizer(latentDim: latentDim, codebookSize: codebookSize, codebookDim: codebookDim)
+        }
+    }
+
+    func decode(_ codes: MLXArray) -> MLXArray {
+        let nCodebooks = quantizers.count
+        var sum: MLXArray?
+        for index in 0..<nCodebooks {
+            let decoded = quantizers[index].decodeCodes(codes[0..., 0..., index])
+            sum = sum == nil ? decoded : sum! + decoded
+        }
+        return sum ?? MLXArray.zeros([codes.dim(0), codes.dim(1), 1_024], type: Float.self)
+    }
+
+    func encode(_ z: MLXArray) -> MLXArray {
+        var residual = z
+        var tokens: [MLXArray] = []
+        for quantizer in quantizers {
+            let indices = quantizer.encode(residual)
+            tokens.append(indices)
+            residual = residual - quantizer.decodeCodes(indices)
+        }
+        return stacked(tokens, axis: -1).asType(.int32)
+    }
+}
+
+public final class HiggsAudioTokenizer: Module {
+    public static let defaultCodecPrefix = "tied.embedding.modality_embeddings.0.model."
+
+    public let config: HiggsAudioTokenizerConfig
+
+    @ModuleInfo(key: "acoustic_encoder") private var acousticEncoder: HiggsAcousticEncoder
+    @ModuleInfo private var quantizer: HiggsResidualVectorQuantizer
+    @ModuleInfo(key: "acoustic_decoder") private var acousticDecoder: HiggsAcousticDecoder
+    @ModuleInfo var fc2: Linear
+
+    public init(config: HiggsAudioTokenizerConfig = HiggsAudioTokenizerConfig()) {
+        self.config = config
+        _acousticEncoder.wrappedValue = HiggsAcousticEncoder()
+        _quantizer.wrappedValue = HiggsResidualVectorQuantizer(
+            nCodebooks: config.dacNumCodebooks,
+            codebookSize: config.codebookSize,
+            codebookDim: config.codebookDim
+        )
+        _acousticDecoder.wrappedValue = HiggsAcousticDecoder()
+        _fc2.wrappedValue = Linear(1_024, 256)
+    }
+
+    public func decode(_ tokens: MLXArray) -> MLXArray {
+        let squeeze = tokens.ndim == 2
+        let batched = squeeze ? tokens.expandedDimensions(axis: 0) : tokens
+        var z = quantizer.decode(batched.asType(.int32))
+        z = fc2(z)
+        let waveform = acousticDecoder(z)
+        return squeeze ? waveform[0, 0..., 0] : waveform
+    }
+
+    public func encodeAcoustic(_ waveform: MLXArray) -> MLXArray {
+        let batched = waveform.ndim == 2 ? waveform.expandedDimensions(axis: -1) : waveform
+        let features = acousticEncoder(batched.asType(.float32))
+        return quantizer.encode(features)
+    }
+
+    public static func fromPretrained(
+        _ source: String,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> HiggsAudioTokenizer {
+        guard let repoID = Repo.ID(rawValue: source) else {
+            return try fromModelDirectory(URL(fileURLWithPath: NSString(string: source).expandingTildeInPath))
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["*.json", "*.index.json"],
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try fromModelDirectory(modelDir)
+    }
+
+    public static func fromModelDirectory(_ directory: URL) throws -> HiggsAudioTokenizer {
+        let modelDir = resolveTokenizerDirectory(directory)
+        let configURL = modelDir.appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            throw HiggsAudioTokenizerError.missingConfig(configURL)
+        }
+        let config = try JSONDecoder().decode(HiggsAudioTokenizerConfig.self, from: Data(contentsOf: configURL))
+        let model = HiggsAudioTokenizer(config: config)
+        let weightsURL = modelDir.appendingPathComponent("model.safetensors")
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw HiggsAudioTokenizerError.missingWeights(weightsURL)
+        }
+        let weights = try loadArrays(url: weightsURL)
+        try model.update(parameters: ModuleParameters.unflattened(sanitize(weights: weights)), verify: .noUnusedKeys)
+        eval(model)
+        return model
+    }
+
+    private static func resolveTokenizerDirectory(_ directory: URL) -> URL {
+        let nested = directory.appendingPathComponent("audio_tokenizer")
+        if FileManager.default.fileExists(atPath: nested.appendingPathComponent("config.json").path) {
+            return nested
+        }
+        return directory
+    }
+
+    public static func sanitize(weights: [String: MLXArray], prefix: String = "") -> [String: MLXArray] {
+        var result: [String: MLXArray] = [:]
+        result.reserveCapacity(weights.count)
+        for (rawKey, rawValue) in weights {
+            var key = rawKey
+            if !prefix.isEmpty {
+                guard key.hasPrefix(prefix) else { continue }
+                key = String(key.dropFirst(prefix.count))
+            }
+            if key == "semantic_model.masked_spec_embed" { continue }
+            if key.hasPrefix("decoder_semantic.") || key.hasPrefix("fc1.") { continue }
+            if key.hasSuffix(".embed_avg") || key.hasSuffix(".cluster_size") || key.hasSuffix(".inited") { continue }
+            guard key.hasPrefix("acoustic_encoder.")
+                || key.hasPrefix("acoustic_decoder.")
+                || key.hasPrefix("quantizer.")
+                || key.hasPrefix("fc2.")
+            else {
+                continue
+            }
+
+            var value = rawValue
+            if key.hasSuffix(".codebook.embed") {
+                key = String(key.dropLast("embed".count)) + "weight"
+            }
+
+            if key.hasSuffix(".alpha"), value.ndim == 3 {
+                value = value.transposed(0, 2, 1)
+            } else if key.contains(".conv_t"), key.hasSuffix(".weight"), value.ndim == 3 {
+                value = value.transposed(1, 2, 0)
+            } else if key.hasSuffix(".weight"), value.ndim == 3 {
+                value = value.transposed(0, 2, 1)
+            }
+
+            result[key] = value
+        }
+        return result
+    }
+}

--- a/Sources/MLXAudioCodecs/Mimi/Conv.swift
+++ b/Sources/MLXAudioCodecs/Mimi/Conv.swift
@@ -2,17 +2,9 @@ import Foundation
 import MLX
 import MLXNN
 
-// MARK: - Conv1d (NCL wrapper over MLX's NLC)
+// MARK: - MimiConv1d (NCL adapter over MLXNN.Conv1d)
 
-public final class Conv1d: Module {
-
-    public var weight: MLXArray
-    public var bias: MLXArray?
-
-    public let padding: Int
-    public let groups: Int
-    public let stride: Int
-    public let dilation: Int
+public final class MimiConv1d: MLXNN.Conv1d {
 
     public init(
         inChannels: Int,
@@ -24,45 +16,33 @@ public final class Conv1d: Module {
         dilation: Int = 1,
         bias: Bool = true
     ) {
-        // Uniform init in [-scale, scale]
-        let scale: Float = 1.0 / Float(inChannels * ksize)
-        self.weight = MLXRandom.uniform(
-            low: -scale, high: scale,
-            [outChannels, ksize, inChannels / groups]
+        super.init(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: ksize,
+            stride: stride,
+            padding: padding,
+            dilation: dilation,
+            groups: groups,
+            bias: bias
         )
-        self.bias = bias ? MLXArray.zeros([outChannels]) : nil
-        self.padding = padding
-        self.groups = groups
-        self.stride = stride
-        self.dilation = dilation
     }
 
     // NCL -> NLC -> conv1d -> NCL
-    public func callAsFunction(_ xsNCL: MLXArray) -> MLXArray {
+    public override func callAsFunction(_ xsNCL: MLXArray) -> MLXArray {
         let xsNLC = swappedAxes(xsNCL, 1, 2)
-        var y = conv1d(
-            xsNLC, weight,
-            stride: stride, padding: padding,
-            dilation: dilation, groups: groups
-        )
-        if let b = bias { y = y + b }
+        let y = super.callAsFunction(xsNLC)
         return swappedAxes(y, 1, 2)
     }
 }
 
-// MARK: - ConvTranspose1d (NCL wrapper)
+// MARK: - MimiConvTransposed1d (NCL adapter over MLXNN.ConvTransposed1d)
 
-public final class ConvTranspose1d: Module {
+public final class MimiConvTransposed1d: MLXNN.ConvTransposed1d {
 
-    public var weight: MLXArray
-    public var bias: MLXArray?
-
-    public let padding: Int
-    public let groups: Int
-    public let stride: Int
-    public let ksize: Int
-    public let inChannels: Int
-    public let outChannels: Int
+    private let ksize: Int
+    private let inChannels: Int
+    private let outChannels: Int
 
     public init(
         inChannels: Int,
@@ -73,19 +53,18 @@ public final class ConvTranspose1d: Module {
         groups: Int = 1,
         bias: Bool = true
     ) {
-        // Weight shape mirrors Python: (out_channels, ksize, in_channels // groups)
-        let scale: Float = 1.0 / Float(inChannels * ksize)
-        self.weight = MLXRandom.uniform(
-            low: -scale, high: scale,
-            [outChannels, ksize, inChannels / groups]
-        )
-        self.bias = bias ? MLXArray.zeros([outChannels]) : nil
-        self.padding = padding
-        self.groups = groups
-        self.stride = stride
         self.ksize = ksize
         self.inChannels = inChannels
         self.outChannels = outChannels
+        super.init(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: ksize,
+            stride: stride,
+            padding: padding,
+            groups: groups,
+            bias: bias
+        )
     }
 
     // Expand weight as needed to emulate grouped depthwise transposed conv like the Python version
@@ -106,16 +85,24 @@ public final class ConvTranspose1d: Module {
             let wRep = repeated(w, count: groups, axis: 0)
             return (wRep * eyeW, 1)
         } else if groups > 1 {
-            fatalError("groups > 1 (non-depthwise) not supported in ConvTranspose1d")
+            fatalError("groups > 1 (non-depthwise) not supported in MimiConvTransposed1d")
         } else {
             return (weight, groups)
         }
     }
 
-    public func callAsFunction(_ xsNCL: MLXArray) -> MLXArray {
+    public override func callAsFunction(_ xsNCL: MLXArray) -> MLXArray {
         let xsNLC = swappedAxes(xsNCL, 1, 2)
         let (wEff, gEff) = expandedWeightAndGroups()
-        var y = convTransposed1d(xsNLC, wEff, stride: stride, padding: padding, groups: gEff)
+        var y = convTransposed1d(
+            xsNLC,
+            wEff,
+            stride: stride,
+            padding: padding,
+            dilation: dilation,
+            outputPadding: outputPadding,
+            groups: gEff
+        )
         if let b = bias { y = y + b }
         return swappedAxes(y, 1, 2)
     }
@@ -124,14 +111,14 @@ public final class ConvTranspose1d: Module {
 // MARK: - Normalized wrappers (kept as simple pass-through like Python)
 
 public final class NormConv1d: Module {
-    @ModuleInfo public var conv: Conv1d
+    @ModuleInfo public var conv: MimiConv1d
 
     public init(
         inChannels: Int, outChannels: Int, ksize: Int,
         stride: Int = 1, padding: Int = 0,
         groups: Int = 1, dilation: Int = 1, bias: Bool = true
     ) {
-        self._conv = ModuleInfo(wrappedValue: Conv1d(
+        self._conv = ModuleInfo(wrappedValue: MimiConv1d(
             inChannels: inChannels, outChannels: outChannels, ksize: ksize,
             stride: stride, padding: padding, groups: groups, dilation: dilation, bias: bias
         ))
@@ -141,14 +128,14 @@ public final class NormConv1d: Module {
 }
 
 public final class NormConvTranspose1d: Module {
-    @ModuleInfo public var convtr: ConvTranspose1d
+    @ModuleInfo public var convtr: MimiConvTransposed1d
 
     public init(
         inChannels: Int, outChannels: Int, ksize: Int,
         stride: Int = 1, padding: Int = 0,
         groups: Int = 1, bias: Bool = true
     ) {
-        self._convtr = ModuleInfo(wrappedValue: ConvTranspose1d(
+        self._convtr = ModuleInfo(wrappedValue: MimiConvTransposed1d(
             inChannels: inChannels, outChannels: outChannels, ksize: ksize,
             stride: stride, padding: padding, groups: groups, bias: bias
         ))

--- a/Sources/MLXAudioCodecs/Mimi/Quantization.swift
+++ b/Sources/MLXAudioCodecs/Mimi/Quantization.swift
@@ -123,8 +123,8 @@ public final class ResidualVectorQuantization: Module {
 // MARK: - ResidualVectorQuantizer
 
 public final class ResidualVectorQuantizer: Module {
-    @ModuleInfo public var input_proj: Conv1d?
-    @ModuleInfo public var output_proj: Conv1d?
+    @ModuleInfo public var input_proj: MimiConv1d?
+    @ModuleInfo public var output_proj: MimiConv1d?
     @ModuleInfo public var vq: ResidualVectorQuantization
 
     public init(
@@ -140,12 +140,12 @@ public final class ResidualVectorQuantizer: Module {
         if inDim == dim, !forceProjection {
             self._input_proj = ModuleInfo(wrappedValue: nil)
         } else {
-            self._input_proj = ModuleInfo(wrappedValue: Conv1d(inChannels: inDim, outChannels: dim, ksize: 1, bias: false))
+            self._input_proj = ModuleInfo(wrappedValue: MimiConv1d(inChannels: inDim, outChannels: dim, ksize: 1, bias: false))
         }
         if outDim == dim, !forceProjection {
             self._output_proj = ModuleInfo(wrappedValue: nil)
         } else {
-            self._output_proj = ModuleInfo(wrappedValue: Conv1d(inChannels: dim, outChannels: outDim, ksize: 1, bias: false))
+            self._output_proj = ModuleInfo(wrappedValue: MimiConv1d(inChannels: dim, outChannels: outDim, ksize: 1, bias: false))
         }
         self._vq = ModuleInfo(wrappedValue: ResidualVectorQuantization(
             nq: nq, dim: dim, codebookSize: bins, codebookDim: nil

--- a/Sources/MLXAudioCodecs/MossAudioTokenizer/MossAudioTokenizer.swift
+++ b/Sources/MLXAudioCodecs/MossAudioTokenizer/MossAudioTokenizer.swift
@@ -7,6 +7,25 @@ import MLXNN
 
 public let mossDefaultAudioTokenizerRepo = "mlx-community/MOSS-Audio-Tokenizer-Nano"
 
+public enum MossAudioTokenizerError: Error, CustomStringConvertible {
+    case invalidInput(String)
+    case notImplemented(String)
+
+    public var description: String {
+        switch self {
+        case .invalidInput(let message):
+            message
+        case .notImplemented(let message):
+            message
+        }
+    }
+}
+
+public protocol MossAudioTokenizing: AnyObject {
+    func encodeAudio(_ audio: MLXArray, numQuantizers: Int) throws -> MLXArray
+    func decodeAudioCodes(_ audioTokenIDs: MLXArray, numQuantizers: Int) throws -> MLXArray
+}
+
 public struct MossAudioTokenizerConfig: Sendable {
     public var sampleRate: Int
     public var samplingRate: Int
@@ -46,7 +65,7 @@ public struct MossAudioTokenizerConfig: Sendable {
     public static func fromFile(_ url: URL) throws -> MossAudioTokenizerConfig {
         let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
         guard let json = object as? [String: Any] else {
-            throw MossTTSNanoError.invalidInput("Invalid MOSS audio tokenizer config.")
+            throw MossAudioTokenizerError.invalidInput("Invalid MOSS audio tokenizer config.")
         }
         return try fromDictionary(json)
     }
@@ -75,9 +94,9 @@ public struct MossAudioTokenizerConfig: Sendable {
 }
 
 public struct SendableValue: @unchecked Sendable {
-    let rawValue: Any
+    public let rawValue: Any
 
-    init(_ rawValue: Any) {
+    public init(_ rawValue: Any) {
         self.rawValue = rawValue
     }
 }
@@ -376,7 +395,7 @@ private final class MossAudioTransformerLayer: Module {
         norm: String
     ) throws {
         guard norm == "layer_norm" else {
-            throw MossTTSNanoError.invalidInput("Unsupported MOSS audio tokenizer norm: \(norm)")
+            throw MossAudioTokenizerError.invalidInput("Unsupported MOSS audio tokenizer norm: \(norm)")
         }
         _selfAttention.wrappedValue = MossAudioMultiheadAttention(
             embedDim: dModel,
@@ -437,7 +456,7 @@ private final class MossAudioTransformer: Module {
         gating: String
     ) throws {
         guard gating == "none" else {
-            throw MossTTSNanoError.invalidInput("Unsupported MOSS audio tokenizer gating: \(gating)")
+            throw MossAudioTokenizerError.invalidInput("Unsupported MOSS audio tokenizer gating: \(gating)")
         }
         self.positionalEmbedding = positionalEmbedding
         self.maxPeriod = maxPeriod
@@ -702,7 +721,7 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
 
         let quantizerType = config.quantizerKwargs.string("quantizer_type", fallback: config.quantizerType)
         guard ["rlfq", "random_prefix_rlfq"].contains(quantizerType) else {
-            throw MossTTSNanoError.invalidInput("Unsupported MOSS quantizer_type: \(quantizerType)")
+            throw MossAudioTokenizerError.invalidInput("Unsupported MOSS quantizer_type: \(quantizerType)")
         }
         let quantizer = MossResidualLFQ(kwargs: config.quantizerKwargs)
         self.numQuantizers = quantizer.numQuantizers
@@ -747,17 +766,30 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
             let module = try MossProjectedTransformer(kwargs: kwargs, context: context)
             return (module, module.downsampleRatio)
         default:
-            throw MossTTSNanoError.invalidInput("Unsupported MOSS audio tokenizer module_type: \(moduleType)")
+            throw MossAudioTokenizerError.invalidInput("Unsupported MOSS audio tokenizer module_type: \(moduleType)")
         }
     }
 
     public static func fromModelDirectory(_ modelDir: URL) throws -> MLXMossAudioTokenizer {
         let config = try MossAudioTokenizerConfig.fromFile(modelDir.appendingPathComponent("config.json"))
         let model = try MLXMossAudioTokenizer(config: config)
-        let weights = try loadWeights(from: modelDir)
+        let weights = try loadMossAudioTokenizerWeights(from: modelDir)
         try model.update(parameters: ModuleParameters.unflattened(sanitize(weights: weights)), verify: .all)
         eval(model)
         return model
+    }
+
+    private static func loadMossAudioTokenizerWeights(from directory: URL) throws -> [String: MLXArray] {
+        let files = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        var weights: [String: MLXArray] = [:]
+        for file in files {
+            let fileWeights = try MLX.loadArrays(url: file)
+            weights.merge(fileWeights) { _, new in new }
+        }
+        return weights
     }
 
     private static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
@@ -826,7 +858,7 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
                 channelCount = audio.dim(1)
             }
         } else {
-            throw MossTTSNanoError.invalidInput("Unsupported audio shape: \(audio.shape)")
+            throw MossAudioTokenizerError.invalidInput("Unsupported audio shape: \(audio.shape)")
         }
 
         if channelCount != channels {
@@ -851,7 +883,7 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
                 samples = mono
                 channelCount = 1
             } else {
-                throw MossTTSNanoError.invalidInput(
+                throw MossAudioTokenizerError.invalidInput(
                     "Unsupported reference audio channel conversion: \(channelCount) -> \(channels)"
                 )
             }
@@ -870,7 +902,7 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
 
     private func prepareWaveformBatch(_ waveforms: [MLXArray]) throws -> (MLXArray, MLXArray) {
         guard !waveforms.isEmpty else {
-            throw MossTTSNanoError.invalidInput("waveforms must not be empty")
+            throw MossAudioTokenizerError.invalidInput("waveforms must not be empty")
         }
         let lengths = waveforms.map { $0.dim($0.ndim - 1) }
         let maxLength = lengths.max() ?? 0
@@ -878,7 +910,7 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
         for waveform in waveforms {
             var current = waveform.ndim == 1 ? waveform.expandedDimensions(axis: 0) : waveform
             guard current.dim(0) == channels else {
-                throw MossTTSNanoError.invalidInput("Expected waveform shape [\(channels), samples], got \(current.shape)")
+                throw MossAudioTokenizerError.invalidInput("Expected waveform shape [\(channels), samples], got \(current.shape)")
             }
             let pad = maxLength - current.dim(1)
             if pad > 0 {
@@ -897,12 +929,12 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
         numQuantizers: Int?
     ) throws -> (MLXArray, MLXArray, Int) {
         guard !codesList.isEmpty else {
-            throw MossTTSNanoError.invalidInput("codesList must not be empty")
+            throw MossAudioTokenizerError.invalidInput("codesList must not be empty")
         }
         let available = codesList.map { $0.dim(0) }
         let effectiveNQ = numQuantizers ?? available[0]
         guard (available.min() ?? 0) >= effectiveNQ else {
-            throw MossTTSNanoError.invalidInput("numQuantizers=\(effectiveNQ) exceeds available quantizers")
+            throw MossAudioTokenizerError.invalidInput("numQuantizers=\(effectiveNQ) exceeds available quantizers")
         }
         let lengths = codesList.map { $0.dim($0.ndim - 1) }
         let maxLength = lengths.max() ?? 0
@@ -984,7 +1016,7 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
         codesLengths: MLXArray? = nil
     ) throws -> (MLXArray, MLXArray) {
         guard codes.ndim == 3 else {
-            throw MossTTSNanoError.invalidInput("Expected codes shape [nq, batch, time], got \(codes.shape)")
+            throw MossAudioTokenizerError.invalidInput("Expected codes shape [nq, batch, time], got \(codes.shape)")
         }
         let lengths = codesLengths ?? MLX.full([codes.dim(1)], values: Int32(codes.dim(2)), type: Int32.self)
         var audio = quantizer.decodeCodes(codes.asType(.int32))
@@ -1013,12 +1045,12 @@ public final class MLXMossAudioTokenizer: Module, MossAudioTokenizing, @unchecke
         var codes = audioTokenIDs.asType(.int32)
         if codes.ndim == 3 {
             guard codes.dim(0) == 1 else {
-                throw MossTTSNanoError.notImplemented("Batched MOSS audio-tokenizer decode is not implemented.")
+                throw MossAudioTokenizerError.notImplemented("Batched MOSS audio-tokenizer decode is not implemented.")
             }
             codes = codes[0]
         }
         guard codes.ndim == 2 else {
-            throw MossTTSNanoError.invalidInput("Expected codes shape [frames, nq], got \(codes.shape)")
+            throw MossAudioTokenizerError.invalidInput("Expected codes shape [frames, nq], got \(codes.shape)")
         }
         guard codes.dim(0) > 0 else {
             return MLXArray.zeros([0, channels], dtype: .float32)

--- a/Sources/MLXAudioCodecs/S3/S3TokenizerV2.swift
+++ b/Sources/MLXAudioCodecs/S3/S3TokenizerV2.swift
@@ -3,6 +3,7 @@
 // Converts 16kHz audio waveform → discrete speech token IDs (6561 vocab, 25 tokens/sec)
 
 import Foundation
+import HuggingFace
 import MLX
 import MLXAudioCore
 import MLXFast
@@ -29,7 +30,7 @@ private func precomputeFreqsCis(dim: Int, end: Int, theta: Float = 10000.0) -> (
     let halfDim = dim / 2
     let freqs = 1.0 / MLX.pow(
         MLXArray(theta),
-        MLXArray(0 ..< halfDim).asType(.float32)[..<halfDim] / Float(dim)
+        MLXArray((0 ..< halfDim).map { Float($0 * 2) }) / Float(dim)
     )
     let t = MLXArray(0 ..< end).asType(.float32)
     let outerProduct = t.expandedDimensions(axis: 1) * freqs.expandedDimensions(axis: 0)
@@ -123,7 +124,7 @@ class FSMNMultiHeadAttention: Module {
     @ModuleInfo(key: "key") var key: Linear
     @ModuleInfo(key: "value") var value: Linear
     @ModuleInfo(key: "out") var out: Linear
-    @ModuleInfo(key: "fsmn_block") var fsmnBlock: Conv1d
+    @ModuleInfo(key: "fsmn_block") var fsmnBlock: MLXNN.Conv1d
 
     let leftPadding: Int
     let rightPadding: Int
@@ -134,7 +135,7 @@ class FSMNMultiHeadAttention: Module {
         self._key.wrappedValue = Linear(nState, nState, bias: false)
         self._value.wrappedValue = Linear(nState, nState)
         self._out.wrappedValue = Linear(nState, nState)
-        self._fsmnBlock.wrappedValue = Conv1d(
+        self._fsmnBlock.wrappedValue = MLXNN.Conv1d(
             inputChannels: nState, outputChannels: nState,
             kernelSize: kernelSize, stride: 1, padding: 0,
             groups: nState, bias: false
@@ -213,18 +214,18 @@ class FSMNMultiHeadAttention: Module {
 class S3ResidualAttentionBlock: Module {
     @ModuleInfo(key: "attn") var attn: FSMNMultiHeadAttention
     @ModuleInfo(key: "attn_ln") var attnLn: LayerNorm
-    @ModuleInfo(key: "mlp") var mlp: Sequential
+    @ModuleInfo(key: "mlp") var mlp: MLXNN.Sequential
     @ModuleInfo(key: "mlp_ln") var mlpLn: LayerNorm
 
     init(nState: Int, nHead: Int, kernelSize: Int = 31) {
         let nMlp = nState * 4
         self._attn.wrappedValue = FSMNMultiHeadAttention(nState: nState, nHead: nHead, kernelSize: kernelSize)
         self._attnLn.wrappedValue = LayerNorm(dimensions: nState, eps: 1e-6)
-        self._mlp.wrappedValue = Sequential {
-            Linear(nState, nMlp)
-            GELU()
+        self._mlp.wrappedValue = MLXNN.Sequential(layers: [
+            Linear(nState, nMlp),
+            GELU(),
             Linear(nMlp, nState)
-        }
+        ])
         self._mlpLn.wrappedValue = LayerNorm(dimensions: nState)
     }
 
@@ -246,19 +247,19 @@ class S3ResidualAttentionBlock: Module {
 /// Total 4x downsampling: stride-2 conv1 + stride-2 conv2.
 class AudioEncoderV2: Module {
     let stride: Int
-    @ModuleInfo(key: "conv1") var conv1: Conv1d
-    @ModuleInfo(key: "conv2") var conv2: Conv1d
+    @ModuleInfo(key: "conv1") var conv1: MLXNN.Conv1d
+    @ModuleInfo(key: "conv2") var conv2: MLXNN.Conv1d
     @ModuleInfo(key: "blocks") var blocks: [S3ResidualAttentionBlock]
 
     let freqsCis: (MLXArray, MLXArray)
 
     init(nMels: Int, nState: Int, nHead: Int, nLayer: Int, stride: Int = 2) {
         self.stride = stride
-        self._conv1.wrappedValue = Conv1d(
+        self._conv1.wrappedValue = MLXNN.Conv1d(
             inputChannels: nMels, outputChannels: nState,
             kernelSize: 3, stride: stride, padding: 1
         )
-        self._conv2.wrappedValue = Conv1d(
+        self._conv2.wrappedValue = MLXNN.Conv1d(
             inputChannels: nState, outputChannels: nState,
             kernelSize: 3, stride: 2, padding: 1
         )
@@ -281,14 +282,14 @@ class AudioEncoderV2: Module {
         out = out * mask1.expandedDimensions(axis: -1)
         out = gelu(conv1(out))
         let strideVal = Int32(stride)
-        outLen = (outLen + MLXArray(Int32(0))) / strideVal + MLXArray(Int32(1))
+        outLen = (outLen - MLXArray(Int32(1))) / strideVal + MLXArray(Int32(1))
 
         // Mask and apply conv2
         // Same formula with stride=2: (L - 1) / 2 + 1
         let mask2 = makeNonPadMask(outLen, maxLen: out.dim(1))
         out = out * mask2.expandedDimensions(axis: -1)
         out = gelu(conv2(out))
-        outLen = (outLen + MLXArray(Int32(0))) / Int32(2) + MLXArray(Int32(1))
+        outLen = (outLen - MLXArray(Int32(1))) / Int32(2) + MLXArray(Int32(1))
 
         // Attention mask
         let mask3 = makeNonPadMask(outLen, maxLen: out.dim(1))
@@ -312,6 +313,9 @@ class AudioEncoderV2: Module {
 /// Input: mel spectrogram (B, 128, T) at 100 frames/sec (from 16kHz audio, hop=160)
 /// Output: token IDs (B, T') at 25 tokens/sec (4x downsampling), vocabulary size 6561.
 public class S3TokenizerV2: Module {
+    public static let defaultRepository = "mlx-community/S3TokenizerV2"
+    public static let defaultTokenizerName = "speech_tokenizer_v2_25hz"
+
     let config: S3TokenizerConfig
     @ModuleInfo(key: "encoder") var encoder: AudioEncoderV2
     @ModuleInfo(key: "quantizer") var quantizer: FSQVectorQuantization
@@ -337,9 +341,87 @@ public class S3TokenizerV2: Module {
     ///   - melLen: Length of each mel in the batch (B,)
     /// - Returns: (tokens, tokenLens) where tokens is (B, T') int32, tokenLens is (B,)
     public func callAsFunction(_ mel: MLXArray, melLen: MLXArray) -> (MLXArray, MLXArray) {
+        quantize(mel, melLen: melLen)
+    }
+
+    /// Quantize mel spectrogram to speech tokens.
+    public func quantize(_ mel: MLXArray, melLen: MLXArray) -> (MLXArray, MLXArray) {
         let (hidden, codeLen) = encoder(mel, xLen: melLen)
         let code = quantizer.encode(hidden)
         return (code, codeLen)
+    }
+
+    /// Load S3TokenizerV2 from a Hugging Face repository.
+    ///
+    /// Supports both `model.safetensors` and named tokenizer files such as
+    /// `speech_tokenizer_v2_25hz.safetensors`.
+    public static func fromPretrained(
+        _ repoId: String = defaultRepository,
+        name: String = defaultTokenizerName,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> S3TokenizerV2 {
+        guard let repoID = Repo.ID(rawValue: repoId) else {
+            throw NSError(
+                domain: "S3TokenizerV2",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(repoId)"]
+            )
+        }
+
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            hfToken: hfToken,
+            cache: cache
+        )
+
+        return try fromModelDirectory(modelDir, name: name)
+    }
+
+    /// Load S3TokenizerV2 from a local directory.
+    public static func fromModelDirectory(
+        _ modelDir: URL,
+        name: String = defaultTokenizerName
+    ) throws -> S3TokenizerV2 {
+        let weightsURL = try resolveWeightsURL(in: modelDir, name: name)
+        let model = S3TokenizerV2()
+        var weights = try loadArrays(url: weightsURL)
+        weights = sanitize(weights: weights, model: model)
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [])
+        eval(model)
+        return model
+    }
+
+    private static func resolveWeightsURL(in modelDir: URL, name: String) throws -> URL {
+        let preferred = [
+            modelDir.appendingPathComponent("model.safetensors"),
+            modelDir.appendingPathComponent("\(name).safetensors"),
+        ]
+
+        for url in preferred where FileManager.default.fileExists(atPath: url.path) {
+            return url
+        }
+
+        let candidates = try FileManager.default.contentsOfDirectory(
+            at: modelDir,
+            includingPropertiesForKeys: nil
+        )
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        if let only = candidates.only {
+            return only
+        }
+
+        throw NSError(
+            domain: "S3TokenizerV2",
+            code: 2,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Could not find S3TokenizerV2 weights in \(modelDir.path). Expected model.safetensors or \(name).safetensors."
+            ]
+        )
     }
 
     /// Weight sanitization for loading from safetensors.
@@ -396,6 +478,12 @@ public class S3TokenizerV2: Module {
     }
 }
 
+private extension Array {
+    var only: Element? {
+        count == 1 ? self[0] : nil
+    }
+}
+
 // MARK: - Helper: Log Mel Spectrogram for S3TokenizerV2
 
 /// Compute log mel spectrogram for S3TokenizerV2 input.
@@ -415,16 +503,14 @@ public func s3TokenizerLogMelSpectrogram(
     nFft: Int = 400,
     hopLength: Int = 160
 ) -> MLXArray {
-    let window = hanningWindow(size: nFft)
+    let window = hanningWindow(size: nFft + 1)[..<nFft]
 
     // STFT (center=true, matching Python default)
     let freqs = stft(audio: audio, window: window, nFft: nFft, hopLength: hopLength)
     // freqs shape: (T', nFft/2+1)
 
-    // Power spectrum — drop last frame to match Python's `spec[:, :-1, :]` behavior
-    // Python drops the last STFT frame to match PyTorch torch.stft convention
-    let numFrames = freqs.dim(0)
-    let magnitudes = abs(freqs[..<(numFrames - 1)]).square()
+    // Power spectrum. Python uses `hanning(n_fft + 1)[:-1]` and keeps all STFT frames.
+    let magnitudes = abs(freqs).square()
 
     // Mel filterbank: (nFreqs, nMels)
     let filters = melFilters(

--- a/Sources/MLXAudioCodecs/S3Gen/CAMPPlus.swift
+++ b/Sources/MLXAudioCodecs/S3Gen/CAMPPlus.swift
@@ -591,7 +591,7 @@ class StatsPool: Module {
 ///
 /// Default config: feat_dim=80, embedding_size=192, growth_rate=32, bn_size=4, init_channels=128
 /// Block config: (12, 24, 16) layers with kernel_sizes=(3, 3, 3) and dilations=(1, 2, 2).
-class CAMPPlus: Module {
+public class CAMPPlus: Module {
     @ModuleInfo(key: "head") var head: FCM
     @ModuleInfo(key: "tdnn") var tdnn: TDNNLayer
     @ModuleInfo(key: "blocks") var blocks: [CAMDenseTDNNBlock]
@@ -692,7 +692,7 @@ class CAMPPlus: Module {
 
     /// Run inference on raw 16kHz audio waveform(s).
     /// Extracts Kaldi fbank features, pads to uniform length, runs forward pass.
-    func inference(_ wavs: [MLXArray], sampleRate: Int = 16000) -> MLXArray {
+    public func inference(_ wavs: [MLXArray], sampleRate: Int = 16000) -> MLXArray {
         // Extract fbank features for each wav
         var feats: [MLXArray] = []
         for wav in wavs {
@@ -727,7 +727,7 @@ class CAMPPlus: Module {
     /// Handles both raw PyTorch and pre-converted MLX-community weight formats.
     /// Conv weight transpositions are only applied when the weight shape doesn't
     /// already match the model's expected parameter shape.
-    static func sanitize(weights: [String: MLXArray], model: CAMPPlus) -> [String: MLXArray] {
+    public static func sanitize(weights: [String: MLXArray], model: CAMPPlus) -> [String: MLXArray] {
         var sanitized: [String: MLXArray] = [:]
         // Flatten model parameters to a dict of "a.b.c.weight" → MLXArray for shape comparison
         let flatParams = Dictionary(uniqueKeysWithValues: model.parameters().flattened())

--- a/Sources/MLXAudioCodecs/S3Gen/ConformerEncoder.swift
+++ b/Sources/MLXAudioCodecs/S3Gen/ConformerEncoder.swift
@@ -13,14 +13,14 @@ class S3GenPositionalEncoding: Module {
     let xscale: Float
     let dropoutRate: Float
     let maxLen: Int
-    var pe: MLXArray
+    @ParameterInfo var pe: MLXArray
 
     init(dModel: Int, dropoutRate: Float, maxLen: Int = 5000) {
         self.dModel = dModel
         self.xscale = sqrt(Float(dModel))
         self.dropoutRate = dropoutRate
         self.maxLen = maxLen
-        self.pe = Self.createPE(maxLen: maxLen, dModel: dModel)
+        _pe.wrappedValue = Self.createPE(maxLen: maxLen, dModel: dModel)
     }
 
     static func createPE(maxLen: Int, dModel: Int) -> MLXArray {
@@ -65,14 +65,14 @@ class S3GenEspnetRelPositionalEncoding: Module {
     let xscale: Float
     let dropoutRate: Float
     let maxLen: Int
-    var pe: MLXArray
+    @ParameterInfo var pe: MLXArray
 
     init(dModel: Int, dropoutRate: Float, maxLen: Int = 5000) {
         self.dModel = dModel
         self.xscale = sqrt(Float(dModel))
         self.dropoutRate = dropoutRate
         self.maxLen = maxLen
-        self.pe = Self.createRelPE(size: maxLen, dModel: dModel)
+        _pe.wrappedValue = Self.createRelPE(size: maxLen, dModel: dModel)
     }
 
     static func createRelPE(size: Int, dModel: Int) -> MLXArray {
@@ -122,13 +122,13 @@ class S3GenLinearNoSubsampling: Module {
     @ModuleInfo(key: "linear") var linear: Linear
     @ModuleInfo(key: "norm") var norm: LayerNorm
     let dropoutRate: Float
-    let posEnc: Module  // One of the positional encoding types
+    @ModuleInfo(key: "pos_enc") var posEnc: Module
 
     init(idim: Int, odim: Int, dropoutRate: Float, posEnc: Module) {
         self._linear.wrappedValue = Linear(idim, odim)
         self._norm.wrappedValue = LayerNorm(dimensions: odim, eps: 1e-5)
         self.dropoutRate = dropoutRate
-        self.posEnc = posEnc
+        self._posEnc.wrappedValue = posEnc
     }
 
     func callAsFunction(

--- a/Sources/MLXAudioCodecs/S3Gen/FlowMatching.swift
+++ b/Sources/MLXAudioCodecs/S3Gen/FlowMatching.swift
@@ -823,7 +823,7 @@ class CausalConditionalCFM: Module {
 ///
 /// Pipeline: tokens → inputEmbedding → Conformer encoder (2x upsample) → encoderProj
 /// → flow matching decoder (Euler ODE) → mel spectrogram → HiFi-GAN vocoder → waveform.
-class CausalMaskedDiffWithXvec: Module {
+public class CausalMaskedDiffWithXvec: Module {
     let outputSize: Int
     let vocabSize: Int
     let tokenMelRatio: Int
@@ -836,9 +836,9 @@ class CausalMaskedDiffWithXvec: Module {
     @ModuleInfo(key: "encoder_proj") var encoderProj: Linear
     @ModuleInfo(key: "decoder") var decoder: CausalConditionalCFM
     @ModuleInfo(key: "mel2wav") var vocoderModule: HiFTGenerator
-    @ModuleInfo(key: "speaker_encoder") var speakerEncoder: CAMPPlus
+    @ModuleInfo(key: "speaker_encoder") public var speakerEncoder: CAMPPlus
 
-    init(
+    public init(
         inputSize: Int = 512, outputSize: Int = 80,
         spkEmbedDim: Int = 192, vocabSize: Int = 6561,
         decoderInChannels: Int = 320,
@@ -875,7 +875,7 @@ class CausalMaskedDiffWithXvec: Module {
     }
 
     /// Run vocoder (HiFi-GAN) on mel spectrogram to produce waveform.
-    func vocoder(_ mel: MLXArray) -> (MLXArray, MLXArray) {
+    public func vocoder(_ mel: MLXArray) -> (MLXArray, MLXArray) {
         return vocoderModule(mel)
     }
 
@@ -891,7 +891,7 @@ class CausalMaskedDiffWithXvec: Module {
     ///   - nTimesteps: Number of Euler ODE steps for flow matching
     ///   - streaming: Whether to use streaming/causal mode
     /// - Returns: Generated mel spectrogram, shape `(B, 80, T_gen_mel)`
-    func inference(
+    public func inference(
         token: MLXArray, tokenLen: MLXArray,
         promptToken: MLXArray, promptTokenLen: MLXArray,
         promptFeat: MLXArray,

--- a/Sources/MLXAudioCodecs/S3Gen/HiFTGenerator.swift
+++ b/Sources/MLXAudioCodecs/S3Gen/HiFTGenerator.swift
@@ -221,26 +221,72 @@ class SineGen: Module {
         self.upsampleScale = upsampleScale
     }
 
+    private func linearInterpolate1DToSize(_ x: MLXArray, newSize: Int) -> MLXArray {
+        let currentSize = x.dim(-1)
+        if newSize == currentSize {
+            return x
+        }
+
+        let newPositions = MLX.linspace(Float32(0), Float32(currentSize - 1), count: newSize)
+        let indicesLow = floor(newPositions).asType(.int32)
+        let indicesHigh = MLX.minimum(indicesLow + 1, MLXArray(Int32(currentSize - 1)))
+        let weights = newPositions.asType(x.dtype) - indicesLow.asType(x.dtype)
+
+        let lowValues = MLX.take(x, indicesLow, axis: -1)
+        let highValues = MLX.take(x, indicesHigh, axis: -1)
+        return lowValues + weights * (highValues - lowValues)
+    }
+
+    private func f02SineInterpolation(_ f0Values: MLXArray) -> MLXArray {
+        let b = f0Values.dim(0)
+        let t = f0Values.dim(1)
+        let h = f0Values.dim(2)
+
+        var radValues = (f0Values / Float(samplingRate)) % 1
+        var randIni = MLXRandom.uniform(0.0 ..< 1.0, [b, h])
+        randIni = MLX.concatenated(
+            [MLXArray.zeros([b, 1]).asType(randIni.dtype), randIni[0..., 1...]],
+            axis: 1
+        )
+        let first = radValues[0..., 0..<1, 0...] + randIni.expandedDimensions(axis: 1)
+        if t > 1 {
+            radValues = MLX.concatenated([first, radValues[0..., 1..., 0...]], axis: 1)
+        } else {
+            radValues = first
+        }
+
+        let radValuesT = radValues.transposed(0, 2, 1)
+        let tDown = Swift.max(1, t / upsampleScale)
+        var radValuesDown = linearInterpolate1DToSize(radValuesT, newSize: tDown)
+        radValuesDown = radValuesDown.transposed(0, 2, 1)
+
+        let phase = MLX.cumsum(radValuesDown, axis: 1) * (2.0 * Float.pi)
+        let phaseT = phase.transposed(0, 2, 1) * Float(upsampleScale)
+        let phaseUp = linearInterpolate1DToSize(phaseT, newSize: t).transposed(0, 2, 1)
+        return MLX.sin(phaseUp)
+    }
+
     func callAsFunction(_ f0: MLXArray) -> (MLXArray, MLXArray, MLXArray) {
         // f0: (B, 1, T)
         let B = f0.dim(0)
 
-        // Create harmonics multiplier: [1, 2, ..., harmonicNum+1]
-        let harmonicMult = (MLXArray(1 ... (harmonicNum + 1)).asType(.float32))
-            .reshaped(1, -1, 1)
-        let fMat = f0 * harmonicMult / Float(samplingRate)
+        let harmonicMult = MLXArray(1 ... (harmonicNum + 1)).asType(f0.dtype)
+        let sineWaves: MLXArray
+        if useInterpolation {
+            let fn = f0.transposed(0, 2, 1) * harmonicMult
+            sineWaves = (f02SineInterpolation(fn) * sineAmp).transposed(0, 2, 1)
+        } else {
+            let harmonicMult = harmonicMult.reshaped(1, -1, 1)
+            let fMat = f0 * harmonicMult / Float(samplingRate)
+            let thetaMat = 2.0 * Float.pi * (MLX.cumsum(fMat, axis: -1) % 1.0)
 
-        // Phase computation
-        let thetaMat = 2.0 * Float.pi * (MLX.cumsum(fMat, axis: -1) % 1.0)
-
-        // Random initial phase (zero for fundamental)
-        var phaseVec = MLXRandom.uniform(
-            low: -Float.pi, high: Float.pi,
-            [B, harmonicNum + 1, 1])
-        let phaseMask = (MLXArray(0 ... harmonicNum).reshaped(1, -1, 1) .> 0).asType(.float32)
-        phaseVec = phaseVec * phaseMask
-
-        var sineWaves = sineAmp * MLX.sin(thetaMat + phaseVec)
+            var phaseVec = MLXRandom.uniform(
+                low: -Float.pi, high: Float.pi,
+                [B, harmonicNum + 1, 1])
+            let phaseMask = (MLXArray(0 ... harmonicNum).reshaped(1, -1, 1) .> 0).asType(.float32)
+            phaseVec = phaseVec * phaseMask
+            sineWaves = sineAmp * MLX.sin(thetaMat + phaseVec)
+        }
 
         // Voiced/unvoiced mask
         let uv = (f0 .> voicedThreshold).asType(.float32)
@@ -249,9 +295,9 @@ class SineGen: Module {
         let noiseAmp = uv * noiseStd + (1.0 - uv) * sineAmp / 3.0
         let noise = noiseAmp * MLXRandom.normal(sineWaves.shape)
 
-        sineWaves = sineWaves * uv + noise
+        let noisySineWaves = sineWaves * uv + noise
 
-        return (sineWaves, uv, noise)
+        return (noisySineWaves, uv, noise)
     }
 }
 

--- a/Sources/MLXAudioCodecs/S3Gen/S3GenMel.swift
+++ b/Sources/MLXAudioCodecs/S3Gen/S3GenMel.swift
@@ -38,7 +38,7 @@ func s3genReflectPad2D(_ x: MLXArray, padAmount: Int) -> MLXArray {
 ///   - fmin: Minimum frequency (default: 0)
 ///   - fmax: Maximum frequency (default: 8000)
 /// - Returns: Mel-spectrogram (B, numMels, T')
-func s3genMelSpectrogram(
+public func s3genMelSpectrogram(
     y: MLXArray,
     nFft: Int = 1920, numMels: Int = 80,
     samplingRate: Int = 24000, hopSize: Int = 480,

--- a/Sources/MLXAudioCodecs/S3Gen/StepAudio2.swift
+++ b/Sources/MLXAudioCodecs/S3Gen/StepAudio2.swift
@@ -1,0 +1,660 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXFast
+import MLXAudioCore
+import MLXNN
+
+public let stepAudio2SampleRate = 24_000
+
+public struct StepAudio2Prompt {
+    public var promptToken: MLXArray
+    public var promptTokenLen: MLXArray
+    public var promptFeat: MLXArray
+    public var promptFeatLen: MLXArray?
+    public var embedding: MLXArray
+
+    public init(
+        promptToken: MLXArray,
+        promptTokenLen: MLXArray,
+        promptFeat: MLXArray,
+        promptFeatLen: MLXArray? = nil,
+        embedding: MLXArray
+    ) {
+        self.promptToken = promptToken
+        self.promptTokenLen = promptTokenLen
+        self.promptFeat = promptFeat
+        self.promptFeatLen = promptFeatLen
+        self.embedding = embedding
+    }
+}
+
+public enum StepAudio2Error: Error, LocalizedError {
+    case missingWeights(URL)
+    case invalidInput(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingWeights(let url):
+            "Missing StepAudio2 weights at \(url.path)"
+        case .invalidInput(let message):
+            message
+        }
+    }
+}
+
+private func stepAudio2ApproxGELU(_ x: MLXArray) -> MLXArray {
+    0.5 * x * (1.0 + tanh(Float(sqrt(2.0 / Float.pi)) * (x + 0.044715 * pow(x, MLXArray(3)))))
+}
+
+private func stepAudio2Modulate(_ x: MLXArray, shift: MLXArray, scale: MLXArray) -> MLXArray {
+    x * (1 + scale) + shift
+}
+
+private final class StepAudio2LayerNormNoAffine: Module {
+    let eps: Float
+
+    init(eps: Float = 1e-6) {
+        self.eps = eps
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.layerNorm(x, weight: nil, bias: nil, eps: eps)
+    }
+}
+
+private final class StepAudio2MLP: Module {
+    @ModuleInfo var fc1: Linear
+    @ModuleInfo var fc2: Linear
+
+    init(inFeatures: Int, hiddenFeatures: Int? = nil, outFeatures: Int? = nil) {
+        let hidden = hiddenFeatures ?? inFeatures
+        let output = outFeatures ?? inFeatures
+        _fc1.wrappedValue = Linear(inFeatures, hidden)
+        _fc2.wrappedValue = Linear(hidden, output)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        fc2(stepAudio2ApproxGELU(fc1(x)))
+    }
+}
+
+private final class StepAudio2Attention: Module {
+    let numHeads: Int
+    let headDim: Int
+    let innerDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "to_q") var toQ: Linear
+    @ModuleInfo(key: "to_k") var toK: Linear
+    @ModuleInfo(key: "to_v") var toV: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: LayerNorm
+    @ModuleInfo(key: "k_norm") var kNorm: LayerNorm
+    @ModuleInfo var proj: Linear
+
+    init(dim: Int, numHeads: Int = 8, headDim: Int = 64, qkvBias: Bool = true) {
+        self.numHeads = numHeads
+        self.headDim = headDim
+        self.innerDim = numHeads * headDim
+        self.scale = pow(Float(headDim), -0.5)
+        _toQ.wrappedValue = Linear(dim, innerDim, bias: qkvBias)
+        _toK.wrappedValue = Linear(dim, innerDim, bias: qkvBias)
+        _toV.wrappedValue = Linear(dim, innerDim, bias: qkvBias)
+        _qNorm.wrappedValue = LayerNorm(dimensions: headDim)
+        _kNorm.wrappedValue = LayerNorm(dimensions: headDim)
+        _proj.wrappedValue = Linear(innerDim, dim)
+    }
+
+    private func toHeads(_ x: MLXArray) -> MLXArray {
+        let b = x.dim(0)
+        let t = x.dim(1)
+        let c = x.dim(2)
+        return x.reshaped(b, t, numHeads, c / numHeads).transposed(0, 2, 1, 3)
+    }
+
+    func callAsFunction(_ x: MLXArray, attnMask: MLXArray?) -> MLXArray {
+        let b = x.dim(0)
+        let t = x.dim(1)
+        var q = toHeads(toQ(x))
+        var k = toHeads(toK(x))
+        let v = toHeads(toV(x))
+
+        q = qNorm(q)
+        k = kNorm(k)
+
+        var scores = matmul(q, k.swappedAxes(-1, -2)) * scale
+        if var mask = attnMask {
+            if mask.ndim == 3 {
+                mask = mask.expandedDimensions(axis: 1)
+            }
+            scores = MLX.where(mask, scores, MLXArray(-Float.infinity))
+        }
+        let attn = softmax(scores, axis: -1)
+        let out = matmul(attn, v).transposed(0, 2, 1, 3).reshaped(b, t, innerDim)
+        return proj(out)
+    }
+}
+
+private final class StepAudio2TimestepEmbedder: Module {
+    let frequencyEmbeddingSize: Int
+    let scale: Float
+
+    @ModuleInfo var mlp: StepAudio2TimestepMLP
+
+    init(hiddenSize: Int, frequencyEmbeddingSize: Int = 256) {
+        self.frequencyEmbeddingSize = frequencyEmbeddingSize
+        self.scale = 1000
+        _mlp.wrappedValue = StepAudio2TimestepMLP(inputSize: frequencyEmbeddingSize, hiddenSize: hiddenSize)
+    }
+
+    private func timestepEmbedding(_ t: MLXArray, dim: Int, maxPeriod: Int = 10_000) -> MLXArray {
+        let half = dim / 2
+        let freqs = exp(
+            -Float(log(Float(maxPeriod))) * MLXArray(0..<half).asType(.float32) / Float(half)
+        ).asType(t.dtype)
+        let args = t.expandedDimensions(axis: -1) * freqs.expandedDimensions(axis: 0)
+        var embedding = MLX.concatenated([cos(args), sin(args)], axis: -1)
+        if dim % 2 != 0 {
+            embedding = MLX.concatenated([embedding, MLXArray.zeros(like: embedding[0..., ..<1])], axis: -1)
+        }
+        return embedding
+    }
+
+    func callAsFunction(_ t: MLXArray) -> MLXArray {
+        mlp(timestepEmbedding(t * scale, dim: frequencyEmbeddingSize))
+    }
+}
+
+private final class StepAudio2TimestepMLP: Module {
+    @ModuleInfo var linear1: Linear
+    @ModuleInfo var linear2: Linear
+
+    init(inputSize: Int, hiddenSize: Int) {
+        _linear1.wrappedValue = Linear(inputSize, hiddenSize)
+        _linear2.wrappedValue = Linear(hiddenSize, hiddenSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(silu(linear1(x)))
+    }
+}
+
+private final class StepAudio2AdaLNModulation: Module {
+    @ModuleInfo var linear: Linear
+
+    init(hiddenSize: Int, outputSize: Int) {
+        _linear.wrappedValue = Linear(hiddenSize, outputSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear(silu(x))
+    }
+}
+
+private final class StepAudio2CausalConvBlockModules: Module {
+    @ModuleInfo var conv1: Conv1d
+    @ModuleInfo var norm: LayerNorm
+    @ModuleInfo var conv2: Conv1d
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int) {
+        _conv1.wrappedValue = Conv1d(inputChannels: inChannels, outputChannels: outChannels, kernelSize: kernelSize)
+        _norm.wrappedValue = LayerNorm(dimensions: outChannels)
+        _conv2.wrappedValue = Conv1d(inputChannels: outChannels, outputChannels: outChannels, kernelSize: kernelSize)
+    }
+}
+
+private final class StepAudio2CausalConvBlock: Module {
+    let kernelSize: Int
+
+    @ModuleInfo var block: StepAudio2CausalConvBlockModules
+
+    init(inChannels: Int, outChannels: Int, kernelSize: Int = 3) {
+        self.kernelSize = kernelSize
+        _block.wrappedValue = StepAudio2CausalConvBlockModules(
+            inChannels: inChannels,
+            outChannels: outChannels,
+            kernelSize: kernelSize
+        )
+    }
+
+    private func causalConv(_ x: MLXArray, _ conv: Conv1d) -> MLXArray {
+        conv(MLX.padded(x, widths: [.init(0), .init((kernelSize - 1, 0)), .init(0)]))
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        var out = x
+        if let mask {
+            out = out * mask
+        }
+        out = causalConv(out, block.conv1)
+        out = block.norm(out)
+        out = mish(out)
+        out = causalConv(out, block.conv2)
+        if let mask {
+            out = out * mask
+        }
+        return out
+    }
+}
+
+private final class StepAudio2DiTBlock: Module {
+    @ModuleInfo var norm1: StepAudio2LayerNormNoAffine
+    @ModuleInfo var attn: StepAudio2Attention
+    @ModuleInfo var norm2: StepAudio2LayerNormNoAffine
+    @ModuleInfo var mlp: StepAudio2MLP
+    @ModuleInfo var norm3: StepAudio2LayerNormNoAffine
+    @ModuleInfo var conv: StepAudio2CausalConvBlock
+    @ModuleInfo(key: "adaLN_modulation") var adaLNModulation: StepAudio2AdaLNModulation
+
+    init(hiddenSize: Int, numHeads: Int, headDim: Int, mlpRatio: Float = 4.0) {
+        _norm1.wrappedValue = StepAudio2LayerNormNoAffine(eps: 1e-6)
+        _attn.wrappedValue = StepAudio2Attention(dim: hiddenSize, numHeads: numHeads, headDim: headDim)
+        _norm2.wrappedValue = StepAudio2LayerNormNoAffine(eps: 1e-6)
+        _mlp.wrappedValue = StepAudio2MLP(inFeatures: hiddenSize, hiddenFeatures: Int(Float(hiddenSize) * mlpRatio))
+        _norm3.wrappedValue = StepAudio2LayerNormNoAffine(eps: 1e-6)
+        _conv.wrappedValue = StepAudio2CausalConvBlock(inChannels: hiddenSize, outChannels: hiddenSize, kernelSize: 3)
+        _adaLNModulation.wrappedValue = StepAudio2AdaLNModulation(hiddenSize: hiddenSize, outputSize: 9 * hiddenSize)
+    }
+
+    func callAsFunction(_ x: MLXArray, c: MLXArray, attnMask: MLXArray?) -> MLXArray {
+        let mod = adaLNModulation(c)
+        let pieces = mod.split(parts: 9, axis: -1)
+        var out = x
+        out = out + pieces[2] * attn(stepAudio2Modulate(norm1(out), shift: pieces[0], scale: pieces[1]), attnMask: attnMask)
+        out = out + pieces[8] * conv(stepAudio2Modulate(norm3(out), shift: pieces[6], scale: pieces[7]))
+        out = out + pieces[5] * mlp(stepAudio2Modulate(norm2(out), shift: pieces[3], scale: pieces[4]))
+        return out
+    }
+}
+
+private final class StepAudio2FinalLayer: Module {
+    @ModuleInfo(key: "adaLN_modulation") var adaLNModulation: StepAudio2AdaLNModulation
+    @ModuleInfo(key: "norm_final") var normFinal: StepAudio2LayerNormNoAffine
+    @ModuleInfo var linear: Linear
+
+    init(hiddenSize: Int, outChannels: Int) {
+        _adaLNModulation.wrappedValue = StepAudio2AdaLNModulation(hiddenSize: hiddenSize, outputSize: 2 * hiddenSize)
+        _normFinal.wrappedValue = StepAudio2LayerNormNoAffine(eps: 1e-6)
+        _linear.wrappedValue = Linear(hiddenSize, outChannels)
+    }
+
+    func callAsFunction(_ x: MLXArray, c: MLXArray) -> MLXArray {
+        let mod = adaLNModulation(c)
+        let pieces = mod.split(parts: 2, axis: -1)
+        return linear(stepAudio2Modulate(normFinal(x), shift: pieces[0], scale: pieces[1]))
+    }
+}
+
+private final class StepAudio2DiT: Module {
+    let inChannels: Int
+    let outChannels: Int
+
+    @ModuleInfo(key: "t_embedder") var tEmbedder: StepAudio2TimestepEmbedder
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo var blocks: [StepAudio2DiTBlock]
+    @ModuleInfo(key: "final_layer") var finalLayer: StepAudio2FinalLayer
+
+    init(
+        inChannels: Int = 320,
+        outChannels: Int = 80,
+        mlpRatio: Float = 4.0,
+        depth: Int = 16,
+        numHeads: Int = 8,
+        headDim: Int = 64,
+        hiddenSize: Int = 512
+    ) {
+        self.inChannels = inChannels
+        self.outChannels = outChannels
+        _tEmbedder.wrappedValue = StepAudio2TimestepEmbedder(hiddenSize: hiddenSize)
+        _inProj.wrappedValue = Linear(inChannels, hiddenSize)
+        _blocks.wrappedValue = (0..<depth).map { _ in
+            StepAudio2DiTBlock(hiddenSize: hiddenSize, numHeads: numHeads, headDim: headDim, mlpRatio: mlpRatio)
+        }
+        _finalLayer.wrappedValue = StepAudio2FinalLayer(hiddenSize: hiddenSize, outChannels: outChannels)
+    }
+
+    func callAsFunction(
+        x: MLXArray,
+        mask: MLXArray,
+        mu: MLXArray,
+        t: MLXArray,
+        spks: MLXArray?,
+        cond: MLXArray?
+    ) -> MLXArray {
+        let time = tEmbedder(t).expandedDimensions(axis: 1)
+        var pieces = [x, mu]
+        if let spks {
+            let expanded = spks.expandedDimensions(axis: -1)
+            pieces.append(MLX.broadcast(expanded, to: [spks.dim(0), spks.dim(1), x.dim(-1)]))
+        }
+        if let cond {
+            pieces.append(cond)
+        }
+        let combined = MLX.concatenated(pieces, axis: 1)
+        return blocksForward(combined, t: time, mask: mask.asType(.bool))
+    }
+
+    private func blocksForward(_ x: MLXArray, t: MLXArray, mask: MLXArray?) -> MLXArray {
+        var out = x.transposed(0, 2, 1)
+        out = inProj(out)
+        for block in blocks {
+            out = block(out, c: t, attnMask: mask)
+        }
+        out = finalLayer(out, c: t)
+        return out.transposed(0, 2, 1)
+    }
+}
+
+private final class StepAudio2CausalConditionalCFM: Module {
+    let inferenceCFGRate: Float
+    let outChannels: Int
+
+    @ModuleInfo var estimator: StepAudio2DiT
+    @ParameterInfo(key: "rand_noise") var randNoise: MLXArray
+
+    init(estimator: StepAudio2DiT = StepAudio2DiT(), inferenceCFGRate: Float = 0.7) {
+        self.inferenceCFGRate = inferenceCFGRate
+        self.outChannels = estimator.outChannels
+        _estimator.wrappedValue = estimator
+        _randNoise.wrappedValue = MLXRandom.normal([1, estimator.outChannels, 50 * 600])
+    }
+
+    private func solveEuler(
+        x initialX: MLXArray,
+        tSpan: MLXArray,
+        mu: MLXArray,
+        mask: MLXArray,
+        spks: MLXArray,
+        cond: MLXArray
+    ) -> MLXArray {
+        var x = initialX
+        var t = tSpan[0].expandedDimensions(axis: 0)
+        var dt = tSpan[1] - tSpan[0]
+        let nSteps = tSpan.dim(0) - 1
+
+        let maskIn = MLX.concatenated([mask, mask], axis: 0)
+        let muIn = MLX.concatenated([mu, MLXArray.zeros(like: mu)], axis: 0)
+        let spksIn = MLX.concatenated([spks, MLXArray.zeros(like: spks)], axis: 0)
+        let condIn = MLX.concatenated([cond, MLXArray.zeros(like: cond)], axis: 0)
+
+        for step in 1...nSteps {
+            let xIn = MLX.concatenated([x, x], axis: 0)
+            let tIn = MLX.concatenated([t, t], axis: 0)
+            var dphiDt = estimator(x: xIn, mask: maskIn, mu: muIn, t: tIn, spks: spksIn, cond: condIn)
+            let split = dphiDt.split(parts: 2, axis: 0)
+            dphiDt = (1.0 + inferenceCFGRate) * split[0] - inferenceCFGRate * split[1]
+            x = x + dt * dphiDt
+            t = t + dt
+            if step < nSteps {
+                dt = tSpan[step + 1] - t
+            }
+        }
+        return x
+    }
+
+    func callAsFunction(
+        mu: MLXArray,
+        mask: MLXArray,
+        spks: MLXArray,
+        cond: MLXArray,
+        nTimesteps: Int = 10,
+        temperature: Float = 1.0,
+        noise: MLXArray? = nil
+    ) -> MLXArray {
+        let z = (noise ?? randNoise[0..., 0..., ..<mu.dim(2)]) * temperature
+        let linear = MLX.linspace(Float32(0), Float32(1), count: nTimesteps + 1).asType(mu.dtype)
+        let tSpan = 1 - cos(linear * Float32(Float.pi / 2))
+        return solveEuler(x: z, tSpan: tSpan, mu: mu, mask: mask, spks: spks, cond: cond)
+    }
+}
+
+private final class StepAudio2Flow: Module {
+    let outputSize: Int
+    let vocabSize: Int
+    let preLookaheadLen: Int
+    let upRate: Int
+
+    @ModuleInfo(key: "input_embedding") var inputEmbedding: Embedding
+    @ModuleInfo(key: "spk_embed_affine_layer") var spkEmbedAffineLayer: Linear
+    @ModuleInfo var encoder: UpsampleConformerEncoder
+    @ModuleInfo(key: "encoder_proj") var encoderProj: Linear
+    @ModuleInfo var decoder: StepAudio2CausalConditionalCFM
+
+    init(inputSize: Int = 512, outputSize: Int = 80, spkEmbedDim: Int = 192, vocabSize: Int = 6_561) {
+        self.outputSize = outputSize
+        self.vocabSize = vocabSize
+        self.preLookaheadLen = 3
+        self.upRate = 2
+        _inputEmbedding.wrappedValue = Embedding(embeddingCount: vocabSize, dimensions: inputSize)
+        _spkEmbedAffineLayer.wrappedValue = Linear(spkEmbedDim, outputSize)
+        _encoder.wrappedValue = UpsampleConformerEncoder(
+            inputSize: inputSize,
+            outputSize: inputSize,
+            attentionHeads: 8,
+            linearUnits: 2048,
+            numBlocks: 6,
+            numUpBlocks: 4,
+            dropoutRate: 0.1,
+            positionalDropoutRate: 0.1,
+            attentionDropoutRate: 0.1,
+            posEncLayerType: "rel_pos_espnet",
+            normalizeBefore: true,
+            selfattentionLayerType: "rel_selfattn",
+            keyBias: true,
+            preLookaheadLen: 3,
+            upsampleStride: 2
+        )
+        _encoderProj.wrappedValue = Linear(inputSize, outputSize)
+        _decoder.wrappedValue = StepAudio2CausalConditionalCFM()
+    }
+
+    func inference(
+        token: MLXArray,
+        tokenLen: MLXArray,
+        prompt: StepAudio2Prompt,
+        nTimesteps: Int = 10
+    ) throws -> MLXArray {
+        if token.dim(0) != 1 {
+            throw StepAudio2Error.invalidInput("StepAudio2 flow inference currently supports batch size 1")
+        }
+
+        let embNorm = sqrt((prompt.embedding * prompt.embedding).sum(axis: 1, keepDims: true))
+        let embedding = spkEmbedAffineLayer(prompt.embedding / (embNorm + 1e-8))
+
+        let combinedToken = MLX.concatenated([prompt.promptToken, token], axis: 1)
+        let combinedLen = prompt.promptTokenLen + tokenLen
+        var mask = MLX.logicalNot(s3genMakePadMask(lengths: combinedLen, maxLen: combinedToken.dim(1)))
+        mask = mask.expandedDimensions(axis: -1).asType(embedding.dtype)
+        let clipped = MLX.clip(combinedToken, min: 0, max: inputEmbedding.weight.dim(0) - 1)
+        let embedded = inputEmbedding(clipped) * mask
+
+        let (encoderOut, _) = encoder(xs: embedded, xsLens: combinedLen)
+        let h = encoderProj(encoderOut)
+
+        let promptMelLen = prompt.promptFeat.dim(1)
+        let generatedMelLen = h.dim(1) - promptMelLen
+        let conds = MLX.concatenated(
+            [
+                prompt.promptFeat,
+                MLXArray.zeros([h.dim(0), generatedMelLen, outputSize]).asType(h.dtype),
+            ],
+            axis: 1
+        ).transposed(0, 2, 1)
+
+        let totalLen = promptMelLen + generatedMelLen
+        var decoderMask = MLX.logicalNot(s3genMakePadMask(lengths: MLXArray([Int32(totalLen)]), maxLen: totalLen))
+        decoderMask = decoderMask.asType(h.dtype).expandedDimensions(axis: 1)
+
+        let feat = decoder(
+            mu: h.transposed(0, 2, 1),
+            mask: decoderMask,
+            spks: embedding,
+            cond: conds,
+            nTimesteps: nTimesteps
+        )
+        let generated = feat[0..., 0..., promptMelLen...]
+        if generated.dim(2) != generatedMelLen {
+            throw StepAudio2Error.invalidInput("Unexpected generated mel length: \(generated.dim(2)) != \(generatedMelLen)")
+        }
+        return generated
+    }
+
+    static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result: [String: MLXArray] = [:]
+        result.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            var newKey = key
+            newKey = newKey.replacingOccurrences(of: "t_embedder.mlp.0.", with: "t_embedder.mlp.linear1.")
+            newKey = newKey.replacingOccurrences(of: "t_embedder.mlp.2.", with: "t_embedder.mlp.linear2.")
+            newKey = newKey.replacingOccurrences(of: ".adaLN_modulation.1.", with: ".adaLN_modulation.linear.")
+            newKey = newKey.replacingOccurrences(of: ".conv.block.1.", with: ".conv.block.conv1.")
+            newKey = newKey.replacingOccurrences(of: ".conv.block.3.", with: ".conv.block.norm.")
+            newKey = newKey.replacingOccurrences(of: ".conv.block.6.", with: ".conv.block.conv2.")
+            result[newKey] = value
+        }
+        return result
+    }
+}
+
+private final class StepAudio2HiFTGenerator: HiFTGenerator {
+    init() {
+        super.init(
+            samplingRate: stepAudio2SampleRate,
+            upsampleRates: [8, 5, 3],
+            upsampleKernelSizes: [16, 11, 7],
+            sourceResblockKernelSizes: [7, 7, 11],
+            sourceResblockDilationSizes: [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+            useInterpolation: true
+        )
+    }
+
+    override func decode(x: MLXArray, s: MLXArray) -> MLXArray {
+        let squeezedS = s.squeezed(axis: 1)
+        let nFft = istftParams["n_fft"]!
+        let hopLen = istftParams["hop_len"]!
+        let (sReal, sImag) = hifigan_stft(x: squeezedS, nFft: nFft, hopLength: hopLen, window: stftWindow)
+        let sStft = MLX.concatenated([sReal, sImag], axis: 1)
+
+        var h = convPre(x.transposed(0, 2, 1)).transposed(0, 2, 1)
+        for i in 0..<numUpsamples {
+            h = leakyRelu(h, negativeSlope: lreluSlope)
+            h = ups[i](h.transposed(0, 2, 1)).transposed(0, 2, 1)
+            if i == numUpsamples - 1 {
+                h = MLX.concatenated([h[0..., 0..., 1..<2], h], axis: 2)
+            }
+
+            var si = sourceDowners[i](sStft.transposed(0, 2, 1)).transposed(0, 2, 1)
+            si = sourceResblocks[i](si)
+            h = h + si
+
+            var sum: MLXArray?
+            let startIndex = i * numKernels
+            for j in 0..<numKernels {
+                let value = resblocks[startIndex + j](h)
+                sum = sum == nil ? value : sum! + value
+            }
+            h = sum! / Float(numKernels)
+        }
+
+        h = leakyRelu(h)
+        h = convPost(h.transposed(0, 2, 1)).transposed(0, 2, 1)
+        let nFftHalf = nFft / 2 + 1
+        let magnitude = exp(h[0..., ..<nFftHalf, 0...])
+        let phase = sin(h[0..., nFftHalf..., 0...])
+        return MLX.clip(
+            hifigan_istft(magnitude: magnitude, phase: phase, nFft: nFft, hopLength: hopLen, window: stftWindow),
+            min: -audioLimit,
+            max: audioLimit
+        )
+    }
+
+    static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result: [String: MLXArray] = [:]
+        result.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            var newKey = key
+            if key == "stft_window" { continue }
+            if key.hasSuffix(".weight") || key.hasSuffix(".bias") {
+                if key.hasPrefix("conv_pre.")
+                    || key.hasPrefix("conv_post.")
+                    || key.hasPrefix("ups.")
+                    || key.hasPrefix("source_downs.")
+                    || key.contains(".convs1.")
+                    || key.contains(".convs2.")
+                    || key.hasPrefix("f0_predictor.condnet.")
+                {
+                    let suffix = key.hasSuffix(".weight") ? ".weight" : ".bias"
+                    newKey = String(key.dropLast(suffix.count)) + ".conv" + suffix
+                }
+            }
+            result[newKey] = value
+        }
+        return result
+    }
+}
+
+public final class StepAudio2Token2Wav: Module {
+    public static let defaultRepository = "mlx-community/Step-Audio-2-token2wav"
+
+    @ModuleInfo private var flow: StepAudio2Flow
+    @ModuleInfo private var hift: StepAudio2HiFTGenerator
+
+    public override init() {
+        _flow.wrappedValue = StepAudio2Flow()
+        _hift.wrappedValue = StepAudio2HiFTGenerator()
+        super.init()
+    }
+
+    public func decodeToMel(_ speechTokens: MLXArray, prompt: StepAudio2Prompt, nTimesteps: Int = 10) throws -> MLXArray {
+        let batchedTokens = speechTokens.ndim == 1 ? speechTokens.expandedDimensions(axis: 0) : speechTokens
+        let tokens = batchedTokens.asType(.int32)
+        let tokenLen = MLXArray([Int32(tokens.dim(1))])
+        return try flow.inference(token: tokens, tokenLen: tokenLen, prompt: prompt, nTimesteps: nTimesteps)
+    }
+
+    public func vocode(_ mel: MLXArray) -> MLXArray {
+        let (wav, _) = hift(mel)
+        return wav
+    }
+
+    public func decode(_ speechTokens: MLXArray, prompt: StepAudio2Prompt, nTimesteps: Int = 10) throws -> MLXArray {
+        try vocode(decodeToMel(speechTokens, prompt: prompt, nTimesteps: nTimesteps))
+    }
+
+    public static func fromModelDirectory(_ directory: URL) throws -> StepAudio2Token2Wav {
+        let flowURL = directory.appendingPathComponent("flow.safetensors")
+        let hiftURL = directory.appendingPathComponent("hift.safetensors")
+        guard FileManager.default.fileExists(atPath: flowURL.path) else {
+            throw StepAudio2Error.missingWeights(flowURL)
+        }
+        guard FileManager.default.fileExists(atPath: hiftURL.path) else {
+            throw StepAudio2Error.missingWeights(hiftURL)
+        }
+
+        let model = StepAudio2Token2Wav()
+        let flowWeights = StepAudio2Flow.sanitize(weights: try loadArrays(url: flowURL))
+        try model.flow.update(parameters: ModuleParameters.unflattened(flowWeights), verify: .all)
+        let hiftWeights = StepAudio2HiFTGenerator.sanitize(weights: try loadArrays(url: hiftURL))
+        try model.hift.update(parameters: ModuleParameters.unflattened(hiftWeights), verify: .noUnusedKeys)
+        eval(model)
+        return model
+    }
+
+    public static func fromPretrained(
+        _ source: String = defaultRepository,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> StepAudio2Token2Wav {
+        guard let repoID = Repo.ID(rawValue: source) else {
+            return try fromModelDirectory(URL(fileURLWithPath: NSString(string: source).expandingTildeInPath))
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["*.yaml"],
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try fromModelDirectory(modelDir)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift
+++ b/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift
@@ -12,6 +12,7 @@ import AVFoundation
 import Foundation
 import HuggingFace
 @preconcurrency import MLX
+import MLXAudioCodecs
 import MLXAudioCore
 import MLXNN
 @preconcurrency import MLXLMCommon
@@ -1024,26 +1025,11 @@ public final class ChatterboxModel: Module, SpeechGenerationModel, @unchecked Se
         // Load S3TokenizerV2 from separate HuggingFace repo (needed for voice cloning)
         let s3TokenizerRepo = "mlx-community/S3TokenizerV2"
         do {
-            guard let s3RepoID = Repo.ID(rawValue: s3TokenizerRepo) else {
-                throw AudioGenerationError.invalidInput("Invalid S3Tokenizer repo ID")
-            }
-            let s3Dir = try await ModelUtils.resolveOrDownloadModel(
-                repoID: s3RepoID,
-                requiredExtension: "safetensors",
+            model.s3Tokenizer = try await S3TokenizerV2.fromPretrained(
+                s3TokenizerRepo,
                 hfToken: hfToken
             )
-            let s3WeightsURL = s3Dir.appendingPathComponent("model.safetensors")
-            if FileManager.default.fileExists(atPath: s3WeightsURL.path) {
-                let s3Tokenizer = S3TokenizerV2()
-                var s3Weights = try MLX.loadArrays(url: s3WeightsURL)
-                s3Weights = S3TokenizerV2.sanitize(weights: s3Weights, model: s3Tokenizer)
-                try s3Tokenizer.update(
-                    parameters: ModuleParameters.unflattened(s3Weights), verify: []
-                )
-                eval(s3Tokenizer)
-                model.s3Tokenizer = s3Tokenizer
-                print("[Chatterbox] Loaded S3TokenizerV2 from \(s3TokenizerRepo)")
-            }
+            print("[Chatterbox] Loaded S3TokenizerV2 from \(s3TokenizerRepo)")
         } catch {
             print("Warning: Could not load S3TokenizerV2: \(error)")
             print("  Voice cloning will fall back to default conditioning tokens.")

--- a/Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTS/MossTTSModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import HuggingFace
 @preconcurrency import MLX
+import MLXAudioCodecs
 import MLXAudioCore
 @preconcurrency import MLXLMCommon
 import MLXNN

--- a/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoModel.swift
+++ b/Sources/MLXAudioTTS/Models/MossTTSNano/MossTTSNanoModel.swift
@@ -1,14 +1,10 @@
 import Foundation
 import HuggingFace
 @preconcurrency import MLX
+import MLXAudioCodecs
 import MLXAudioCore
 @preconcurrency import MLXLMCommon
 import MLXNN
-
-public protocol MossAudioTokenizing: AnyObject {
-    func encodeAudio(_ audio: MLXArray, numQuantizers: Int) throws -> MLXArray
-    func decodeAudioCodes(_ audioTokenIDs: MLXArray, numQuantizers: Int) throws -> MLXArray
-}
 
 public final class MossTTSNanoModel: Module, SpeechGenerationModel, @unchecked Sendable {
     public let config: MossTTSNanoConfig

--- a/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSMimiAdapter.swift
+++ b/Sources/MLXAudioTTS/Models/PocketTTS/PocketTTSMimiAdapter.swift
@@ -21,10 +21,10 @@ private func pocketPadForConv1d(_ x: MLXArray, ksize: Int, stride: Int, paddingT
 }
 
 public final class DummyQuantizer: Module {
-    @ModuleInfo(key: "output_proj") public var output_proj: MLXAudioCodecs.Conv1d
+    @ModuleInfo(key: "output_proj") public var output_proj: MLXAudioCodecs.MimiConv1d
 
     public init(dimension: Int, outputDimension: Int) {
-        self._output_proj = ModuleInfo(wrappedValue: MLXAudioCodecs.Conv1d(
+        self._output_proj = ModuleInfo(wrappedValue: MLXAudioCodecs.MimiConv1d(
             inChannels: dimension,
             outChannels: outputDimension,
             ksize: 1,

--- a/Sources/MLXAudioVAD/Models/FSMNVAD/FSMNVAD.swift
+++ b/Sources/MLXAudioVAD/Models/FSMNVAD/FSMNVAD.swift
@@ -1,0 +1,965 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXNN
+
+public struct FSMNVADEncoderConfig: Codable, Sendable {
+    public var inputDim: Int
+    public var inputAffineDim: Int
+    public var fsmnLayers: Int
+    public var linearDim: Int
+    public var projDim: Int
+    public var lorder: Int
+    public var rorder: Int
+    public var lstride: Int
+    public var rstride: Int
+    public var outputAffineDim: Int
+    public var outputDim: Int
+
+    public init(
+        inputDim: Int = 400,
+        inputAffineDim: Int = 140,
+        fsmnLayers: Int = 4,
+        linearDim: Int = 250,
+        projDim: Int = 128,
+        lorder: Int = 20,
+        rorder: Int = 0,
+        lstride: Int = 1,
+        rstride: Int = 0,
+        outputAffineDim: Int = 140,
+        outputDim: Int = 248
+    ) {
+        self.inputDim = inputDim
+        self.inputAffineDim = inputAffineDim
+        self.fsmnLayers = fsmnLayers
+        self.linearDim = linearDim
+        self.projDim = projDim
+        self.lorder = lorder
+        self.rorder = rorder
+        self.lstride = lstride
+        self.rstride = rstride
+        self.outputAffineDim = outputAffineDim
+        self.outputDim = outputDim
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case inputDim = "input_dim"
+        case inputAffineDim = "input_affine_dim"
+        case fsmnLayers = "fsmn_layers"
+        case linearDim = "linear_dim"
+        case projDim = "proj_dim"
+        case lorder
+        case rorder
+        case lstride
+        case rstride
+        case outputAffineDim = "output_affine_dim"
+        case outputDim = "output_dim"
+    }
+}
+
+public struct FSMNVADConfig: Codable, Sendable {
+    public var modelType: String
+    public var architecture: String
+    public var encoder: FSMNVADEncoderConfig
+    public var sampleRate: Int
+    public var nMels: Int
+    public var frameLength: Int
+    public var frameShift: Int
+    public var lfrM: Int
+    public var lfrN: Int
+    public var maxEndSilenceTime: Int
+    public var maxStartSilenceTime: Int
+    public var windowSizeMs: Int
+    public var silToSpeechTimeThres: Int
+    public var speechToSilTimeThres: Int
+    public var speechNoiseThres: Float
+    public var silPdfIds: [Int]
+    public var frameInMs: Int
+
+    public init(
+        modelType: String = "fsmn",
+        architecture: String = "fsmn_vad",
+        encoder: FSMNVADEncoderConfig = FSMNVADEncoderConfig(),
+        sampleRate: Int = 16_000,
+        nMels: Int = 80,
+        frameLength: Int = 25,
+        frameShift: Int = 10,
+        lfrM: Int = 5,
+        lfrN: Int = 1,
+        maxEndSilenceTime: Int = 800,
+        maxStartSilenceTime: Int = 3_000,
+        windowSizeMs: Int = 200,
+        silToSpeechTimeThres: Int = 150,
+        speechToSilTimeThres: Int = 150,
+        speechNoiseThres: Float = 0.6,
+        silPdfIds: [Int] = [0],
+        frameInMs: Int = 10
+    ) {
+        self.modelType = modelType
+        self.architecture = architecture
+        self.encoder = encoder
+        self.sampleRate = sampleRate
+        self.nMels = nMels
+        self.frameLength = frameLength
+        self.frameShift = frameShift
+        self.lfrM = lfrM
+        self.lfrN = lfrN
+        self.maxEndSilenceTime = maxEndSilenceTime
+        self.maxStartSilenceTime = maxStartSilenceTime
+        self.windowSizeMs = windowSizeMs
+        self.silToSpeechTimeThres = silToSpeechTimeThres
+        self.speechToSilTimeThres = speechToSilTimeThres
+        self.speechNoiseThres = speechNoiseThres
+        self.silPdfIds = silPdfIds
+        self.frameInMs = frameInMs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architecture
+        case encoder
+        case sampleRate = "sample_rate"
+        case nMels = "n_mels"
+        case frameLength = "frame_length"
+        case frameShift = "frame_shift"
+        case lfrM = "lfr_m"
+        case lfrN = "lfr_n"
+        case maxEndSilenceTime = "max_end_silence_time"
+        case maxStartSilenceTime = "max_start_silence_time"
+        case windowSizeMs = "window_size_ms"
+        case silToSpeechTimeThres = "sil_to_speech_time_thres"
+        case speechToSilTimeThres = "speech_to_sil_time_thres"
+        case speechNoiseThres = "speech_noise_thres"
+        case silPdfIds = "sil_pdf_ids"
+        case frameInMs = "frame_in_ms"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "fsmn"
+        self.architecture = try container.decodeIfPresent(String.self, forKey: .architecture) ?? "fsmn_vad"
+        self.encoder = try container.decodeIfPresent(FSMNVADEncoderConfig.self, forKey: .encoder) ?? FSMNVADEncoderConfig()
+        self.sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 16_000
+        self.nMels = try container.decodeIfPresent(Int.self, forKey: .nMels) ?? 80
+        self.frameLength = try container.decodeIfPresent(Int.self, forKey: .frameLength) ?? 25
+        self.frameShift = try container.decodeIfPresent(Int.self, forKey: .frameShift) ?? 10
+        self.lfrM = try container.decodeIfPresent(Int.self, forKey: .lfrM) ?? 5
+        self.lfrN = try container.decodeIfPresent(Int.self, forKey: .lfrN) ?? 1
+        self.maxEndSilenceTime = try container.decodeIfPresent(Int.self, forKey: .maxEndSilenceTime) ?? 800
+        self.maxStartSilenceTime = try container.decodeIfPresent(Int.self, forKey: .maxStartSilenceTime) ?? 3_000
+        self.windowSizeMs = try container.decodeIfPresent(Int.self, forKey: .windowSizeMs) ?? 200
+        self.silToSpeechTimeThres = try container.decodeIfPresent(Int.self, forKey: .silToSpeechTimeThres) ?? 150
+        self.speechToSilTimeThres = try container.decodeIfPresent(Int.self, forKey: .speechToSilTimeThres) ?? 150
+        self.speechNoiseThres = try container.decodeIfPresent(Float.self, forKey: .speechNoiseThres) ?? 0.6
+        self.silPdfIds = try container.decodeIfPresent([Int].self, forKey: .silPdfIds) ?? [0]
+        self.frameInMs = try container.decodeIfPresent(Int.self, forKey: .frameInMs) ?? 10
+    }
+}
+
+private final class FSMNMemoryBlock: Module {
+    let padLeft: Int
+    @ModuleInfo(key: "conv_left") var convLeft: Conv1d
+
+    init(projDim: Int, lorder: Int, lstride: Int = 1) {
+        self.padLeft = (lorder - 1) * lstride
+        _convLeft.wrappedValue = Conv1d(
+            inputChannels: projDim,
+            outputChannels: projDim,
+            kernelSize: lorder,
+            stride: 1,
+            padding: 0,
+            groups: projDim,
+            bias: false
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let padded = MLX.concatenated([
+            MLXArray.zeros([x.dim(0), padLeft, x.dim(2)], dtype: x.dtype),
+            x,
+        ], axis: 1)
+        return x + convLeft(padded)
+    }
+}
+
+private final class FSMNLayer: Module {
+    @ModuleInfo var linear: Linear
+    @ModuleInfo(key: "fsmn_block") var fsmnBlock: FSMNMemoryBlock
+    @ModuleInfo var affine: Linear
+
+    init(linearDim: Int, projDim: Int, lorder: Int, lstride: Int = 1) {
+        _linear.wrappedValue = Linear(linearDim, projDim, bias: false)
+        _fsmnBlock.wrappedValue = FSMNMemoryBlock(projDim: projDim, lorder: lorder, lstride: lstride)
+        _affine.wrappedValue = Linear(projDim, linearDim)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        relu(affine(fsmnBlock(linear(x))))
+    }
+}
+
+public final class FSMNVADEncoder: Module {
+    public let config: FSMNVADEncoderConfig
+
+    @ModuleInfo(key: "in_linear1") var inLinear1: Linear
+    @ModuleInfo(key: "in_linear2") var inLinear2: Linear
+    @ModuleInfo fileprivate var fsmn: [FSMNLayer]
+    @ModuleInfo(key: "out_linear1") var outLinear1: Linear
+    @ModuleInfo(key: "out_linear2") var outLinear2: Linear
+
+    public init(config: FSMNVADEncoderConfig = FSMNVADEncoderConfig()) {
+        self.config = config
+        _inLinear1.wrappedValue = Linear(config.inputDim, config.inputAffineDim)
+        _inLinear2.wrappedValue = Linear(config.inputAffineDim, config.linearDim)
+        _fsmn.wrappedValue = (0..<config.fsmnLayers).map { _ in
+            FSMNLayer(
+                linearDim: config.linearDim,
+                projDim: config.projDim,
+                lorder: config.lorder,
+                lstride: config.lstride
+            )
+        }
+        _outLinear1.wrappedValue = Linear(config.linearDim, config.outputAffineDim)
+        _outLinear2.wrappedValue = Linear(config.outputAffineDim, config.outputDim)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var hidden = inLinear1(x)
+        hidden = relu(inLinear2(hidden))
+        for layer in fsmn {
+            hidden = layer(hidden)
+        }
+        hidden = outLinear1(hidden)
+        hidden = outLinear2(hidden)
+        return softmax(hidden, axis: -1)
+    }
+}
+
+private enum FSMNVADState {
+    case startPointNotDetected
+    case inSpeechSegment
+    case endPointDetected
+}
+
+private enum FSMNVADFrameState {
+    case invalid
+    case speech
+    case silence
+}
+
+private enum FSMNVADAudioChangeState {
+    case speechToSpeech
+    case speechToSilence
+    case silenceToSilence
+    case silenceToSpeech
+    case invalid
+}
+
+private final class FSMNVADSpeechBuffer {
+    var startMs = 0
+    var endMs = 0
+    var containSegStartPoint = false
+    var containSegEndPoint = false
+
+    func reset() {
+        startMs = 0
+        endMs = 0
+        containSegStartPoint = false
+        containSegEndPoint = false
+    }
+}
+
+private final class FSMNVADWindowDetector {
+    let winSizeFrame: Int
+    let silToSpeechFrameCountThreshold: Int
+    let speechToSilFrameCountThreshold: Int
+    var curWinPos = 0
+    var winSum = 0
+    var winState: [Int]
+    var previousFrameState: FSMNVADFrameState = .silence
+
+    init(windowSizeMs: Int, silToSpeechTime: Int, speechToSilTime: Int, frameSizeMs: Int) {
+        self.winSizeFrame = windowSizeMs / frameSizeMs
+        self.silToSpeechFrameCountThreshold = silToSpeechTime / frameSizeMs
+        self.speechToSilFrameCountThreshold = speechToSilTime / frameSizeMs
+        self.winState = Array(repeating: 0, count: max(winSizeFrame, 1))
+    }
+
+    func reset() {
+        curWinPos = 0
+        winSum = 0
+        winState = Array(repeating: 0, count: max(winSizeFrame, 1))
+        previousFrameState = .silence
+    }
+
+    func detectOneFrame(_ frameState: FSMNVADFrameState) -> FSMNVADAudioChangeState {
+        let current = frameState == .speech ? 1 : 0
+        winSum -= winState[curWinPos]
+        winSum += current
+        winState[curWinPos] = current
+        curWinPos = (curWinPos + 1) % winState.count
+
+        if previousFrameState == .silence && winSum >= silToSpeechFrameCountThreshold {
+            previousFrameState = .speech
+            return .silenceToSpeech
+        }
+        if previousFrameState == .speech && winSum <= speechToSilFrameCountThreshold {
+            previousFrameState = .silence
+            return .speechToSilence
+        }
+        if previousFrameState == .silence { return .silenceToSilence }
+        if previousFrameState == .speech { return .speechToSpeech }
+        return .invalid
+    }
+}
+
+private final class FSMNVADPostprocessStats {
+    var dataBufStartFrame = 0
+    var frameCount = 0
+    var latestConfirmedSpeechFrame = 0
+    var latestConfirmedSilenceFrame = -1
+    var continuousSilenceFrameCount = 0
+    var vadStateMachine: FSMNVADState = .startPointNotDetected
+    var confirmedStartFrame = -1
+    var confirmedEndFrame = -1
+    var numberEndTimeDetected = 0
+    var silFrame = 0
+    let silPdfIds: [Int]
+    var noiseAverageDecibel: Float = -100.0
+    var preEndSilenceDetected = false
+    var outputDataBuf: [FSMNVADSpeechBuffer] = []
+    var outputDataBufOffset = 0
+    let maxEndSilFrameCountThreshold: Int
+    let speechNoiseThreshold: Float
+    var scores: [[Float]] = []
+    var maxTimeOut = false
+    var decibel: [Float] = []
+    var dataBuf: [Float] = []
+    var dataBufAll: [Float] = []
+    var lastDropFrames = 0
+
+    init(silPdfIds: [Int], maxEndSilFrameCountThreshold: Int, speechNoiseThreshold: Float) {
+        self.silPdfIds = silPdfIds
+        self.maxEndSilFrameCountThreshold = maxEndSilFrameCountThreshold
+        self.speechNoiseThreshold = speechNoiseThreshold
+    }
+}
+
+private final class FSMNVADPostprocess {
+    let config: FSMNVADConfig
+    let windowDetector: FSMNVADWindowDetector
+    let stats: FSMNVADPostprocessStats
+
+    init(config: FSMNVADConfig) {
+        self.config = config
+        self.windowDetector = FSMNVADWindowDetector(
+            windowSizeMs: config.windowSizeMs,
+            silToSpeechTime: config.silToSpeechTimeThres,
+            speechToSilTime: config.speechToSilTimeThres,
+            frameSizeMs: config.frameInMs
+        )
+        self.stats = FSMNVADPostprocessStats(
+            silPdfIds: config.silPdfIds,
+            maxEndSilFrameCountThreshold: config.maxEndSilenceTime - config.speechToSilTimeThres,
+            speechNoiseThreshold: config.speechNoiseThres
+        )
+    }
+
+    private var frameShiftSamples: Int {
+        config.frameInMs * config.sampleRate / 1000
+    }
+
+    private func computeDecibel(_ waveform: [Float]) {
+        let frameSampleLength = config.frameLength * config.sampleRate / 1000
+        let shift = frameShiftSamples
+        if stats.dataBufAll.isEmpty {
+            stats.dataBufAll = waveform
+            stats.dataBuf = waveform
+        } else {
+            stats.dataBufAll.append(contentsOf: waveform)
+        }
+        guard waveform.count >= frameSampleLength else { return }
+        var start = 0
+        while start + frameSampleLength <= waveform.count {
+            var energy: Float = 0
+            for sample in waveform[start..<(start + frameSampleLength)] {
+                energy += sample * sample
+            }
+            stats.decibel.append(10.0 * log10(energy + 1e-6))
+            start += shift
+        }
+    }
+
+    private func computeScores(_ scores: [[Float]]) {
+        stats.frameCount += scores.count
+        stats.scores.append(contentsOf: scores)
+    }
+
+    private func latencyFrameCountAtStartPoint() -> Int {
+        var vadLatency = windowDetector.winSizeFrame
+        vadLatency += config.windowSizeMs / config.frameInMs
+        return vadLatency
+    }
+
+    private func popDataBufTillFrame(_ frameIndex: Int) {
+        while stats.dataBufStartFrame < frameIndex {
+            if stats.dataBuf.count >= frameShiftSamples {
+                stats.dataBufStartFrame += 1
+                let start = max(0, (stats.dataBufStartFrame - stats.lastDropFrames) * frameShiftSamples)
+                stats.dataBuf = start < stats.dataBufAll.count ? Array(stats.dataBufAll[start...]) : []
+            } else {
+                break
+            }
+        }
+    }
+
+    private func popDataToOutputBuffer(
+        startFrame: Int,
+        frameCount: Int,
+        firstFrameIsStartPoint: Bool,
+        lastFrameIsEndPoint: Bool
+    ) {
+        popDataBufTillFrame(startFrame)
+        if stats.outputDataBuf.isEmpty || firstFrameIsStartPoint {
+            let buffer = FSMNVADSpeechBuffer()
+            buffer.reset()
+            buffer.startMs = startFrame * config.frameInMs
+            buffer.endMs = buffer.startMs
+            stats.outputDataBuf.append(buffer)
+        }
+        guard let current = stats.outputDataBuf.last else { return }
+        stats.dataBufStartFrame += frameCount
+        current.endMs = (startFrame + frameCount) * config.frameInMs
+        if firstFrameIsStartPoint {
+            current.containSegStartPoint = true
+        }
+        if lastFrameIsEndPoint {
+            current.containSegEndPoint = true
+        }
+    }
+
+    private func onSilenceDetected(_ validFrame: Int) {
+        stats.latestConfirmedSilenceFrame = validFrame
+        if stats.vadStateMachine == .startPointNotDetected {
+            popDataBufTillFrame(validFrame)
+        }
+    }
+
+    private func onVoiceDetected(_ validFrame: Int) {
+        stats.latestConfirmedSpeechFrame = validFrame
+        popDataToOutputBuffer(
+            startFrame: validFrame,
+            frameCount: 1,
+            firstFrameIsStartPoint: false,
+            lastFrameIsEndPoint: false
+        )
+    }
+
+    private func onVoiceStart(_ startFrame: Int, fakeResult: Bool = false) {
+        if stats.confirmedStartFrame == -1 {
+            stats.confirmedStartFrame = startFrame
+        }
+        if !fakeResult && stats.vadStateMachine == .startPointNotDetected {
+            popDataToOutputBuffer(
+                startFrame: stats.confirmedStartFrame,
+                frameCount: 1,
+                firstFrameIsStartPoint: true,
+                lastFrameIsEndPoint: false
+            )
+        }
+    }
+
+    private func onVoiceEnd(_ endFrame: Int, fakeResult: Bool, isLastFrame: Bool) {
+        if stats.latestConfirmedSpeechFrame + 1 < endFrame {
+            for frame in (stats.latestConfirmedSpeechFrame + 1)..<endFrame {
+                onVoiceDetected(frame)
+            }
+        }
+        if stats.confirmedEndFrame == -1 {
+            stats.confirmedEndFrame = endFrame
+        }
+        if !fakeResult {
+            stats.silFrame = 0
+            popDataToOutputBuffer(
+                startFrame: stats.confirmedEndFrame,
+                frameCount: 1,
+                firstFrameIsStartPoint: false,
+                lastFrameIsEndPoint: true
+            )
+        }
+        stats.numberEndTimeDetected += 1
+        _ = isLastFrame
+    }
+
+    private func maybeOnVoiceEndIfLastFrame(_ isFinalFrame: Bool, currentFrameIndex: Int) {
+        if isFinalFrame {
+            onVoiceEnd(currentFrameIndex, fakeResult: false, isLastFrame: true)
+            stats.vadStateMachine = .endPointDetected
+        }
+    }
+
+    private func resetDetection() {
+        stats.continuousSilenceFrameCount = 0
+        stats.latestConfirmedSpeechFrame = 0
+        stats.latestConfirmedSilenceFrame = -1
+        stats.confirmedStartFrame = -1
+        stats.confirmedEndFrame = -1
+        stats.vadStateMachine = .startPointNotDetected
+        windowDetector.reset()
+        stats.silFrame = 0
+        if let last = stats.outputDataBuf.last, last.containSegEndPoint {
+            let dropFrames = last.endMs / config.frameInMs
+            let realDropFrames = dropFrames - stats.lastDropFrames
+            stats.lastDropFrames = dropFrames
+            let sampleDrop = realDropFrames * frameShiftSamples
+            stats.dataBufAll = sampleDrop < stats.dataBufAll.count ? Array(stats.dataBufAll[sampleDrop...]) : []
+            stats.decibel = realDropFrames < stats.decibel.count ? Array(stats.decibel[realDropFrames...]) : []
+            stats.scores = realDropFrames < stats.scores.count ? Array(stats.scores[realDropFrames...]) : []
+        }
+    }
+
+    private func frameState(at index: Int) -> FSMNVADFrameState {
+        if index < 0 || index >= stats.decibel.count || index >= stats.scores.count {
+            return .silence
+        }
+        let currentDecibel = stats.decibel[index]
+        let currentSNR = currentDecibel - stats.noiseAverageDecibel
+        if currentDecibel < -100.0 {
+            return .silence
+        }
+
+        var sumScore: Float = 0
+        var noiseProb: Float = log(1e-7)
+        if !stats.silPdfIds.isEmpty {
+            if stats.silPdfIds.count > 1 {
+                for id in stats.silPdfIds where id < stats.scores[index].count {
+                    sumScore += stats.scores[index][id]
+                }
+            } else if let id = stats.silPdfIds.first, id < stats.scores[index].count {
+                sumScore = stats.scores[index][id]
+            }
+            sumScore = max(min(sumScore, 1.0 - 1e-7), 1e-7)
+            noiseProb = log(sumScore)
+            sumScore = 1.0 - sumScore
+        }
+
+        let speechProb = log(sumScore)
+        if exp(speechProb) >= exp(noiseProb) + stats.speechNoiseThreshold {
+            if currentSNR >= -100.0 && currentDecibel >= -100.0 {
+                return .speech
+            }
+            return .silence
+        }
+
+        if stats.noiseAverageDecibel < -99.9 {
+            stats.noiseAverageDecibel = currentDecibel
+        } else {
+            stats.noiseAverageDecibel = (
+                currentDecibel + stats.noiseAverageDecibel * Float(100 - 1)
+            ) / Float(100)
+        }
+        return .silence
+    }
+
+    private func detectOneFrame(
+        _ currentFrameState: FSMNVADFrameState,
+        currentFrameIndex: Int,
+        isFinalFrame: Bool
+    ) {
+        let stateChange = windowDetector.detectOneFrame(currentFrameState == .speech ? .speech : .silence)
+        let frameShiftMs = config.frameInMs
+
+        switch stateChange {
+        case .silenceToSpeech:
+            stats.continuousSilenceFrameCount = 0
+            stats.preEndSilenceDetected = false
+            if stats.vadStateMachine == .startPointNotDetected {
+                let startFrame = max(
+                    stats.dataBufStartFrame,
+                    currentFrameIndex - latencyFrameCountAtStartPoint()
+                )
+                onVoiceStart(startFrame)
+                stats.vadStateMachine = .inSpeechSegment
+                if startFrame + 1 <= currentFrameIndex {
+                    for frame in (startFrame + 1)...currentFrameIndex {
+                        onVoiceDetected(frame)
+                    }
+                }
+            } else if stats.vadStateMachine == .inSpeechSegment {
+                if stats.latestConfirmedSpeechFrame + 1 < currentFrameIndex {
+                    for frame in (stats.latestConfirmedSpeechFrame + 1)..<currentFrameIndex {
+                        onVoiceDetected(frame)
+                    }
+                }
+                if currentFrameIndex - stats.confirmedStartFrame + 1 > 60_000 / frameShiftMs {
+                    onVoiceEnd(currentFrameIndex, fakeResult: false, isLastFrame: false)
+                    stats.vadStateMachine = .endPointDetected
+                } else if !isFinalFrame {
+                    onVoiceDetected(currentFrameIndex)
+                } else {
+                    maybeOnVoiceEndIfLastFrame(isFinalFrame, currentFrameIndex: currentFrameIndex)
+                }
+            }
+
+        case .speechToSilence:
+            stats.continuousSilenceFrameCount = 0
+            if stats.vadStateMachine == .inSpeechSegment {
+                if currentFrameIndex - stats.confirmedStartFrame + 1 > 60_000 / frameShiftMs {
+                    onVoiceEnd(currentFrameIndex, fakeResult: false, isLastFrame: false)
+                    stats.vadStateMachine = .endPointDetected
+                } else if !isFinalFrame {
+                    onVoiceDetected(currentFrameIndex)
+                } else {
+                    maybeOnVoiceEndIfLastFrame(isFinalFrame, currentFrameIndex: currentFrameIndex)
+                }
+            }
+
+        case .speechToSpeech:
+            stats.continuousSilenceFrameCount = 0
+            if stats.vadStateMachine == .inSpeechSegment {
+                if currentFrameIndex - stats.confirmedStartFrame + 1 > 60_000 / frameShiftMs {
+                    stats.maxTimeOut = true
+                    onVoiceEnd(currentFrameIndex, fakeResult: false, isLastFrame: false)
+                    stats.vadStateMachine = .endPointDetected
+                } else if !isFinalFrame {
+                    onVoiceDetected(currentFrameIndex)
+                } else {
+                    maybeOnVoiceEndIfLastFrame(isFinalFrame, currentFrameIndex: currentFrameIndex)
+                }
+            }
+
+        case .silenceToSilence:
+            stats.continuousSilenceFrameCount += 1
+            if stats.vadStateMachine == .startPointNotDetected {
+                if isFinalFrame && stats.numberEndTimeDetected == 0 {
+                    if stats.latestConfirmedSilenceFrame + 1 < currentFrameIndex {
+                        for frame in (stats.latestConfirmedSilenceFrame + 1)..<currentFrameIndex {
+                            onSilenceDetected(frame)
+                        }
+                    }
+                    onVoiceStart(0, fakeResult: true)
+                    onVoiceEnd(0, fakeResult: true, isLastFrame: false)
+                    stats.vadStateMachine = .endPointDetected
+                } else if currentFrameIndex >= latencyFrameCountAtStartPoint() {
+                    onSilenceDetected(currentFrameIndex - latencyFrameCountAtStartPoint())
+                }
+            } else if stats.vadStateMachine == .inSpeechSegment {
+                if stats.continuousSilenceFrameCount * frameShiftMs >= stats.maxEndSilFrameCountThreshold {
+                    var lookbackFrame = stats.maxEndSilFrameCountThreshold / frameShiftMs
+                    lookbackFrame -= config.windowSizeMs / frameShiftMs / 2
+                    lookbackFrame -= 1
+                    lookbackFrame = max(0, lookbackFrame)
+                    onVoiceEnd(currentFrameIndex - lookbackFrame, fakeResult: false, isLastFrame: false)
+                    stats.vadStateMachine = .endPointDetected
+                } else if currentFrameIndex - stats.confirmedStartFrame + 1 > 60_000 / frameShiftMs {
+                    onVoiceEnd(currentFrameIndex, fakeResult: false, isLastFrame: false)
+                    stats.vadStateMachine = .endPointDetected
+                } else if stats.continuousSilenceFrameCount <= config.windowSizeMs / frameShiftMs / 2 && !isFinalFrame {
+                    onVoiceDetected(currentFrameIndex)
+                } else {
+                    maybeOnVoiceEndIfLastFrame(isFinalFrame, currentFrameIndex: currentFrameIndex)
+                }
+            }
+
+        case .invalid:
+            break
+        }
+
+        if stats.vadStateMachine == .endPointDetected {
+            resetDetection()
+        }
+    }
+
+    private func detectLastFrames() {
+        if stats.vadStateMachine == .endPointDetected { return }
+        let blockSize = stats.scores.count
+        for i in stride(from: blockSize - 1, through: 0, by: -1) {
+            let frameIndex = stats.frameCount - 1 - i
+            let state = frameState(at: frameIndex - stats.lastDropFrames)
+            detectOneFrame(state, currentFrameIndex: frameIndex, isFinalFrame: i == 0)
+        }
+    }
+
+    func forward(scores: [[Float]], waveform: [Float]) -> [[Int]] {
+        computeDecibel(waveform)
+        computeScores(scores)
+        detectLastFrames()
+
+        var segments: [[Int]] = []
+        if !stats.outputDataBuf.isEmpty {
+            var index = stats.outputDataBufOffset
+            while index < stats.outputDataBuf.count {
+                let segment = stats.outputDataBuf[index]
+                stats.outputDataBufOffset += 1
+                segments.append([segment.startMs, segment.endMs])
+                index += 1
+            }
+        }
+        return segments
+    }
+}
+
+public final class FSMNVAD: Module {
+    public static let defaultRepository = "mlx-community/fsmn-vad"
+
+    public let config: FSMNVADConfig
+    private var cmvnShift: [Float]?
+    private var cmvnScale: [Float]?
+    @ModuleInfo public var encoder: FSMNVADEncoder
+
+    public init(config: FSMNVADConfig = FSMNVADConfig()) {
+        self.config = config
+        _encoder.wrappedValue = FSMNVADEncoder(config: config.encoder)
+    }
+
+    public func callAsFunction(_ features: MLXArray) -> MLXArray {
+        encoder(features)
+    }
+
+    public func extractFeatures(_ waveform: MLXArray, sampleRate: Int = 16_000) throws -> MLXArray {
+        var samples = waveform.asType(.float32).asArray(Float.self)
+        if sampleRate != config.sampleRate {
+            samples = try resampleAudio(samples, from: sampleRate, to: config.sampleRate)
+        }
+        let audio = MLXArray(samples) * Float(1 << 15)
+        let winLen = config.sampleRate * config.frameLength / 1000
+        let winInc = config.sampleRate * config.frameShift / 1000
+        let fbank = Self.computeKaldiFbank(
+            audio,
+            sampleRate: config.sampleRate,
+            winLen: winLen,
+            winInc: winInc,
+            numMels: config.nMels
+        )
+        var features = Self.applyLFR(fbank, lfrM: config.lfrM, lfrN: config.lfrN)
+        if let cmvnShift, let cmvnScale, cmvnShift.count == features.dim(1), cmvnScale.count == features.dim(1) {
+            features = (features + MLXArray(cmvnShift)) * MLXArray(cmvnScale)
+        }
+        return features
+    }
+
+    public func detect(_ waveform: MLXArray, sampleRate: Int = 16_000) throws -> [[Int]] {
+        var samples = waveform.asType(.float32).asArray(Float.self)
+        if sampleRate != config.sampleRate {
+            samples = try resampleAudio(samples, from: sampleRate, to: config.sampleRate)
+        }
+        let features = try extractFeatures(MLXArray(samples), sampleRate: config.sampleRate)
+        let scores = encoder(features.expandedDimensions(axis: 0))
+        eval(scores)
+        let values = scores.asArray(Float.self)
+        let time = scores.dim(1)
+        let dim = scores.dim(2)
+        var rows: [[Float]] = []
+        rows.reserveCapacity(time)
+        for t in 0..<time {
+            let start = t * dim
+            rows.append(Array(values[start..<(start + dim)]))
+        }
+        return FSMNVADPostprocess(config: config).forward(scores: rows, waveform: samples)
+    }
+
+    public static func fromPretrained(
+        _ repoId: String = defaultRepository,
+        hfToken: String? = nil,
+        cache: HubCache = .default
+    ) async throws -> FSMNVAD {
+        guard let repoID = Repo.ID(rawValue: repoId) else {
+            return try fromModelDirectory(URL(fileURLWithPath: NSString(string: repoId).expandingTildeInPath))
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: ".safetensors",
+            additionalMatchingPatterns: ["cmvn.json", "am.mvn"],
+            hfToken: hfToken,
+            cache: cache
+        )
+        return try fromModelDirectory(modelDir)
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) throws -> FSMNVAD {
+        let configURL = modelDir.appendingPathComponent("config.json")
+        let config = try JSONDecoder().decode(FSMNVADConfig.self, from: Data(contentsOf: configURL))
+        let model = FSMNVAD(config: config)
+        let weights = try loadArrays(url: modelDir.appendingPathComponent("model.safetensors"))
+        try model.encoder.update(parameters: ModuleParameters.unflattened(sanitizeEncoderWeights(weights)), verify: .all)
+        try model.loadCMVN(from: modelDir)
+        eval(model)
+        return model
+    }
+
+    private struct CMVNJSON: Decodable {
+        let shift: [Float]
+        let scale: [Float]
+    }
+
+    private func loadCMVN(from modelDir: URL) throws {
+        let cmvnURL = modelDir.appendingPathComponent("cmvn.json")
+        if FileManager.default.fileExists(atPath: cmvnURL.path) {
+            let cmvn = try JSONDecoder().decode(CMVNJSON.self, from: Data(contentsOf: cmvnURL))
+            cmvnShift = cmvn.shift
+            cmvnScale = cmvn.scale
+            return
+        }
+        let mvnURL = modelDir.appendingPathComponent("am.mvn")
+        if FileManager.default.fileExists(atPath: mvnURL.path) {
+            let parsed = try Self.parseKaldiCMVN(Data(contentsOf: mvnURL))
+            cmvnShift = parsed.shift
+            cmvnScale = parsed.scale
+        }
+    }
+
+    private static func sanitizeEncoderWeights(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var sanitized: [String: MLXArray] = [:]
+        for (key, value) in weights {
+            let newKey = key.hasPrefix("encoder.") ? String(key.dropFirst("encoder.".count)) : key
+            sanitized[newKey] = value
+        }
+        return sanitized
+    }
+
+    private static func computeKaldiFbank(
+        _ waveform: MLXArray,
+        sampleRate: Int,
+        winLen: Int,
+        winInc: Int,
+        numMels: Int
+    ) -> MLXArray {
+        let audioLength = waveform.dim(0)
+        guard audioLength >= winLen else {
+            return MLXArray.zeros([0, numMels], type: Float.self)
+        }
+        let numFrames = 1 + (audioLength - winLen) / winInc
+        var frames: [MLXArray] = []
+        frames.reserveCapacity(numFrames)
+        for frameIndex in 0..<numFrames {
+            let start = frameIndex * winInc
+            var frame = waveform[start..<(start + winLen)]
+            frame = frame - mean(frame)
+            if winLen > 1 {
+                let first = frame[0..<1]
+                let rest = frame[1..<winLen] - Float(0.97) * frame[0..<(winLen - 1)]
+                frame = concatenated([first, rest], axis: 0)
+            }
+            frames.append(frame)
+        }
+        var frameTensor = stacked(frames, axis: 0)
+        let nFft = nextPowerOfTwo(winLen)
+        frameTensor = frameTensor * hammingWindow(size: winLen, periodic: false)
+        if nFft > winLen {
+            frameTensor = concatenated([
+                frameTensor,
+                MLXArray.zeros([numFrames, nFft - winLen], type: Float.self),
+            ], axis: 1)
+        }
+        let spectrum = abs(MLXFFT.rfft(frameTensor, n: nFft, axis: 1)).square()
+        let melBank = kaldiMelFilterbank(
+            numBins: numMels,
+            nFft: nFft,
+            sampleRate: sampleRate,
+            lowFreq: 20.0,
+            highFreq: 0.0
+        )
+        return log(maximum(matmul(spectrum, melBank), MLXArray(Float(1e-8))))
+    }
+
+    private static func applyLFR(_ features: MLXArray, lfrM: Int, lfrN: Int) -> MLXArray {
+        let time = features.dim(0)
+        let dim = features.dim(1)
+        guard time > 0 else { return MLXArray.zeros([0, dim * lfrM], type: Float.self) }
+        let values = features.asArray(Float.self)
+        let leftPad = (lfrM - 1) / 2
+        let paddedTime = time + leftPad
+        let outputTime = (paddedTime + lfrN - 1) / lfrN
+        var output = Array(repeating: Float(0), count: outputTime * dim * lfrM)
+
+        func sourceFrame(_ index: Int, feature: Int) -> Float {
+            let sourceIndex: Int
+            if index < leftPad {
+                sourceIndex = 0
+            } else if index - leftPad < time {
+                sourceIndex = index - leftPad
+            } else {
+                sourceIndex = time - 1
+            }
+            return values[sourceIndex * dim + feature]
+        }
+
+        for outFrame in 0..<outputTime {
+            let start = outFrame * lfrN
+            for stackIndex in 0..<lfrM {
+                let frameIndex = start + stackIndex
+                for feature in 0..<dim {
+                    output[(outFrame * lfrM + stackIndex) * dim + feature] = sourceFrame(frameIndex, feature: feature)
+                }
+            }
+        }
+        return MLXArray(output, [outputTime, dim * lfrM])
+    }
+
+    private static func parseKaldiCMVN(_ data: Data) throws -> (shift: [Float], scale: [Float]) {
+        let text = String(decoding: data, as: UTF8.self)
+        func parseBlock(_ marker: String) -> [Float]? {
+            guard let markerRange = text.range(of: marker),
+                  let open = text[markerRange.upperBound...].firstIndex(of: "["),
+                  let close = text[open...].firstIndex(of: "]")
+            else { return nil }
+            return text[text.index(after: open)..<close]
+                .split { $0 == " " || $0 == "\n" || $0 == "\t" }
+                .compactMap { Float($0) }
+        }
+        guard let shift = parseBlock("<AddShift>"),
+              let scale = parseBlock("<Rescale>")
+        else {
+            throw NSError(
+                domain: "FSMNVAD",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not parse Kaldi CMVN data"]
+            )
+        }
+        return (shift, scale)
+    }
+
+    private static func kaldiMelFilterbank(
+        numBins: Int,
+        nFft: Int,
+        sampleRate: Int,
+        lowFreq: Float,
+        highFreq: Float
+    ) -> MLXArray {
+        let numFFTbins = nFft / 2
+        let nyquist = 0.5 * Float(sampleRate)
+        let high = highFreq <= 0 ? highFreq + nyquist : highFreq
+        let fftBinWidth = Float(sampleRate) / Float(nFft)
+        let melLow = kaldiMel(lowFreq)
+        let melHigh = kaldiMel(high)
+        let melDelta = (melHigh - melLow) / Float(numBins + 1)
+
+        var values = Array(repeating: Float(0), count: (numFFTbins + 1) * numBins)
+        for bin in 0..<numBins {
+            let leftMel = melLow + Float(bin) * melDelta
+            let centerMel = melLow + Float(bin + 1) * melDelta
+            let rightMel = melLow + Float(bin + 2) * melDelta
+            for fftBin in 0..<numFFTbins {
+                let mel = kaldiMel(fftBinWidth * Float(fftBin))
+                let upSlope = (mel - leftMel) / (centerMel - leftMel)
+                let downSlope = (rightMel - mel) / (rightMel - centerMel)
+                values[fftBin * numBins + bin] = max(0, min(upSlope, downSlope))
+            }
+        }
+        return MLXArray(values, [numFFTbins + 1, numBins])
+    }
+
+    private static func kaldiMel(_ frequency: Float) -> Float {
+        1127.0 * log(1.0 + frequency / 700.0)
+    }
+
+    private static func nextPowerOfTwo(_ value: Int) -> Int {
+        guard value > 1 else { return max(value, 1) }
+        var n = 1
+        while n < value {
+            n <<= 1
+        }
+        return n
+    }
+}

--- a/Tests/MLXAudioCodecsTests.swift
+++ b/Tests/MLXAudioCodecsTests.swift
@@ -79,6 +79,31 @@ struct SharedDSPTests {
     }
 }
 
+struct S3TokenizerTests {
+
+    @Test func smallConfigQuantizesMelToSpeechTokens() throws {
+        var config = S3TokenizerConfig()
+        config.nMels = 4
+        config.nAudioState = 16
+        config.nAudioHead = 4
+        config.nAudioLayer = 1
+        config.nCodebookSize = 6_561
+
+        let model = S3TokenizerV2(config: config)
+        let mel = MLXRandom.normal([1, config.nMels, 16])
+        let melLen = MLXArray([Int32(16)])
+
+        let (tokens, tokenLens) = model.quantize(mel, melLen: melLen)
+        eval(tokens, tokenLens)
+
+        #expect(tokens.shape == [1, 4])
+        #expect(tokenLens.asArray(Int32.self) == [4])
+
+        let values = tokens.asArray(Int32.self)
+        #expect(values.allSatisfy { $0 >= 0 && $0 < Int32(config.nCodebookSize) })
+    }
+}
+
 
 // MARK: - Vocos Tests
 // Run Vocos tests with:  xcodebuild test \
@@ -1010,6 +1035,56 @@ struct FishS1DACTests {
 
 @Suite("Codec Network Tests", .serialized)
 struct CodecNetworkTests {
+
+    @Test func s3TokenizerFromPretrainedMatchesPythonReferenceTokens() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("Skipping network S3Tokenizer test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_S3_TOKENIZER_REPO"] ?? S3TokenizerV2.defaultRepository
+        let model = try await S3TokenizerV2.fromPretrained(repo)
+        let audio = MLXArray((0..<16_000).map { Float(($0 % 97) - 48) / 480.0 })
+        let mel = s3TokenizerLogMelSpectrogram(audio)
+        let melLen = MLXArray([Int32(mel.dim(1))])
+
+        let (tokens, tokenLens) = model.quantize(mel.expandedDimensions(axis: 0), melLen: melLen)
+        eval(tokens, tokenLens)
+
+        let expectedTokens: [Int32] = [
+            365, 4252, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255,
+            4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255, 4255,
+            4254, 1092,
+        ]
+
+        #expect(tokenLens.asArray(Int32.self) == [Int32(expectedTokens.count)])
+        #expect(tokens[0, 0..<expectedTokens.count].asArray(Int32.self) == expectedTokens)
+    }
+
+    @Test func mossAudioTokenizerFromPretrainedMatchesPythonReferenceCodes() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("Skipping network Moss audio tokenizer test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_MOSS_AUDIO_TOKENIZER_REPO"] ?? mossDefaultAudioTokenizerRepo
+        let model = try await MLXMossAudioTokenizer.fromPretrained(repo)
+        let samples = (0..<3_840).flatMap { index -> [Float] in
+            [
+                Float((index % 97) - 48) / 960.0,
+                Float((index % 89) - 44) / 880.0,
+            ]
+        }
+        let audio = MLXArray(samples, [3_840, 2])
+
+        let codes = try model.encodeAudio(audio, numQuantizers: 4)
+        eval(codes)
+
+        #expect(codes.shape == [1, 4])
+        #expect(codes.asArray(Int32.self) == [364, 162, 461, 742])
+    }
 
     @Test func descriptDACFromPretrainedLoadsRealWeightsAndRoundTripsAudio() async throws {
         let env = ProcessInfo.processInfo.environment

--- a/Tests/MLXAudioCodecsTests.swift
+++ b/Tests/MLXAudioCodecsTests.swift
@@ -33,6 +33,7 @@
 
 import Testing
 import MLX
+import MLXNN
 import Foundation
 
 @testable import MLXAudioCore
@@ -49,6 +50,66 @@ private func loadCodecNetworkFixture(sampleRate: Int, maxSamples: Int) throws ->
     let (_, audio) = try loadAudioArray(from: audioURL, sampleRate: sampleRate)
     let sampleCount = min(audio.shape[0], maxSamples)
     return audio[0..<sampleCount]
+}
+
+struct MimiConvAdapterTests {
+
+    @Test func convAdaptersKeepFlatParameterKeys() throws {
+        let conv = MimiConv1d(inChannels: 3, outChannels: 4, ksize: 3, padding: 1)
+        let convKeys = Set(conv.parameters().flattened().map(\.0))
+        #expect(convKeys == ["weight", "bias"])
+
+        let y = conv(MLXArray.zeros([2, 3, 8]))
+        eval(y)
+        #expect(y.shape == [2, 4, 8])
+
+        try conv.update(
+            parameters: ModuleParameters.unflattened([
+                "weight": MLXArray.zeros(conv.weight.shape),
+                "bias": MLXArray.zeros(conv.bias!.shape),
+            ]),
+            verify: .all
+        )
+        let zeroed = conv(MLXArray.ones([2, 3, 8]))
+        eval(zeroed)
+        #expect(MLX.max(MLX.abs(zeroed)).item(Float.self) == 0)
+
+        let convtr = MimiConvTransposed1d(
+            inChannels: 3,
+            outChannels: 3,
+            ksize: 4,
+            stride: 2,
+            groups: 3
+        )
+        let convtrKeys = Set(convtr.parameters().flattened().map(\.0))
+        #expect(convtrKeys == ["weight", "bias"])
+
+        let upsampled = convtr(MLXArray.zeros([2, 3, 5]))
+        eval(upsampled)
+        #expect(upsampled.shape == [2, 3, 12])
+    }
+
+    @Test func normWrappersKeepExistingCheckpointNesting() throws {
+        let conv = NormConv1d(inChannels: 3, outChannels: 4, ksize: 3)
+        let convKeys = Set(conv.parameters().flattened().map(\.0))
+        #expect(convKeys.contains("conv.weight"))
+        #expect(convKeys.contains("conv.bias"))
+        #expect(!convKeys.contains("conv.conv.weight"))
+
+        try conv.update(
+            parameters: ModuleParameters.unflattened([
+                "conv.weight": MLXArray.zeros(conv.conv.weight.shape),
+                "conv.bias": MLXArray.zeros(conv.conv.bias!.shape),
+            ]),
+            verify: .all
+        )
+
+        let convtr = NormConvTranspose1d(inChannels: 3, outChannels: 3, ksize: 4, groups: 3)
+        let convtrKeys = Set(convtr.parameters().flattened().map(\.0))
+        #expect(convtrKeys.contains("convtr.weight"))
+        #expect(convtrKeys.contains("convtr.bias"))
+        #expect(!convtrKeys.contains("convtr.conv.weight"))
+    }
 }
 
 struct SharedDSPTests {
@@ -101,6 +162,200 @@ struct S3TokenizerTests {
 
         let values = tokens.asArray(Int32.self)
         #expect(values.allSatisfy { $0 >= 0 && $0 < Int32(config.nCodebookSize) })
+    }
+}
+
+struct HiggsAudioTokenizerTests {
+
+    @Test func configDefaultsAndDecodeShape() throws {
+        let config = HiggsAudioTokenizerConfig()
+        #expect(config.sampleRate == 24_000)
+        #expect(config.codebookSize == 1_024)
+        #expect(config.codebookDim == 64)
+        #expect(config.dacNumCodebooks == 8)
+        #expect(config.dacEncoderRatios == [8, 5, 4, 2, 3])
+
+        let model = HiggsAudioTokenizer(config: config)
+        let tokens = MLXArray(Array(repeating: Int32(0), count: 8), [1, 8])
+        let waveform = model.decode(tokens)
+        eval(waveform)
+
+        #expect(waveform.shape == [960])
+    }
+
+    @Test func sanitizerMapsBundledCheckpointWeights() {
+        let prefix = HiggsAudioTokenizer.defaultCodecPrefix
+        let raw: [String: MLXArray] = [
+            "\(prefix)quantizer.quantizers.0.codebook.embed": MLXRandom.normal([4, 2]),
+            "\(prefix)quantizer.quantizers.0.codebook.embed_avg": MLXRandom.normal([4, 2]),
+            "\(prefix)acoustic_decoder.block.0.conv_t1.weight": MLXRandom.normal([3, 4, 5]),
+            "\(prefix)acoustic_encoder.conv1.weight": MLXRandom.normal([6, 2, 3]),
+            "\(prefix)acoustic_decoder.snake1.alpha": MLXRandom.normal([1, 2, 1]),
+            "\(prefix)semantic_model.encoder.pos_conv.weight": MLXRandom.normal([3, 2, 5]),
+        ]
+
+        let sanitized = HiggsAudioTokenizer.sanitize(weights: raw, prefix: prefix)
+
+        #expect(sanitized["quantizer.quantizers.0.codebook.weight"]?.shape == [4, 2])
+        #expect(sanitized["quantizer.quantizers.0.codebook.embed_avg"] == nil)
+        #expect(sanitized["acoustic_decoder.block.0.conv_t1.weight"]?.shape == [4, 5, 3])
+        #expect(sanitized["acoustic_encoder.conv1.weight"]?.shape == [6, 3, 2])
+        #expect(sanitized["acoustic_decoder.snake1.alpha"]?.shape == [1, 1, 2])
+        #expect(sanitized["semantic_model.encoder.pos_conv.weight"] == nil)
+    }
+
+    @Test func fromExtractedCheckpointMatchesPythonReferenceDecode() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let modelPath = env["MLXAUDIO_HIGGS_AUDIO_CODEC_DIR"], !modelPath.isEmpty else {
+            print("Skipping Higgs audio tokenizer parity test. Set MLXAUDIO_HIGGS_AUDIO_CODEC_DIR to an extracted tokenizer directory.")
+            return
+        }
+
+        let expandedPath = NSString(string: modelPath).expandingTildeInPath
+        let model = try HiggsAudioTokenizer.fromModelDirectory(URL(fileURLWithPath: expandedPath))
+        let tokens = MLXArray((0..<16).map { Int32($0) }, [2, 8])
+        let waveform = model.decode(tokens)
+        eval(waveform)
+
+        let expectedFirst16: [Float] = [
+            -0.0014731525, -0.0012872171, -0.0006351388, -0.0010763766,
+            -0.0013186398, -0.00085378025, 0.00090220413, 0.001662272,
+            0.0026287395, 0.0033317907, 0.0018368699, 0.0017412195,
+            0.0050528753, 0.0084180925, 0.0085247, 0.006915033,
+        ]
+        let actualFirst16 = waveform[0..<16].asArray(Float.self)
+
+        #expect(waveform.shape == [1_920])
+        for (actual, expected) in zip(actualFirst16, expectedFirst16) {
+            #expect(abs(actual - expected) < 1e-4)
+        }
+
+        let mean = MLX.mean(waveform).item(Float.self)
+        let absMean = MLX.mean(MLX.abs(waveform)).item(Float.self)
+        let minValue = MLX.min(waveform).item(Float.self)
+        let maxValue = MLX.max(waveform).item(Float.self)
+        #expect(abs(mean - -0.00023663044) < 1e-4)
+        #expect(abs(absMean - 0.018707583) < 1e-4)
+        #expect(abs(minValue - -0.10222458) < 2e-4)
+        #expect(abs(maxValue - 0.05652249) < 2e-4)
+    }
+}
+
+struct StepAudio2Token2WavTests {
+
+    @Test func fromLocalWeightsMatchesPythonReference() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let modelPath = env["MLXAUDIO_STEPAUDIO2_DIR"], !modelPath.isEmpty else {
+            print("Skipping StepAudio2 parity test. Set MLXAUDIO_STEPAUDIO2_DIR to a local Step-Audio-2-token2wav directory.")
+            return
+        }
+
+        let expandedPath = NSString(string: modelPath).expandingTildeInPath
+        let model = try StepAudio2Token2Wav.fromModelDirectory(URL(fileURLWithPath: expandedPath))
+        let speechTokens = MLXArray([Int32(11), Int32(22)], [1, 2])
+        let promptToken = MLXArray([Int32(3), Int32(4)], [1, 2])
+        let promptTokenLen = MLXArray([Int32(2)])
+        let promptValues = (0..<(1 * 4 * 80)).map { Float(($0 % 17) - 8) / 200.0 }
+        let promptFeat = MLXArray(promptValues, [1, 4, 80])
+        let promptFeatLen = MLXArray([Int32(4)])
+        let embeddingValues = (0..<192).map { Float(($0 % 19) - 9) / 50.0 }
+        let embedding = MLXArray(embeddingValues, [1, 192])
+        let prompt = StepAudio2Prompt(
+            promptToken: promptToken,
+            promptTokenLen: promptTokenLen,
+            promptFeat: promptFeat,
+            promptFeatLen: promptFeatLen,
+            embedding: embedding
+        )
+
+        let mel = try model.decodeToMel(speechTokens, prompt: prompt, nTimesteps: 1)
+        eval(mel)
+
+        let expectedMelFirst16: [Float] = [
+            -5.4603024, -5.7961235, -5.953307, -5.4654946,
+            -5.4765887, -5.585214, -5.3559914, -4.6866426,
+            -1.3002429, -1.2458072, -1.4626238, -1.6580737,
+            -0.8557438, -1.4504211, -1.9609354, -2.5217037,
+        ]
+        let actualMelFirst16 = mel.reshaped([-1])[0..<16].asArray(Float.self)
+        #expect(mel.shape == [1, 80, 4])
+        for (actual, expected) in zip(actualMelFirst16, expectedMelFirst16) {
+            #expect(abs(actual - expected) < 1.2e-2)
+        }
+
+        let melMean = MLX.mean(mel).item(Float.self)
+        let melAbsMean = MLX.mean(MLX.abs(mel)).item(Float.self)
+        let melMin = MLX.min(mel).item(Float.self)
+        let melMax = MLX.max(mel).item(Float.self)
+        #expect(abs(melMean - -5.3294158) < 8e-3)
+        #expect(abs(melAbsMean - 5.3294158) < 8e-3)
+        #expect(abs(melMin - -8.932683) < 1e-2)
+        #expect(abs(melMax - -0.8557438) < 3e-3)
+
+        MLXRandom.seed(42)
+        let waveform = model.vocode(mel)
+        eval(waveform)
+
+        let expectedFirst16: [Float] = [
+            0.017583441, 0.014671039, 0.010786231, 0.007566597,
+            0.0047792904, 0.0016860055, -0.002296098, -0.005033145,
+            -0.004722653, -0.0017132716, 0.0027768025, 0.008602597,
+            0.014388927, 0.01985283, 0.022311501, 0.019210702,
+        ]
+        let actualFirst16 = waveform.reshaped([-1])[0..<16].asArray(Float.self)
+
+        #expect(waveform.shape == [1, 1_920])
+        for (actual, expected) in zip(actualFirst16, expectedFirst16) {
+            #expect(abs(actual - expected) < 6e-4)
+        }
+
+        let mean = MLX.mean(waveform).item(Float.self)
+        let absMean = MLX.mean(MLX.abs(waveform)).item(Float.self)
+        let minValue = MLX.min(waveform).item(Float.self)
+        let maxValue = MLX.max(waveform).item(Float.self)
+        #expect(abs(mean - -0.00004073924) < 5e-5)
+        #expect(abs(absMean - 0.0040236986) < 1e-4)
+        #expect(abs(minValue - -0.03442881) < 5e-4)
+        #expect(abs(maxValue - 0.03196751) < 5e-4)
+    }
+
+    @Test func vocoderMatchesPythonReferenceWithSeededSource() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let modelPath = env["MLXAUDIO_STEPAUDIO2_DIR"], !modelPath.isEmpty else {
+            print("Skipping StepAudio2 vocoder parity test. Set MLXAUDIO_STEPAUDIO2_DIR to a local Step-Audio-2-token2wav directory.")
+            return
+        }
+
+        let expandedPath = NSString(string: modelPath).expandingTildeInPath
+        let model = try StepAudio2Token2Wav.fromModelDirectory(URL(fileURLWithPath: expandedPath))
+        let melValues = (0..<(1 * 80 * 4)).map { Float(($0 % 31) - 15) / 10.0 }
+        let mel = MLXArray(melValues, [1, 80, 4])
+
+        MLXRandom.seed(42)
+        let waveform = model.vocode(mel)
+        eval(waveform)
+
+        let expectedFirst16: [Float] = [
+            -0.069332026, -0.14232807, -0.33608523, -0.29552692,
+            -0.09244516, 0.15974744, 0.25917616, 0.2368055,
+            0.23517483, 0.20596091, 0.17615812, 0.23605251,
+            0.19910856, 0.18924898, 0.044373818, -0.021684408,
+        ]
+        let actualFirst16 = waveform.reshaped([-1])[0..<16].asArray(Float.self)
+
+        #expect(waveform.shape == [1, 1_920])
+        for (actual, expected) in zip(actualFirst16, expectedFirst16) {
+            #expect(abs(actual - expected) < 3e-3)
+        }
+
+        let mean = MLX.mean(waveform).item(Float.self)
+        let absMean = MLX.mean(MLX.abs(waveform)).item(Float.self)
+        let minValue = MLX.min(waveform).item(Float.self)
+        let maxValue = MLX.max(waveform).item(Float.self)
+        #expect(abs(mean - 0.015998093) < 5e-4)
+        #expect(abs(absMean - 0.37149265) < 3e-3)
+        #expect(abs(minValue - -0.99) < 1e-5)
+        #expect(abs(maxValue - 0.99) < 1e-5)
     }
 }
 

--- a/Tests/MLXAudioVADTests.swift
+++ b/Tests/MLXAudioVADTests.swift
@@ -45,6 +45,113 @@ import MLXNN
 
 // MARK: - Configuration Tests
 
+struct FSMNVADTests {
+
+    @Test func encoderConfigDefaultsAndShapeSmoke() throws {
+        var encoderConfig = FSMNVADEncoderConfig()
+        encoderConfig.inputDim = 8
+        encoderConfig.inputAffineDim = 6
+        encoderConfig.fsmnLayers = 2
+        encoderConfig.linearDim = 10
+        encoderConfig.projDim = 4
+        encoderConfig.lorder = 3
+        encoderConfig.outputAffineDim = 5
+        encoderConfig.outputDim = 7
+
+        let model = FSMNVADEncoder(config: encoderConfig)
+        let features = MLXRandom.normal([1, 6, encoderConfig.inputDim])
+        let scores = model(features)
+        eval(scores)
+
+        #expect(scores.shape == [1, 6, encoderConfig.outputDim])
+        let rowSums = scores.sum(axis: -1).asArray(Float.self)
+        #expect(rowSums.allSatisfy { abs($0 - 1.0) < 1e-5 })
+    }
+}
+
+struct FSMNVADNetworkTests {
+
+    @Test func fromPretrainedMatchesPythonReferenceScores() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("Skipping network FSMN VAD test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_FSMNVAD_REPO"] ?? FSMNVAD.defaultRepository
+        let model = try await FSMNVAD.fromPretrained(repo)
+        let values = (0..<(6 * 400)).map { Float(($0 % 101) - 50) / 50.0 }
+        let features = MLXArray(values, [1, 6, 400])
+        let scores = model(features)
+        eval(scores)
+
+        #expect(scores.shape == [1, 6, 248])
+        #expect(argMax(scores, axis: -1).asArray(Int32.self) == [42, 42, 42, 42, 0, 0])
+
+        let row0 = scores[0, 0, 0..<12].asArray(Float.self)
+        let expectedRow0: [Float] = [
+            0.1140450165, 0.0059785182, 0.0013659892, 0.0000232112,
+            0.0003191938, 0.0002223742, 0.0006398718, 0.0002070427,
+            0.0014147682, 0.0009946637, 0.0675965324, 0.0000362443,
+        ]
+        for (actual, expected) in zip(row0, expectedRow0) {
+            #expect(abs(actual - expected) < 1e-3)
+        }
+
+        let row3 = scores[0, 3, 0..<12].asArray(Float.self)
+        let expectedRow3: [Float] = [
+            0.1232639179, 0.0030032848, 0.0003252966, 0.0000322826,
+            0.0000923602, 0.0000542990, 0.0001371839, 0.0000965531,
+            0.0010185738, 0.0003324346, 0.0428580716, 0.0000095264,
+        ]
+        for (actual, expected) in zip(row3, expectedRow3) {
+            #expect(abs(actual - expected) < 1e-3)
+        }
+    }
+
+    @Test func fromPretrainedExtractsFeaturesAndDetectsLikePythonReference() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MLXAUDIO_ENABLE_NETWORK_TESTS"] == "1" else {
+            print("Skipping network FSMN VAD test. Set MLXAUDIO_ENABLE_NETWORK_TESTS=1 to enable.")
+            return
+        }
+
+        let repo = env["MLXAUDIO_FSMNVAD_REPO"] ?? FSMNVAD.defaultRepository
+        let model = try await FSMNVAD.fromPretrained(repo)
+        let waveform = MLXArray((0..<16_000).map { Float(($0 % 97) - 48) / 96.0 })
+        let features = try model.extractFeatures(waveform, sampleRate: 16_000)
+        eval(features)
+
+        #expect(features.shape == [100, 400])
+
+        let first = features[0, 0..<8].asArray(Float.self)
+        let expectedFirst: [Float] = [
+            1.0393178463, 0.6021140814, 0.9425991178, 1.4960573912,
+            1.5817567110, 1.5437985659, 1.3930199146, 0.9451034665,
+        ]
+        for (actual, expected) in zip(first, expectedFirst) {
+            #expect(abs(actual - expected) < 1e-3)
+        }
+
+        let last = features[99, 392..<400].asArray(Float.self)
+        let expectedLast: [Float] = [
+            1.3597297668, 1.3523129225, 1.3584715128, 1.3944844007,
+            1.4115253687, 1.4911217690, 1.5815925598, 1.7701300383,
+        ]
+        for (actual, expected) in zip(last, expectedLast) {
+            #expect(abs(actual - expected) < 1e-3)
+        }
+
+        let segments = try model.detect(waveform, sampleRate: 16_000)
+        #expect(segments == [])
+
+        let audioURL = Bundle.module.url(forResource: "intention", withExtension: "wav", subdirectory: "media")!
+        let (_, speechAudio) = try loadAudioArray(from: audioURL, sampleRate: 16_000)
+        let speechSegments = try model.detect(speechAudio, sampleRate: 16_000)
+        #expect(speechSegments == [[0, 1_520]])
+    }
+}
+
 struct SortformerConfigTests {
 
     @Test func fcEncoderConfigDefaults() throws {


### PR DESCRIPTION
This adds the remaining codecs that we're currently missing from `mlx-audio`, so we can work towards 1-to-1 parity between the python and swift repos.