### PR TITLE
OmniVoice: emit per-step denoise progress through generateStream

### DIFF
--- a/Examples/VoicesApp/VoicesApp/ViewModels/TTSViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/TTSViewModel.swift
@@ -453,6 +453,14 @@ class TTSViewModel {
                                 generationProgress = "Generated \(chunkTokenCount) tokens..."
                             }
                         }
+                    case .progress(let fraction):
+                        // Diffusion models report exact step progress instead of tokens.
+                        let percent = Int((fraction * 100).rounded())
+                        if chunks.count > 1 {
+                            generationProgress = "Chunk \(index + 1)/\(chunks.count): \(percent)%"
+                        } else {
+                            generationProgress = "Generating... \(percent)%"
+                        }
                     case .info(let info):
                         tokensPerSecond = info.tokensPerSecond
                     case .audio(let audioData):

--- a/Sources/MLXAudioCore/Generation/GenerationTypes.swift
+++ b/Sources/MLXAudioCore/Generation/GenerationTypes.swift
@@ -54,6 +54,10 @@ public enum AudioGeneration: Sendable {
     case info(AudioGenerationInfo)
     /// Final generated audio
     case audio(MLXArray)
+    /// Fractional progress through generation (0-1). Emitted by models with a
+    /// deterministic step count (e.g. diffusion denoise steps), where the
+    /// fraction is exact rather than an estimate.
+    case progress(Double)
 }
 
 // MARK: - Generation Errors

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -257,7 +257,10 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
                     refAudio: refAudio,
                     refText: refText,
                     language: language,
-                    ovParameters: ovParams
+                    ovParameters: ovParams,
+                    onStepProgress: { done, total in
+                        continuation.yield(.progress(Double(done) / Double(total)))
+                    }
                 )
                 let info = AudioGenerationInfo(
                     promptTokenCount: 0,
@@ -285,7 +288,8 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         refAudio: MLXArray?,
         refText: String?,
         language: String?,
-        ovParameters: OmniVoiceGenerateParameters
+        ovParameters: OmniVoiceGenerateParameters,
+        onStepProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> MLXArray {
         guard let audioTok = audioTokenizer else {
             throw AudioGenerationError.modelNotInitialized("Audio tokenizer not loaded")
@@ -369,7 +373,12 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         // 7. Iterative diffusion generation
         for step in 0..<numSteps {
             let k = schedule[step]
-            if k <= 0 { continue }
+            if k <= 0 {
+                // Nothing left to unmask this step — still report it so
+                // progress always reaches numSteps/numSteps.
+                onStepProgress?(step + 1, numSteps)
+                continue
+            }
 
             // Separate forward passes for cond and uncond (bidirectional attention)
             let condLogits = forward(
@@ -436,6 +445,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             uncondInputIds = tokens  // uncond is just the target region
 
             eval(inputIds, uncondInputIds, tokens)
+            onStepProgress?(step + 1, numSteps)
         }
 
         // Safeguard: fill any remaining mask tokens with a final deterministic prediction

--- a/Sources/Tools/mlx-audio-swift-tts/App.swift
+++ b/Sources/Tools/mlx-audio-swift-tts/App.swift
@@ -144,7 +144,7 @@ enum App {
 
             for try await event in stream {
                 switch event {
-                case .token:
+                case .token, .progress:
                     break
                 case .info(let info):
                     generationInfo = info

--- a/Tests/MLXAudioSmokeTests.swift
+++ b/Tests/MLXAudioSmokeTests.swift
@@ -225,6 +225,8 @@ struct TTSSmokeTests {
             case .audio(let audio):
                 finalAudio = audio
                 print("\u{001B}[32mReceived final audio: \(audio.shape)\u{001B}[0m")
+            case .progress(_):
+                break
             }
         }
 
@@ -312,6 +314,8 @@ struct TTSSmokeTests {
             case .audio(let audio):
                 finalAudio = audio
                 print("\u{001B}[32mReceived final audio: \(audio.shape)\u{001B}[0m")
+            case .progress(_):
+                break
             }
         }
 
@@ -421,6 +425,8 @@ struct TTSSmokeTests {
             case .audio(let audio):
                 finalAudio = audio
                 print("\u{001B}[32mReceived final audio: \(audio.shape)\u{001B}[0m")
+            case .progress(_):
+                break
             }
         }
 
@@ -494,7 +500,7 @@ struct TTSSmokeTests {
             case .info(let info):
                 generationInfo = info
                 print("\u{001B}[36mGeneration info: generateTime=\(info.generateTime)s\u{001B}[0m")
-            case .token(_):
+            case .token(_), .progress(_):
                 break
             }
         }
@@ -585,7 +591,7 @@ struct TTSSmokeTests {
                 print("\u{001B}[32mReceived audio chunk: \(audio.shape)\u{001B}[0m")
             case .info(let info):
                 print("\u{001B}[36mGeneration info: \(String(format: "%.2f", info.generateTime))s\u{001B}[0m")
-            case .token(_):
+            case .token(_), .progress(_):
                 break
             }
         }

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -701,6 +701,8 @@ private func collectQwen3TTSStream(
             infoCount += 1
         case .audio(let audio):
             lastAudio = audio
+        case .progress:
+            break
         }
     }
 

--- a/Tests/OmniVoiceTests.swift
+++ b/Tests/OmniVoiceTests.swift
@@ -397,6 +397,7 @@ struct OmniVoiceModelTests {
 
         var totalSamples = 0
         var chunkCount = 0
+        var progressFractions: [Double] = []
         let startTime = CFAbsoluteTimeGetCurrent()
 
         for try await event in model.generateStream(
@@ -420,13 +421,27 @@ struct OmniVoiceModelTests {
                 let samples = chunk.asArray(Float.self)
                 totalSamples += samples.count
                 print("Received audio chunk: \(samples.count) samples (total: \(totalSamples))")
+            case .progress(let fraction):
+                progressFractions.append(fraction)
             }
         }
 
         let elapsed = CFAbsoluteTimeGetCurrent() - startTime
         print("Streaming completed: \(totalSamples) samples in \(String(format: "%.2f", elapsed))s")
+        print("Received \(progressFractions.count) progress events")
 
         #expect(totalSamples > 0, "Should have received audio samples")
+
+        // OmniVoice's denoise loop has a deterministic step count, so progress is
+        // exact: monotonically increasing and always arriving at 1.0.
+        #expect(!progressFractions.isEmpty, "Should have received progress events")
+        #expect(
+            zip(progressFractions, progressFractions.dropFirst()).allSatisfy { $0 < $1 },
+            "Progress should increase monotonically, got \(progressFractions)"
+        )
+        if let last = progressFractions.last {
+            #expect(abs(last - 1.0) < 1e-6, "Progress should reach 1.0, got \(last)")
+        }
 
         // Save streamed audio
         if totalSamples > 0 {


### PR DESCRIPTION
## Summary

OmniVoice generates NAR-diffusion audio in one shot, so `generateStream` consumers currently get **no signal until the final `.audio` event** — for a 30s utterance that's ~30s of silence with no way to render progress. Unlike AR models, though, OmniVoice's denoise loop has a **deterministic step count**, so exact (not estimated) progress is available for free.

This PR surfaces it:

- `AudioGeneration` gains a `case progress(Double)` (fraction 0–1), documented as exact-step progress for models with deterministic step counts.
- `OmniVoiceModel.generateAudio` takes an optional `onStepProgress: (@Sendable (Int, Int) -> Void)?` and invokes it after each denoise step (post-`eval`, so the step's compute is actually done when the event fires).
- The streaming `generateStream(…, streamingInterval:)` overload yields `.progress(done/total)` through the existing continuation.

## Compatibility

- Additive enum case: `proxyAudioStream` / `generateSamplesStream` filter with `guard case .audio` and are unaffected; the one exhaustive switch in-tree (`Sources/Tools/mlx-audio-swift-tts/App.swift`) is updated.
- `generateAudio`'s new parameter is defaulted; the non-streaming `generate` paths are unchanged.
- No behavior change for any other model family.

## Testing

- `swift build --target mlx-audio-swift-tts` clean.
- Ran the package CLI (`--benchmark` streaming path) against `mlx-community/OmniVoice-bf16` with a temporary print on `.progress`: exactly 32 events per generation, monotonic `0.03125 → 1.0`, including generations where trailing schedule steps have an empty unmask quota (those emit too, so the fraction always reaches 1.0). Audio output unchanged.

Happy to also thread progress through other diffusion-style models (Irodori's flow matching, etc.) in a follow-up if this shape looks right.
