### PR TITLE
Improve Voices STT controls and MOSS streaming

### DIFF
--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -35,6 +35,8 @@ struct STTView: View {
                             Spacer()
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if viewModel.transcriptionText.isEmpty && viewModel.isRecording {
+                        RecordingTranscriptPlaceholder(supportsRealtime: viewModel.supportsRealtimeRecording)
                     } else {
                         Text(viewModel.transcriptionText)
                             .font(bodyFont)
@@ -59,7 +61,9 @@ struct STTView: View {
             if viewModel.isRecording {
                 RecordingIndicator(
                     duration: viewModel.recordingDuration,
-                    audioLevel: viewModel.audioLevel
+                    audioLevel: viewModel.audioLevel,
+                    supportsRealtime: viewModel.supportsRealtimeRecording,
+                    isRealtime: viewModel.usesRealtimeRecording
                 )
                 .padding(.horizontal)
                 .padding(.bottom, 4)
@@ -385,38 +389,160 @@ struct STTView: View {
 
 // MARK: - Recording Indicator
 
-private struct RecordingIndicator: View {
-    let duration: TimeInterval
-    let audioLevel: Float
-
-    @State private var isPulsing = false
+private struct RecordingTranscriptPlaceholder: View {
+    let supportsRealtime: Bool
 
     var body: some View {
-        HStack(spacing: 10) {
-            // Pulsing red dot
-            Circle()
-                .fill(Color.red)
-                .frame(width: 10, height: 10)
-                .scaleEffect(isPulsing ? 1.3 : 1.0)
-                .opacity(isPulsing ? 0.7 : 1.0)
-                .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: isPulsing)
-                .onAppear { isPulsing = true }
+        VStack(spacing: 8) {
+            Spacer(minLength: 80)
 
-            // Duration
-            Text(formatDuration(duration))
-                .font(.caption)
-                .monospacedDigit()
+            Image(systemName: supportsRealtime ? "text.bubble.fill" : "waveform.circle.fill")
+                .font(.system(size: 40, weight: .medium))
+                .foregroundStyle(.tertiary)
+
+            Text(supportsRealtime ? "Listening..." : "Recording...")
+                .font(.headline)
                 .foregroundStyle(.secondary)
+
+            Text(supportsRealtime ? "Realtime prediction will appear here" : "Starting realtime preview")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
 
             Spacer()
         }
-        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+private struct RecordingIndicator: View {
+    let duration: TimeInterval
+    let audioLevel: Float
+    let supportsRealtime: Bool
+    let isRealtime: Bool
+
+    private let barCount = 28
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(Color.red.opacity(0.14))
+                    .frame(width: 34, height: 34)
+
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.red)
+                    .symbolEffect(.pulse, options: .repeating, value: duration)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(isRealtime ? "Live" : "Recording")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text(supportsRealtime ? "Realtime preview" : "Starting...")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(minWidth: 88, alignment: .leading)
+
+            TimelineView(.animation) { timeline in
+                let phase = timeline.date.timeIntervalSinceReferenceDate * 5.8
+                let level = max(0, min(CGFloat(audioLevel), 1))
+
+                HStack(alignment: .center, spacing: 3) {
+                    ForEach(0..<barCount, id: \.self) { index in
+                        let position = CGFloat(index) / CGFloat(max(barCount - 1, 1))
+                        let ripple = abs(sin(phase + Double(index) * 0.47))
+                        let envelope = 0.35 + 0.65 * sin(position * .pi)
+                        let idleLift = 0.10 + 0.10 * CGFloat(ripple)
+                        let reactiveLift = level * CGFloat(0.35 + 0.65 * ripple) * envelope
+                        let height = 8 + (idleLift + reactiveLift) * 34
+
+                        Capsule()
+                            .fill(barGradient(at: position))
+                            .frame(width: 4, height: height)
+                            .shadow(color: Color.red.opacity(0.22 * (idleLift + reactiveLift)), radius: 6)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .animation(.easeOut(duration: 0.12), value: audioLevel)
+            }
+
+            Spacer()
+
+            Text(formatDuration(duration))
+                .font(.caption.monospacedDigit().weight(.medium))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 42, alignment: .trailing)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.red.opacity(0.07))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.red.opacity(0.16), lineWidth: 1)
+        }
+    }
+
+    private func barGradient(at position: CGFloat) -> LinearGradient {
+        let leading = Color(red: 1.0, green: 0.23, blue: 0.30)
+        let center = Color(red: 1.0, green: 0.42, blue: 0.58)
+        let trailing = Color(red: 0.72, green: 0.33, blue: 1.0)
+        let color = position < 0.5
+            ? leading.mix(with: center, by: position * 2)
+            : center.mix(with: trailing, by: (position - 0.5) * 2)
+
+        return LinearGradient(
+            colors: [color.opacity(0.65), color, color.opacity(0.75)],
+            startPoint: .bottom,
+            endPoint: .top
+        )
     }
 
     private func formatDuration(_ duration: TimeInterval) -> String {
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
         return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+private extension Color {
+    func mix(with other: Color, by amount: CGFloat) -> Color {
+        #if os(iOS)
+        let first = UIColor(self)
+        let second = UIColor(other)
+        #else
+        let first = NSColor(self)
+        let second = NSColor(other)
+        #endif
+
+        var red1: CGFloat = 0
+        var green1: CGFloat = 0
+        var blue1: CGFloat = 0
+        var alpha1: CGFloat = 0
+        var red2: CGFloat = 0
+        var green2: CGFloat = 0
+        var blue2: CGFloat = 0
+        var alpha2: CGFloat = 0
+
+        first.getRed(&red1, green: &green1, blue: &blue1, alpha: &alpha1)
+        second.getRed(&red2, green: &green2, blue: &blue2, alpha: &alpha2)
+
+        let clampedAmount = max(0, min(amount, 1))
+        return Color(
+            red: red1 + (red2 - red1) * clampedAmount,
+            green: green1 + (green2 - green1) * clampedAmount,
+            blue: blue1 + (blue2 - blue1) * clampedAmount,
+            opacity: alpha1 + (alpha2 - alpha1) * clampedAmount
+        )
     }
 }
 

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -6,6 +6,7 @@ struct STTView: View {
     @State private var viewModel = STTViewModel()
     @State private var showFileImporter = false
     @State private var showSettings = false
+    @State private var isAudioHovering = false
 
     #if os(iOS)
     private let buttonHeight: CGFloat = 44
@@ -71,17 +72,19 @@ struct STTView: View {
                     if let fileName = viewModel.audioFileName {
                         HStack(spacing: 6) {
                             Image(systemName: "doc.fill")
-                                .font(.caption)
+                                .font(.footnote)
                                 .foregroundStyle(.secondary)
                             Text(fileName)
-                                .font(.caption)
+                                .font(.footnote)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                             Spacer()
                             Button(action: { viewModel.removeAudioFile() }) {
                                 Image(systemName: "xmark.circle.fill")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .font(.system(size: 18, weight: .semibold))
+                                    .foregroundStyle(isAudioHovering ? Color.red : Color.secondary)
+                                    .frame(width: 28, height: 28)
+                                    .contentShape(Circle())
                             }
                             .buttonStyle(.plain)
                             .disabled(viewModel.isGenerating)
@@ -89,6 +92,7 @@ struct STTView: View {
                             .help("Remove audio")
                         }
                         .padding(.horizontal)
+                        .padding(.top, 6)
                     }
 
                     // Audio player
@@ -101,6 +105,16 @@ struct STTView: View {
                     )
                     .padding(.horizontal)
                 }
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isAudioHovering ? Color.gray.opacity(0.12) : Color.clear)
+                        .padding(.horizontal, 8)
+                )
+                .contentShape(Rectangle())
+                .onHover { hovering in
+                    isAudioHovering = hovering
+                }
+                .animation(.easeOut(duration: 0.12), value: isAudioHovering)
                 .padding(.bottom, 4)
             }
 

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -243,8 +243,8 @@ struct STTView: View {
                         }
                     }
 
-                    // Stats after generation
-                    if !viewModel.isGenerating && viewModel.tokensPerSecond > 0 {
+                    // Stats
+                    if viewModel.tokensPerSecond > 0 {
                         HStack(spacing: 8) {
                             Label(
                                 String(format: "%.1f tok/s", viewModel.tokensPerSecond),

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -201,7 +201,7 @@ struct STTView: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .disabled(!viewModel.isModelLoaded)
+                .disabled(!viewModel.canRecord)
 
                 if !viewModel.isRecording {
                     // Settings button

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -78,6 +78,15 @@ struct STTView: View {
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                             Spacer()
+                            Button(action: { viewModel.removeAudioFile() }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(viewModel.isGenerating)
+                            .accessibilityLabel("Remove audio")
+                            .help("Remove audio")
                         }
                         .padding(.horizontal)
                     }
@@ -203,6 +212,20 @@ struct STTView: View {
                                 .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
+
+                        if !viewModel.isGenerating {
+                            Button(action: { viewModel.clearTranscription() }) {
+                                Image(systemName: "trash")
+                                    .font(buttonFont)
+                                    .foregroundStyle(.red)
+                                    .frame(width: buttonHeight, height: buttonHeight)
+                                    .background(Color.gray.opacity(0.2))
+                                    .clipShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Clear transcription")
+                            .help("Clear transcription")
+                        }
                     }
 
                     // Stats after generation

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import Foundation
 
 struct STTView: View {
     @Environment(\.scenePhase) private var scenePhase
@@ -38,11 +39,7 @@ struct STTView: View {
                     } else if viewModel.transcriptionText.isEmpty && viewModel.isRecording {
                         RecordingTranscriptPlaceholder(supportsRealtime: viewModel.supportsRealtimeRecording)
                     } else {
-                        Text(viewModel.transcriptionText)
-                            .font(bodyFont)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding()
+                        TranscriptOutputView(text: viewModel.transcriptionText, font: bodyFont)
 
                         Color.clear
                             .frame(height: 1)
@@ -384,6 +381,177 @@ struct STTView: View {
 
     private var canTranscribe: Bool {
         viewModel.selectedAudioURL != nil && !viewModel.isGenerating && viewModel.isModelLoaded
+    }
+}
+
+// MARK: - Transcript Output
+
+private struct TranscriptOutputView: View {
+    let text: String
+    let font: Font
+
+    private var segments: [TaggedTranscriptSegment] {
+        TaggedTranscriptParser.parse(text)
+    }
+
+    var body: some View {
+        if segments.isEmpty {
+            Text(text)
+                .font(font)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        } else {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(segments) { segment in
+                    TaggedTranscriptSegmentRow(segment: segment, font: font)
+                }
+            }
+            .padding()
+            .textSelection(.enabled)
+        }
+    }
+}
+
+private struct TaggedTranscriptSegmentRow: View {
+    let segment: TaggedTranscriptSegment
+    let font: Font
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(segment.speaker)
+                    .font(.caption.monospaced().weight(.semibold))
+                    .foregroundStyle(speakerColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(speakerColor.opacity(0.14))
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                Text(segment.formattedTimeRange)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: 0)
+            }
+
+            Text(segment.text)
+                .font(font)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.035))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(speakerColor.opacity(0.14), lineWidth: 1)
+        }
+    }
+
+    private var speakerColor: Color {
+        let palette: [Color] = [
+            .blue,
+            .green,
+            .orange,
+            .purple,
+            .pink,
+            .teal,
+        ]
+        let number = Int(segment.speaker.drop { !$0.isNumber }) ?? 1
+        return palette[(max(number, 1) - 1) % palette.count]
+    }
+}
+
+private struct TaggedTranscriptSegment: Identifiable {
+    let id: Int
+    let speaker: String
+    let startTime: String
+    let endTime: String?
+    let text: String
+
+    var formattedTimeRange: String {
+        if let endTime {
+            return "\(Self.formatTimestamp(startTime)) - \(Self.formatTimestamp(endTime))"
+        }
+        return Self.formatTimestamp(startTime)
+    }
+
+    private static func formatTimestamp(_ rawValue: String) -> String {
+        guard let totalSeconds = Double(rawValue) else { return rawValue }
+
+        let minutes = Int(totalSeconds) / 60
+        let seconds = totalSeconds - Double(minutes * 60)
+        return String(format: "%d:%05.2f", minutes, seconds)
+    }
+}
+
+private enum TaggedTranscriptParser {
+    private static let startTagRegex = try! NSRegularExpression(
+        pattern: #"\[(\d+(?:\.\d+)?)\]\[(S\d{1,3})\]"#,
+        options: [.caseInsensitive]
+    )
+    private static let trailingTimestampRegex = try! NSRegularExpression(
+        pattern: #"\[(\d+(?:\.\d+)?)\]\s*$"#,
+        options: []
+    )
+
+    static func parse(_ text: String) -> [TaggedTranscriptSegment] {
+        let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = startTagRegex.matches(in: text, range: fullRange)
+        guard !matches.isEmpty else { return [] }
+
+        return matches.enumerated().compactMap { index, match in
+            guard
+                let matchRange = Range(match.range, in: text),
+                let startRange = Range(match.range(at: 1), in: text),
+                let speakerRange = Range(match.range(at: 2), in: text)
+            else {
+                return nil
+            }
+
+            let bodyEnd: String.Index
+            if index + 1 < matches.count,
+               let nextRange = Range(matches[index + 1].range, in: text) {
+                bodyEnd = nextRange.lowerBound
+            } else {
+                bodyEnd = text.endIndex
+            }
+
+            var segmentText = String(text[matchRange.upperBound..<bodyEnd])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let endTime = stripTrailingTimestamp(from: &segmentText)
+
+            guard !segmentText.isEmpty else { return nil }
+
+            return TaggedTranscriptSegment(
+                id: index,
+                speaker: String(text[speakerRange]).uppercased(),
+                startTime: String(text[startRange]),
+                endTime: endTime,
+                text: segmentText
+            )
+        }
+    }
+
+    private static func stripTrailingTimestamp(from text: inout String) -> String? {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard
+            let match = trailingTimestampRegex.firstMatch(in: text, range: range),
+            let timestampRange = Range(match.range(at: 1), in: text),
+            let fullMatchRange = Range(match.range, in: text)
+        else {
+            return nil
+        }
+
+        let timestamp = String(text[timestampRange])
+        text.removeSubrange(fullMatchRange)
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return timestamp
     }
 }
 

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -20,6 +20,11 @@ struct STTView: View {
     #endif
 
     var body: some View {
+        let transcriptSegments = TaggedTranscriptParser.parse(viewModel.transcriptionText)
+        let activeTranscriptSegmentID = viewModel.isPlaying
+            ? TaggedTranscriptParser.activeSegmentID(in: transcriptSegments, at: viewModel.currentTime)
+            : nil
+
         VStack(spacing: 0) {
             // Transcription result area
             ScrollViewReader { proxy in
@@ -39,7 +44,12 @@ struct STTView: View {
                     } else if viewModel.transcriptionText.isEmpty && viewModel.isRecording {
                         RecordingTranscriptPlaceholder(supportsRealtime: viewModel.supportsRealtimeRecording)
                     } else {
-                        TranscriptOutputView(text: viewModel.transcriptionText, font: bodyFont)
+                        TranscriptOutputView(
+                            text: viewModel.transcriptionText,
+                            font: bodyFont,
+                            segments: transcriptSegments,
+                            activeSegmentID: activeTranscriptSegmentID
+                        )
 
                         Color.clear
                             .frame(height: 1)
@@ -49,6 +59,12 @@ struct STTView: View {
                 .onChange(of: viewModel.transcriptionText) {
                     withAnimation(.easeOut(duration: 0.15)) {
                         proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: activeTranscriptSegmentID) { _, segmentID in
+                    guard viewModel.isPlaying, let segmentID else { return }
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        proxy.scrollTo(segmentID, anchor: .center)
                     }
                 }
             }
@@ -389,10 +405,8 @@ struct STTView: View {
 private struct TranscriptOutputView: View {
     let text: String
     let font: Font
-
-    private var segments: [TaggedTranscriptSegment] {
-        TaggedTranscriptParser.parse(text)
-    }
+    let segments: [TaggedTranscriptSegment]
+    let activeSegmentID: TaggedTranscriptSegment.ID?
 
     var body: some View {
         if segments.isEmpty {
@@ -404,7 +418,12 @@ private struct TranscriptOutputView: View {
         } else {
             LazyVStack(alignment: .leading, spacing: 8) {
                 ForEach(segments) { segment in
-                    TaggedTranscriptSegmentRow(segment: segment, font: font)
+                    TaggedTranscriptSegmentRow(
+                        segment: segment,
+                        font: font,
+                        isActive: segment.id == activeSegmentID
+                    )
+                    .id(segment.id)
                 }
             }
             .padding()
@@ -416,41 +435,51 @@ private struct TranscriptOutputView: View {
 private struct TaggedTranscriptSegmentRow: View {
     let segment: TaggedTranscriptSegment
     let font: Font
+    let isActive: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Text(segment.speaker)
-                    .font(.caption.monospaced().weight(.semibold))
-                    .foregroundStyle(speakerColor)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(speakerColor.opacity(0.14))
-                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        HStack(alignment: .top, spacing: 10) {
+            Capsule()
+                .fill(speakerColor)
+                .frame(width: 4)
+                .padding(.vertical, 2)
+                .opacity(isActive ? 1 : 0)
 
-                Text(segment.formattedTimeRange)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Text(segment.speaker)
+                        .font(.caption.monospaced().weight(.semibold))
+                        .foregroundStyle(speakerColor)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(speakerColor.opacity(isActive ? 0.22 : 0.14))
+                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
 
-                Spacer(minLength: 0)
+                    Text(segment.formattedTimeRange)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(isActive ? .primary : .secondary)
+
+                    Spacer(minLength: 0)
+                }
+
+                Text(segment.text)
+                    .font(font)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-
-            Text(segment.text)
-                .font(font)
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.035))
+                .fill(isActive ? speakerColor.opacity(0.12) : Color.primary.opacity(0.035))
         )
         .overlay {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(speakerColor.opacity(0.14), lineWidth: 1)
+                .stroke(speakerColor.opacity(isActive ? 0.6 : 0.14), lineWidth: isActive ? 1.5 : 1)
         }
+        .animation(.easeOut(duration: 0.16), value: isActive)
     }
 
     private var speakerColor: Color {
@@ -471,7 +500,9 @@ private struct TaggedTranscriptSegment: Identifiable {
     let id: Int
     let speaker: String
     let startTime: String
+    let startSeconds: TimeInterval
     let endTime: String?
+    let endSeconds: TimeInterval?
     let text: String
 
     var formattedTimeRange: String {
@@ -494,7 +525,7 @@ private struct TaggedTranscriptSegment: Identifiable {
         )
     }
 
-    private static func timestampValue(_ text: String) -> Double? {
+    static func timestampValue(_ text: String) -> Double? {
         Double(text.replacingOccurrences(of: ",", with: "."))
     }
 }
@@ -518,7 +549,8 @@ private enum TaggedTranscriptParser {
             guard
                 let matchRange = Range(match.range, in: text),
                 let startRange = Range(match.range(at: 1), in: text),
-                let speakerRange = Range(match.range(at: 2), in: text)
+                let speakerRange = Range(match.range(at: 2), in: text),
+                let startSeconds = TaggedTranscriptSegment.timestampValue(String(text[startRange]))
             else {
                 return nil
             }
@@ -534,6 +566,7 @@ private enum TaggedTranscriptParser {
             var segmentText = String(text[matchRange.upperBound..<bodyEnd])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let endTime = stripTrailingTimestamp(from: &segmentText)
+            let endSeconds = endTime.flatMap(TaggedTranscriptSegment.timestampValue)
 
             guard !segmentText.isEmpty else { return nil }
 
@@ -541,10 +574,29 @@ private enum TaggedTranscriptParser {
                 id: index,
                 speaker: String(text[speakerRange]).uppercased(),
                 startTime: String(text[startRange]),
+                startSeconds: startSeconds,
                 endTime: endTime,
+                endSeconds: endSeconds,
                 text: segmentText
             )
         }
+    }
+
+    static func activeSegmentID(in segments: [TaggedTranscriptSegment], at time: TimeInterval) -> TaggedTranscriptSegment.ID? {
+        for (index, segment) in segments.enumerated() {
+            let nextStart = index + 1 < segments.count ? segments[index + 1].startSeconds : nil
+            let end = segment.endSeconds ?? nextStart
+
+            if let end {
+                if time >= segment.startSeconds && time < max(end, segment.startSeconds) {
+                    return segment.id
+                }
+            } else if time >= segment.startSeconds {
+                return segment.id
+            }
+        }
+
+        return nil
     }
 
     private static func stripTrailingTimestamp(from text: inout String) -> String? {

--- a/Examples/VoicesApp/VoicesApp/STTView.swift
+++ b/Examples/VoicesApp/VoicesApp/STTView.swift
@@ -482,21 +482,30 @@ private struct TaggedTranscriptSegment: Identifiable {
     }
 
     private static func formatTimestamp(_ rawValue: String) -> String {
-        guard let totalSeconds = Double(rawValue) else { return rawValue }
+        guard let totalSeconds = timestampValue(rawValue) else { return rawValue }
 
         let minutes = Int(totalSeconds) / 60
         let seconds = totalSeconds - Double(minutes * 60)
-        return String(format: "%d:%05.2f", minutes, seconds)
+        return String(
+            format: "%d:%05.2f",
+            locale: Locale(identifier: "en_US_POSIX"),
+            minutes,
+            seconds
+        )
+    }
+
+    private static func timestampValue(_ text: String) -> Double? {
+        Double(text.replacingOccurrences(of: ",", with: "."))
     }
 }
 
 private enum TaggedTranscriptParser {
     private static let startTagRegex = try! NSRegularExpression(
-        pattern: #"\[(\d+(?:\.\d+)?)\]\[(S\d{1,3})\]"#,
+        pattern: #"\[(\d+(?:[\.,]\d+)?)\]\[(S\d{1,3})\]"#,
         options: [.caseInsensitive]
     )
     private static let trailingTimestampRegex = try! NSRegularExpression(
-        pattern: #"\[(\d+(?:\.\d+)?)\]\s*$"#,
+        pattern: #"\[(\d+(?:[\.,]\d+)?)\]\s*$"#,
         options: []
     )
 
@@ -539,19 +548,22 @@ private enum TaggedTranscriptParser {
     }
 
     private static func stripTrailingTimestamp(from text: inout String) -> String? {
-        let range = NSRange(text.startIndex..<text.endIndex, in: text)
-        guard
-            let match = trailingTimestampRegex.firstMatch(in: text, range: range),
-            let timestampRange = Range(match.range(at: 1), in: text),
-            let fullMatchRange = Range(match.range, in: text)
-        else {
-            return nil
-        }
+        var lastTimestamp: String?
 
-        let timestamp = String(text[timestampRange])
-        text.removeSubrange(fullMatchRange)
-        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return timestamp
+        while true {
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            guard
+                let match = trailingTimestampRegex.firstMatch(in: text, range: range),
+                let timestampRange = Range(match.range(at: 1), in: text),
+                let fullMatchRange = Range(match.range, in: text)
+            else {
+                return lastTimestamp
+            }
+
+            lastTimestamp = String(text[timestampRange])
+            text.removeSubrange(fullMatchRange)
+            text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 }
 

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STSViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STSViewModel.swift
@@ -20,7 +20,11 @@ import AppKit
 @Observable
 class STSViewModel {
     private static let defaultModelId = "mlx-community/sam-audio-base"
+    private static let defaultSeparationDescription = "speech"
+    private static let defaultUseResidual = false
     private static let modelIdStorageKey = "VoicesApp.STSViewModel.modelId"
+    private static let separationDescriptionStorageKey = "VoicesApp.STSViewModel.separationDescription"
+    private static let useResidualStorageKey = "VoicesApp.STSViewModel.useResidual"
 
     var isLoading = false
     var isGenerating = false
@@ -29,10 +33,20 @@ class STSViewModel {
     var audioURL: URL?
 
     // What to isolate. "speech", "music", "drums", etc.
-    var separationDescription: String = "speech"
+    var separationDescription: String = UserDefaults.standard.string(forKey: STSViewModel.separationDescriptionStorageKey) ?? STSViewModel.defaultSeparationDescription {
+        didSet {
+            UserDefaults.standard.set(separationDescription, forKey: STSViewModel.separationDescriptionStorageKey)
+        }
+    }
 
     // Whether to play the residual (everything *except* the target) instead
-    var useResidual: Bool = false
+    var useResidual: Bool = UserDefaults.standard.object(forKey: STSViewModel.useResidualStorageKey).map { _ in
+        UserDefaults.standard.bool(forKey: STSViewModel.useResidualStorageKey)
+    } ?? STSViewModel.defaultUseResidual {
+        didSet {
+            UserDefaults.standard.set(useResidual, forKey: STSViewModel.useResidualStorageKey)
+        }
+    }
 
     // Model config
     var modelId: String = UserDefaults.standard.string(forKey: STSViewModel.modelIdStorageKey) ?? STSViewModel.defaultModelId {
@@ -103,6 +117,16 @@ class STSViewModel {
         loadedModelId = nil
         Memory.clearCache()
         await loadModel()
+    }
+
+    func resetSettingsToDefaults() {
+        modelId = STSViewModel.defaultModelId
+        separationDescription = STSViewModel.defaultSeparationDescription
+        useResidual = STSViewModel.defaultUseResidual
+
+        UserDefaults.standard.removeObject(forKey: STSViewModel.modelIdStorageKey)
+        UserDefaults.standard.removeObject(forKey: STSViewModel.separationDescriptionStorageKey)
+        UserDefaults.standard.removeObject(forKey: STSViewModel.useResidualStorageKey)
     }
 
     // MARK: - Separation

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STSViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STSViewModel.swift
@@ -19,6 +19,9 @@ import AppKit
 @MainActor
 @Observable
 class STSViewModel {
+    private static let defaultModelId = "mlx-community/sam-audio-base"
+    private static let modelIdStorageKey = "VoicesApp.STSViewModel.modelId"
+
     var isLoading = false
     var isGenerating = false
     var generationProgress: String = ""
@@ -32,7 +35,11 @@ class STSViewModel {
     var useResidual: Bool = false
 
     // Model config
-    var modelId: String = "mlx-community/sam-audio-base"
+    var modelId: String = UserDefaults.standard.string(forKey: STSViewModel.modelIdStorageKey) ?? STSViewModel.defaultModelId {
+        didSet {
+            UserDefaults.standard.set(modelId, forKey: STSViewModel.modelIdStorageKey)
+        }
+    }
     private var loadedModelId: String?
 
     // Audio player state (manually synced from AudioPlayer via Combine)

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -458,40 +458,7 @@ class STTViewModel {
     }
 
     private func loadSTTModel(_ repo: String) async throws -> any STTGenerationModel {
-        let lower = repo.lowercased()
-
-        if lower.contains("glmasr") || lower.contains("glm-asr") {
-            return try await GLMASRModel.fromPretrained(repo)
-        }
-        if lower.contains("qwen3-asr") || lower.contains("qwen3_asr") {
-            return try await Qwen3ASRModel.fromPretrained(repo)
-        }
-        if lower.contains("voxtral") {
-            return try await VoxtralRealtimeModel.fromPretrained(repo)
-        }
-        if lower.contains("cohere") {
-            return try await CohereTranscribeModel.fromPretrained(repo)
-        }
-        if lower.contains("parakeet") {
-            return try await ParakeetModel.fromPretrained(repo)
-        }
-        if lower.contains("firered") || lower.contains("fire-red") {
-            return try await FireRedASR2Model.fromPretrained(repo)
-        }
-        if lower.contains("sensevoice") {
-            return try await SenseVoiceModel.fromPretrained(repo)
-        }
-        if lower.contains("granite") {
-            return try await GraniteSpeechModel.fromPretrained(repo)
-        }
-
-        throw NSError(
-            domain: "STT",
-            code: 5,
-            userInfo: [
-                NSLocalizedDescriptionKey: "Unsupported STT model repo: \(repo)"
-            ]
-        )
+        try await STT.loadModel(modelRepo: repo)
     }
 
     func play() {

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -75,6 +75,11 @@ class STTViewModel {
     }
     private var loadedModelId: String?
 
+    private var languageHint: String? {
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     // Audio file
     var selectedAudioURL: URL?
     var audioFileName: String?
@@ -305,7 +310,7 @@ class STTViewModel {
             topP: defaultParameters.topP,
             topK: defaultParameters.topK,
             verbose: false,
-            language: language.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : language,
+            language: languageHint,
             chunkDuration: chunkDuration,
             minChunkDuration: defaultParameters.minChunkDuration,
             repetitionPenalty: defaultParameters.repetitionPenalty,
@@ -350,7 +355,7 @@ class STTViewModel {
             decodeIntervalSeconds: 1.0,
             maxCachedWindows: 60,
             delayPreset: .custom(ms: streamingDelayMs),
-            language: language,
+            language: languageHint,
             temperature: temperature,
             maxTokensPerPass: maxTokens
         )

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -9,6 +9,9 @@ import Combine
 @MainActor
 @Observable
 class STTViewModel {
+    private static let defaultModelId = "mlx-community/Qwen3-ASR-0.6B-4bit"
+    private static let modelIdStorageKey = "VoicesApp.STTViewModel.modelId"
+
     var isLoading = false
     var isGenerating = false
     var generationProgress: String = ""
@@ -27,7 +30,11 @@ class STTViewModel {
     var streamingDelayMs: Int = 480  // .agent default
 
     // Model configuration
-    var modelId: String = "mlx-community/Qwen3-ASR-0.6B-4bit"
+    var modelId: String = UserDefaults.standard.string(forKey: STTViewModel.modelIdStorageKey) ?? STTViewModel.defaultModelId {
+        didSet {
+            UserDefaults.standard.set(modelId, forKey: STTViewModel.modelIdStorageKey)
+        }
+    }
     private var loadedModelId: String?
 
     // Audio file
@@ -44,7 +51,8 @@ class STTViewModel {
     var recordingDuration: TimeInterval { recorder.recordingDuration }
     var audioLevel: Float { recorder.audioLevel }
 
-    private var model: Qwen3ASRModel?
+    private var model: (any STTGenerationModel)?
+    private var streamingModel: Qwen3ASRModel?
     private let audioPlayer = AudioPlayer()
     private let recorder = AudioRecorderManager()
     private var cancellables = Set<AnyCancellable>()
@@ -52,6 +60,10 @@ class STTViewModel {
 
     var isModelLoaded: Bool {
         model != nil
+    }
+
+    var canRecord: Bool {
+        streamingModel != nil
     }
 
     init() {
@@ -89,7 +101,9 @@ class STTViewModel {
         generationProgress = "Downloading model..."
 
         do {
-            model = try await Qwen3ASRModel.fromPretrained(modelId)
+            let loadedModel = try await loadSTTModel(modelId)
+            model = loadedModel
+            streamingModel = loadedModel as? Qwen3ASRModel
             loadedModelId = modelId
             generationProgress = ""
         } catch {
@@ -102,6 +116,7 @@ class STTViewModel {
 
     func reloadModel() async {
         model = nil
+        streamingModel = nil
         loadedModelId = nil
         Memory.clearCache()
         await loadModel()
@@ -149,27 +164,29 @@ class STTViewModel {
         peakMemory = 0
 
         do {
-            let (sampleRate, audioData) = try loadAudioArray(from: audioURL)
-            let targetRate = model.sampleRate
-
-            let resampled: MLXArray
-            if sampleRate != targetRate {
-                generationProgress = "Resampling \(sampleRate)Hz → \(targetRate)Hz..."
-                resampled = try resampleAudio(audioData, from: sampleRate, to: targetRate)
-            } else {
-                resampled = audioData
+            let (sampleRate, audioData) = try loadAudioArray(from: audioURL, sampleRate: 16_000)
+            if sampleRate != 16_000 {
+                generationProgress = "Resampling \(sampleRate)Hz → 16000Hz..."
             }
 
             generationProgress = "Transcribing..."
 
-            var tokenCount = 0
-            for try await event in model.generateStream(
-                audio: resampled,
+            let defaultParameters = model.defaultGenerationParameters
+            let parameters = STTGenerateParameters(
                 maxTokens: maxTokens,
                 temperature: temperature,
-                language: language,
-                chunkDuration: chunkDuration
-            ) {
+                topP: defaultParameters.topP,
+                topK: defaultParameters.topK,
+                verbose: false,
+                language: language.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : language,
+                chunkDuration: chunkDuration,
+                minChunkDuration: defaultParameters.minChunkDuration,
+                repetitionPenalty: defaultParameters.repetitionPenalty,
+                repetitionContextSize: defaultParameters.repetitionContextSize
+            )
+
+            var tokenCount = 0
+            for try await event in model.generateStream(audio: audioData, generationParameters: parameters) {
                 try Task.checkCancellation()
 
                 switch event {
@@ -180,7 +197,12 @@ class STTViewModel {
                 case .info(let info):
                     tokensPerSecond = info.tokensPerSecond
                     peakMemory = info.peakMemoryUsage
-                case .result:
+                case .result(let output):
+                    if transcriptionText.isEmpty {
+                        transcriptionText = output.text
+                    }
+                    tokensPerSecond = output.generationTps
+                    peakMemory = output.peakMemoryUsage
                     generationProgress = ""
                 }
             }
@@ -205,7 +227,7 @@ class STTViewModel {
     private var lastReadPos: Int = 0
 
     func startRecording() async {
-        guard let model = model else {
+        guard let model = streamingModel else {
             errorMessage = "Model not loaded"
             return
         }
@@ -320,6 +342,43 @@ class STTViewModel {
             isGenerating = false
             generationProgress = ""
         }
+    }
+
+    private func loadSTTModel(_ repo: String) async throws -> any STTGenerationModel {
+        let lower = repo.lowercased()
+
+        if lower.contains("glmasr") || lower.contains("glm-asr") {
+            return try await GLMASRModel.fromPretrained(repo)
+        }
+        if lower.contains("qwen3-asr") || lower.contains("qwen3_asr") {
+            return try await Qwen3ASRModel.fromPretrained(repo)
+        }
+        if lower.contains("voxtral") {
+            return try await VoxtralRealtimeModel.fromPretrained(repo)
+        }
+        if lower.contains("cohere") {
+            return try await CohereTranscribeModel.fromPretrained(repo)
+        }
+        if lower.contains("parakeet") {
+            return try await ParakeetModel.fromPretrained(repo)
+        }
+        if lower.contains("firered") || lower.contains("fire-red") {
+            return try await FireRedASR2Model.fromPretrained(repo)
+        }
+        if lower.contains("sensevoice") {
+            return try await SenseVoiceModel.fromPretrained(repo)
+        }
+        if lower.contains("granite") {
+            return try await GraniteSpeechModel.fromPretrained(repo)
+        }
+
+        throw NSError(
+            domain: "STT",
+            code: 5,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported STT model repo: \(repo)"
+            ]
+        )
     }
 
     func play() {

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -104,7 +104,7 @@ class STTViewModel {
     }
 
     var supportsRealtimeRecording: Bool {
-        model is Qwen3ASRModel || model is CohereTranscribeModel
+        model is Qwen3ASRModel || model is CohereTranscribeModel || model is MossTranscribeDiarizeModel
     }
 
     var usesRealtimeRecording: Bool {
@@ -329,7 +329,7 @@ class STTViewModel {
             return
         }
         guard supportsRealtimeRecording else {
-            errorMessage = "Realtime recording is available for Qwen3-ASR and Cohere Transcribe models"
+            errorMessage = "Realtime recording is available for Qwen3-ASR, Cohere Transcribe, and MOSS Transcribe models"
             return
         }
 

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -10,7 +10,17 @@ import Combine
 @Observable
 class STTViewModel {
     private static let defaultModelId = "mlx-community/Qwen3-ASR-0.6B-4bit"
+    private static let defaultMaxTokens = 1024
+    private static let defaultTemperature: Float = 0.0
+    private static let defaultLanguage = "English"
+    private static let defaultChunkDuration: Float = 30.0
+    private static let defaultStreamingDelayMs = 480
     private static let modelIdStorageKey = "VoicesApp.STTViewModel.modelId"
+    private static let maxTokensStorageKey = "VoicesApp.STTViewModel.maxTokens"
+    private static let temperatureStorageKey = "VoicesApp.STTViewModel.temperature"
+    private static let languageStorageKey = "VoicesApp.STTViewModel.language"
+    private static let chunkDurationStorageKey = "VoicesApp.STTViewModel.chunkDuration"
+    private static let streamingDelayMsStorageKey = "VoicesApp.STTViewModel.streamingDelayMs"
 
     var isLoading = false
     var isGenerating = false
@@ -21,13 +31,41 @@ class STTViewModel {
     var peakMemory: Double = 0
 
     // Generation parameters
-    var maxTokens: Int = 1024
-    var temperature: Float = 0.0
-    var language: String = "English"
-    var chunkDuration: Float = 30.0
+    var maxTokens: Int = UserDefaults.standard.object(forKey: STTViewModel.maxTokensStorageKey).map { _ in
+        UserDefaults.standard.integer(forKey: STTViewModel.maxTokensStorageKey)
+    } ?? STTViewModel.defaultMaxTokens {
+        didSet {
+            UserDefaults.standard.set(maxTokens, forKey: STTViewModel.maxTokensStorageKey)
+        }
+    }
+    var temperature: Float = UserDefaults.standard.object(forKey: STTViewModel.temperatureStorageKey).map { _ in
+        UserDefaults.standard.float(forKey: STTViewModel.temperatureStorageKey)
+    } ?? STTViewModel.defaultTemperature {
+        didSet {
+            UserDefaults.standard.set(temperature, forKey: STTViewModel.temperatureStorageKey)
+        }
+    }
+    var language: String = UserDefaults.standard.string(forKey: STTViewModel.languageStorageKey) ?? STTViewModel.defaultLanguage {
+        didSet {
+            UserDefaults.standard.set(language, forKey: STTViewModel.languageStorageKey)
+        }
+    }
+    var chunkDuration: Float = UserDefaults.standard.object(forKey: STTViewModel.chunkDurationStorageKey).map { _ in
+        UserDefaults.standard.float(forKey: STTViewModel.chunkDurationStorageKey)
+    } ?? STTViewModel.defaultChunkDuration {
+        didSet {
+            UserDefaults.standard.set(chunkDuration, forKey: STTViewModel.chunkDurationStorageKey)
+        }
+    }
 
     // Streaming parameters
-    var streamingDelayMs: Int = 480  // .agent default
+    var streamingDelayMs: Int = UserDefaults.standard.object(forKey: STTViewModel.streamingDelayMsStorageKey).map { _ in
+        UserDefaults.standard.integer(forKey: STTViewModel.streamingDelayMsStorageKey)
+    } ?? STTViewModel.defaultStreamingDelayMs {
+        didSet {
+            UserDefaults.standard.set(streamingDelayMs, forKey: STTViewModel.streamingDelayMsStorageKey)
+        }
+    } // .agent default
 
     // Model configuration
     var modelId: String = UserDefaults.standard.string(forKey: STTViewModel.modelIdStorageKey) ?? STTViewModel.defaultModelId {
@@ -125,6 +163,22 @@ class STTViewModel {
         loadedModelId = nil
         Memory.clearCache()
         await loadModel()
+    }
+
+    func resetSettingsToDefaults() {
+        modelId = STTViewModel.defaultModelId
+        maxTokens = STTViewModel.defaultMaxTokens
+        temperature = STTViewModel.defaultTemperature
+        language = STTViewModel.defaultLanguage
+        chunkDuration = STTViewModel.defaultChunkDuration
+        streamingDelayMs = STTViewModel.defaultStreamingDelayMs
+
+        UserDefaults.standard.removeObject(forKey: STTViewModel.modelIdStorageKey)
+        UserDefaults.standard.removeObject(forKey: STTViewModel.maxTokensStorageKey)
+        UserDefaults.standard.removeObject(forKey: STTViewModel.temperatureStorageKey)
+        UserDefaults.standard.removeObject(forKey: STTViewModel.languageStorageKey)
+        UserDefaults.standard.removeObject(forKey: STTViewModel.chunkDurationStorageKey)
+        UserDefaults.standard.removeObject(forKey: STTViewModel.streamingDelayMsStorageKey)
     }
 
     func selectAudioFile(_ url: URL) {

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -219,8 +219,7 @@ class STTViewModel {
         errorMessage = nil
         transcriptionText = ""
         generationProgress = "Loading audio..."
-        tokensPerSecond = 0
-        peakMemory = 0
+        resetGenerationStats()
 
         do {
             let (sampleRate, audioData) = try loadAudioArray(from: audioURL, sampleRate: 16_000)
@@ -254,8 +253,7 @@ class STTViewModel {
             transcriptionText = ""
         }
         generationProgress = "Transcribing recording..."
-        tokensPerSecond = 0
-        peakMemory = 0
+        resetGenerationStats()
 
         do {
             try await transcribe(audioData: audioData, with: model)
@@ -337,8 +335,7 @@ class STTViewModel {
         activeRecordingID = recordingID
         errorMessage = nil
         transcriptionText = ""
-        tokensPerSecond = 0
-        peakMemory = 0
+        resetGenerationStats()
         lastReadPos = 0
 
         do {
@@ -494,6 +491,13 @@ class STTViewModel {
         generationProgress = ""
         tokensPerSecond = 0
         peakMemory = 0
+    }
+
+    private func resetGenerationStats() {
+        tokensPerSecond = 0
+        peakMemory = 0
+        Memory.clearCache()
+        Memory.peakMemory = 0
     }
 
     private func resampleAudio(_ audio: MLXArray, from sourceSR: Int, to targetSR: Int) throws -> MLXArray {

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -52,7 +52,6 @@ class STTViewModel {
     var audioLevel: Float { recorder.audioLevel }
 
     private var model: (any STTGenerationModel)?
-    private var streamingModel: Qwen3ASRModel?
     private let audioPlayer = AudioPlayer()
     private let recorder = AudioRecorderManager()
     private var cancellables = Set<AnyCancellable>()
@@ -63,7 +62,15 @@ class STTViewModel {
     }
 
     var canRecord: Bool {
-        streamingModel != nil
+        isRecording || (supportsRealtimeRecording && !isLoading && !isGenerating)
+    }
+
+    var supportsRealtimeRecording: Bool {
+        model is Qwen3ASRModel || model is CohereTranscribeModel
+    }
+
+    var usesRealtimeRecording: Bool {
+        isRecording && streamingSession != nil
     }
 
     init() {
@@ -103,7 +110,6 @@ class STTViewModel {
         do {
             let loadedModel = try await loadSTTModel(modelId)
             model = loadedModel
-            streamingModel = loadedModel as? Qwen3ASRModel
             loadedModelId = modelId
             generationProgress = ""
         } catch {
@@ -116,7 +122,6 @@ class STTViewModel {
 
     func reloadModel() async {
         model = nil
-        streamingModel = nil
         loadedModelId = nil
         Memory.clearCache()
         await loadModel()
@@ -169,43 +174,7 @@ class STTViewModel {
                 generationProgress = "Resampling \(sampleRate)Hz → 16000Hz..."
             }
 
-            generationProgress = "Transcribing..."
-
-            let defaultParameters = model.defaultGenerationParameters
-            let parameters = STTGenerateParameters(
-                maxTokens: maxTokens,
-                temperature: temperature,
-                topP: defaultParameters.topP,
-                topK: defaultParameters.topK,
-                verbose: false,
-                language: language.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : language,
-                chunkDuration: chunkDuration,
-                minChunkDuration: defaultParameters.minChunkDuration,
-                repetitionPenalty: defaultParameters.repetitionPenalty,
-                repetitionContextSize: defaultParameters.repetitionContextSize
-            )
-
-            var tokenCount = 0
-            for try await event in model.generateStream(audio: audioData, generationParameters: parameters) {
-                try Task.checkCancellation()
-
-                switch event {
-                case .token(let token):
-                    transcriptionText += token
-                    tokenCount += 1
-                    generationProgress = "Transcribing... \(tokenCount) tokens"
-                case .info(let info):
-                    tokensPerSecond = info.tokensPerSecond
-                    peakMemory = info.peakMemoryUsage
-                case .result(let output):
-                    if transcriptionText.isEmpty {
-                        transcriptionText = output.text
-                    }
-                    tokensPerSecond = output.generationTps
-                    peakMemory = output.peakMemoryUsage
-                    generationProgress = ""
-                }
-            }
+            try await transcribe(audioData: audioData, with: model)
 
             generationProgress = ""
         } catch is CancellationError {
@@ -219,19 +188,99 @@ class STTViewModel {
         isGenerating = false
     }
 
+    private func transcribeRecording(audioData: MLXArray, clearExistingText: Bool = true) async {
+        guard let model = model else {
+            errorMessage = "Model not loaded"
+            return
+        }
+
+        isGenerating = true
+        errorMessage = nil
+        if clearExistingText {
+            transcriptionText = ""
+        }
+        generationProgress = "Transcribing recording..."
+        tokensPerSecond = 0
+        peakMemory = 0
+
+        do {
+            try await transcribe(audioData: audioData, with: model)
+            generationProgress = ""
+        } catch is CancellationError {
+            Memory.clearCache()
+            generationProgress = ""
+        } catch {
+            errorMessage = "Transcription failed: \(error.localizedDescription)"
+            generationProgress = ""
+        }
+
+        isGenerating = false
+    }
+
+    private func transcribe(audioData: MLXArray, with model: any STTGenerationModel) async throws {
+        generationProgress = "Transcribing..."
+
+        let parameters = generationParameters(for: model)
+
+        var tokenCount = 0
+        for try await event in model.generateStream(audio: audioData, generationParameters: parameters) {
+            try Task.checkCancellation()
+
+            switch event {
+            case .token(let token):
+                transcriptionText += token
+                tokenCount += 1
+                generationProgress = "Transcribing... \(tokenCount) tokens"
+            case .info(let info):
+                tokensPerSecond = info.tokensPerSecond
+                peakMemory = info.peakMemoryUsage
+            case .result(let output):
+                if transcriptionText.isEmpty {
+                    transcriptionText = output.text
+                }
+                tokensPerSecond = output.generationTps
+                peakMemory = output.peakMemoryUsage
+                generationProgress = ""
+            }
+        }
+    }
+
+    private func generationParameters(for model: any STTGenerationModel) -> STTGenerateParameters {
+        let defaultParameters = model.defaultGenerationParameters
+        return STTGenerateParameters(
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: defaultParameters.topP,
+            topK: defaultParameters.topK,
+            verbose: false,
+            language: language.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : language,
+            chunkDuration: chunkDuration,
+            minChunkDuration: defaultParameters.minChunkDuration,
+            repetitionPenalty: defaultParameters.repetitionPenalty,
+            repetitionContextSize: defaultParameters.repetitionContextSize
+        )
+    }
+
     // MARK: - Live Recording & Streaming Transcription
 
     private var liveTask: Task<Void, Never>?
     private var eventTask: Task<Void, Never>?
     private var streamingSession: StreamingInferenceSession?
+    private var activeRecordingID: UUID?
     private var lastReadPos: Int = 0
 
     func startRecording() async {
-        guard let model = streamingModel else {
+        guard let model else {
             errorMessage = "Model not loaded"
             return
         }
+        guard supportsRealtimeRecording else {
+            errorMessage = "Realtime recording is available for Qwen3-ASR and Cohere Transcribe models"
+            return
+        }
 
+        let recordingID = UUID()
+        activeRecordingID = recordingID
         errorMessage = nil
         transcriptionText = ""
         tokensPerSecond = 0
@@ -260,6 +309,7 @@ class STTViewModel {
         // Listen to events from the session
         eventTask = Task {
             for await event in session.events {
+                guard activeRecordingID == recordingID else { continue }
                 switch event {
                 case .displayUpdate(let confirmed, let provisional):
                     transcriptionText = confirmed + provisional
@@ -275,8 +325,11 @@ class STTViewModel {
                 }
             }
             // Stream ended naturally — clean up
-            streamingSession = nil
-            eventTask = nil
+            if activeRecordingID == recordingID {
+                activeRecordingID = nil
+                streamingSession = nil
+                eventTask = nil
+            }
         }
 
         // Audio feed loop: read new samples every 100ms and feed to session
@@ -296,9 +349,7 @@ class STTViewModel {
         liveTask?.cancel()
         liveTask = nil
 
-        _ = recorder.stopRecording()
-
-        // Feed any remaining audio, then stop session
+        // Feed any remaining audio, then stop session.
         if let session = streamingSession {
             if let (audio, endPos) = recorder.getAudio(from: lastReadPos) {
                 lastReadPos = endPos
@@ -306,10 +357,16 @@ class STTViewModel {
                 session.feedAudio(samples: samples)
             }
 
+            _ = recorder.stopRecording()
+
             // Stop promotes all provisional tokens and emits .ended
             // The eventTask will process .ended and clean up naturally
             session.stop()
+            return
         }
+
+        _ = recorder.stopRecording()
+        activeRecordingID = nil
     }
 
     func cancelRecording() {
@@ -320,6 +377,7 @@ class STTViewModel {
         eventTask?.cancel()
         eventTask = nil
         recorder.cancelRecording()
+        activeRecordingID = nil
         lastReadPos = 0
     }
 
@@ -332,6 +390,7 @@ class STTViewModel {
         eventTask = nil
         generationTask?.cancel()
         generationTask = nil
+        activeRecordingID = nil
 
         if isRecording {
             recorder.cancelRecording()

--- a/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/STTViewModel.swift
@@ -113,6 +113,17 @@ class STTViewModel {
         audioPlayer.loadAudio(from: url)
     }
 
+    func removeAudioFile() {
+        guard !isGenerating && !isRecording else { return }
+
+        audioPlayer.unloadAudio()
+        selectedAudioURL = nil
+        audioFileName = nil
+        currentTime = 0
+        duration = 0
+        isPlaying = false
+    }
+
     func startTranscription() {
         guard let audioURL = selectedAudioURL else {
             errorMessage = "No audio file selected"
@@ -334,6 +345,16 @@ class STTViewModel {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(transcriptionText, forType: .string)
         #endif
+    }
+
+    func clearTranscription() {
+        guard !isGenerating && !isRecording else { return }
+
+        transcriptionText = ""
+        errorMessage = nil
+        generationProgress = ""
+        tokensPerSecond = 0
+        peakMemory = 0
     }
 
     private func resampleAudio(_ audio: MLXArray, from sourceSR: Int, to targetSR: Int) throws -> MLXArray {

--- a/Examples/VoicesApp/VoicesApp/ViewModels/TTSViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/TTSViewModel.swift
@@ -13,6 +13,9 @@ import AppKit
 @MainActor
 @Observable
 class TTSViewModel {
+    private static let defaultModelId = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit"
+    private static let modelIdStorageKey = "VoicesApp.TTSViewModel.modelId"
+
     var isLoading = false
     var isGenerating = false
     var generationProgress: String = ""
@@ -77,7 +80,11 @@ class TTSViewModel {
     var streamingPlayback: Bool = true // Play audio as chunks are generated
 
     // Model configuration
-    var modelId: String = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit"
+    var modelId: String = UserDefaults.standard.string(forKey: TTSViewModel.modelIdStorageKey) ?? TTSViewModel.defaultModelId {
+        didSet {
+            UserDefaults.standard.set(modelId, forKey: TTSViewModel.modelIdStorageKey)
+        }
+    }
     private var loadedModelId: String?
 
     // Audio player state (manually synced from AudioPlayerManager)

--- a/Examples/VoicesApp/VoicesApp/ViewModels/TTSViewModel.swift
+++ b/Examples/VoicesApp/VoicesApp/ViewModels/TTSViewModel.swift
@@ -15,6 +15,16 @@ import AppKit
 class TTSViewModel {
     private static let defaultModelId = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit"
     private static let modelIdStorageKey = "VoicesApp.TTSViewModel.modelId"
+    private static let maxTokensStorageKey = "VoicesApp.TTSViewModel.maxTokens"
+    private static let temperatureStorageKey = "VoicesApp.TTSViewModel.temperature"
+    private static let topPStorageKey = "VoicesApp.TTSViewModel.topP"
+    private static let repetitionPenaltyStorageKey = "VoicesApp.TTSViewModel.repetitionPenalty"
+    private static let voiceDescriptionStorageKey = "VoicesApp.TTSViewModel.voiceDescription"
+    private static let useVoiceDesignStorageKey = "VoicesApp.TTSViewModel.useVoiceDesign"
+    private static let enableChunkingStorageKey = "VoicesApp.TTSViewModel.enableChunking"
+    private static let maxChunkLengthStorageKey = "VoicesApp.TTSViewModel.maxChunkLength"
+    private static let splitPatternStorageKey = "VoicesApp.TTSViewModel.splitPattern"
+    private static let streamingPlaybackStorageKey = "VoicesApp.TTSViewModel.streamingPlayback"
 
     var isLoading = false
     var isGenerating = false
@@ -31,15 +41,28 @@ class TTSViewModel {
         repetitionPenalty: 1.3,
         repetitionContextSize: 20
     )
-    private var maxTokensOverride: Int?
-    private var temperatureOverride: Float?
-    private var topPOverride: Float?
-    private var repetitionPenaltyOverride: Float?
+    private var maxTokensOverride: Int? = UserDefaults.standard.object(forKey: TTSViewModel.maxTokensStorageKey).map { _ in
+        UserDefaults.standard.integer(forKey: TTSViewModel.maxTokensStorageKey)
+    }
+    private var temperatureOverride: Float? = UserDefaults.standard.object(forKey: TTSViewModel.temperatureStorageKey).map { _ in
+        UserDefaults.standard.float(forKey: TTSViewModel.temperatureStorageKey)
+    }
+    private var topPOverride: Float? = UserDefaults.standard.object(forKey: TTSViewModel.topPStorageKey).map { _ in
+        UserDefaults.standard.float(forKey: TTSViewModel.topPStorageKey)
+    }
+    private var repetitionPenaltyOverride: Float? = UserDefaults.standard.object(forKey: TTSViewModel.repetitionPenaltyStorageKey).map { _ in
+        UserDefaults.standard.float(forKey: TTSViewModel.repetitionPenaltyStorageKey)
+    }
 
     var maxTokens: Int {
         get { maxTokensOverride ?? defaultMaxTokens }
         set {
             maxTokensOverride = (newValue == defaultMaxTokens) ? nil : newValue
+            if let maxTokensOverride {
+                UserDefaults.standard.set(maxTokensOverride, forKey: TTSViewModel.maxTokensStorageKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: TTSViewModel.maxTokensStorageKey)
+            }
         }
     }
 
@@ -48,6 +71,11 @@ class TTSViewModel {
         set {
             let defaultValue = defaultGenerationParameters.temperature
             temperatureOverride = abs(newValue - defaultValue) < 0.0001 ? nil : newValue
+            if let temperatureOverride {
+                UserDefaults.standard.set(temperatureOverride, forKey: TTSViewModel.temperatureStorageKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: TTSViewModel.temperatureStorageKey)
+            }
         }
     }
 
@@ -56,6 +84,11 @@ class TTSViewModel {
         set {
             let defaultValue = defaultGenerationParameters.topP
             topPOverride = abs(newValue - defaultValue) < 0.0001 ? nil : newValue
+            if let topPOverride {
+                UserDefaults.standard.set(topPOverride, forKey: TTSViewModel.topPStorageKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: TTSViewModel.topPStorageKey)
+            }
         }
     }
     
@@ -64,20 +97,55 @@ class TTSViewModel {
         set {
             let defaultValue = defaultGenerationParameters.repetitionPenalty ?? 1.3
             repetitionPenaltyOverride = abs(newValue - defaultValue) < 0.0001 ? nil : newValue
+            if let repetitionPenaltyOverride {
+                UserDefaults.standard.set(repetitionPenaltyOverride, forKey: TTSViewModel.repetitionPenaltyStorageKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: TTSViewModel.repetitionPenaltyStorageKey)
+            }
         }
     }
     
     // Voice Design (for Qwen3-TTS VoiceDesign models)
-    var voiceDescription: String = ""
-    var useVoiceDesign: Bool = false
+    var voiceDescription: String = UserDefaults.standard.string(forKey: TTSViewModel.voiceDescriptionStorageKey) ?? "" {
+        didSet {
+            UserDefaults.standard.set(voiceDescription, forKey: TTSViewModel.voiceDescriptionStorageKey)
+        }
+    }
+    var useVoiceDesign: Bool = UserDefaults.standard.bool(forKey: TTSViewModel.useVoiceDesignStorageKey) {
+        didSet {
+            UserDefaults.standard.set(useVoiceDesign, forKey: TTSViewModel.useVoiceDesignStorageKey)
+        }
+    }
 
     // Text chunking
-    var enableChunking: Bool = true
-    var maxChunkLength: Int = 200
-    var splitPattern: String = "\n" // Can be regex like "\\n" or "[.!?]\\s+"
+    var enableChunking: Bool = UserDefaults.standard.object(forKey: TTSViewModel.enableChunkingStorageKey).map { _ in
+        UserDefaults.standard.bool(forKey: TTSViewModel.enableChunkingStorageKey)
+    } ?? true {
+        didSet {
+            UserDefaults.standard.set(enableChunking, forKey: TTSViewModel.enableChunkingStorageKey)
+        }
+    }
+    var maxChunkLength: Int = UserDefaults.standard.object(forKey: TTSViewModel.maxChunkLengthStorageKey).map { _ in
+        UserDefaults.standard.integer(forKey: TTSViewModel.maxChunkLengthStorageKey)
+    } ?? 200 {
+        didSet {
+            UserDefaults.standard.set(maxChunkLength, forKey: TTSViewModel.maxChunkLengthStorageKey)
+        }
+    }
+    var splitPattern: String = UserDefaults.standard.string(forKey: TTSViewModel.splitPatternStorageKey) ?? "\n" {
+        didSet {
+            UserDefaults.standard.set(splitPattern, forKey: TTSViewModel.splitPatternStorageKey)
+        }
+    } // Can be regex like "\\n" or "[.!?]\\s+"
 
     // Streaming playback
-    var streamingPlayback: Bool = true // Play audio as chunks are generated
+    var streamingPlayback: Bool = UserDefaults.standard.object(forKey: TTSViewModel.streamingPlaybackStorageKey).map { _ in
+        UserDefaults.standard.bool(forKey: TTSViewModel.streamingPlaybackStorageKey)
+    } ?? true {
+        didSet {
+            UserDefaults.standard.set(streamingPlayback, forKey: TTSViewModel.streamingPlaybackStorageKey)
+        }
+    } // Play audio as chunks are generated
 
     // Model configuration
     var modelId: String = UserDefaults.standard.string(forKey: TTSViewModel.modelIdStorageKey) ?? TTSViewModel.defaultModelId {
@@ -166,6 +234,30 @@ class TTSViewModel {
         maxTokensOverride = nil
         temperatureOverride = nil
         topPOverride = nil
+        repetitionPenaltyOverride = nil
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.maxTokensStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.temperatureStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.topPStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.repetitionPenaltyStorageKey)
+    }
+
+    func resetSettingsToDefaults() {
+        modelId = TTSViewModel.defaultModelId
+        resetGenerationParameterOverrides()
+        useVoiceDesign = false
+        voiceDescription = ""
+        enableChunking = true
+        maxChunkLength = 200
+        splitPattern = "\n"
+        streamingPlayback = true
+
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.modelIdStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.voiceDescriptionStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.useVoiceDesignStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.enableChunkingStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.maxChunkLengthStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.splitPatternStorageKey)
+        UserDefaults.standard.removeObject(forKey: TTSViewModel.streamingPlaybackStorageKey)
     }
 
     private func effectiveGenerationParameters() -> GenerateParameters {
@@ -178,6 +270,9 @@ class TTSViewModel {
         }
         if let topPOverride {
             parameters.topP = topPOverride
+        }
+        if let repetitionPenaltyOverride {
+            parameters.repetitionPenalty = repetitionPenaltyOverride
         }
         return parameters
     }

--- a/Examples/VoicesApp/VoicesApp/Views/STTSettingsView.swift
+++ b/Examples/VoicesApp/VoicesApp/Views/STTSettingsView.swift
@@ -243,7 +243,7 @@ struct STTSettingsView: View {
                     .font(labelFont)
                     .foregroundStyle(.secondary)
 
-                TextField("Language", text: $viewModel.language)
+                TextField("Auto", text: $viewModel.language)
                     .font(textFont)
                     .textFieldStyle(.plain)
                     .padding(8)
@@ -251,7 +251,7 @@ struct STTSettingsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 6))
                     .padding(.top, 4)
 
-                Text("e.g. English, Chinese, Japanese, Korean")
+                Text("Leave empty for model default/auto, or enter e.g. English, Chinese, Japanese, Korean")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }

--- a/Examples/VoicesApp/VoicesApp/Views/STTSettingsView.swift
+++ b/Examples/VoicesApp/VoicesApp/Views/STTSettingsView.swift
@@ -259,12 +259,7 @@ struct STTSettingsView: View {
 
             // Reset button
             Button(action: {
-                viewModel.modelId = "mlx-community/Qwen3-ASR-0.6B-4bit"
-                viewModel.maxTokens = 1024
-                viewModel.temperature = 0.0
-                viewModel.language = "English"
-                viewModel.chunkDuration = 30.0
-                viewModel.streamingDelayMs = 480
+                viewModel.resetSettingsToDefaults()
             }) {
                 Text("Reset to Defaults")
                     .font(textFont)

--- a/Examples/VoicesApp/VoicesApp/Views/SettingsView.swift
+++ b/Examples/VoicesApp/VoicesApp/Views/SettingsView.swift
@@ -426,14 +426,7 @@ struct SettingsView: View {
 
             // Reset button
             Button(action: {
-                viewModel.modelId = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit"
-                viewModel.resetGenerationParameterOverrides()
-                viewModel.useVoiceDesign = false
-                viewModel.voiceDescription = ""
-                viewModel.enableChunking = true
-                viewModel.maxChunkLength = 200
-                viewModel.splitPattern = "\n"
-                viewModel.streamingPlayback = true
+                viewModel.resetSettingsToDefaults()
             }) {
                 Text("Reset to Defaults")
                     .font(textFont)

--- a/Sources/MLXAudioCore/AudioPlayer.swift
+++ b/Sources/MLXAudioCore/AudioPlayer.swift
@@ -115,6 +115,14 @@ public class AudioPlayer: NSObject, ObservableObject {
         }
     }
 
+    public func unloadAudio() {
+        stop()
+        player = nil
+        currentAudioURL = nil
+        duration = 0
+        currentTime = 0
+    }
+
     public func seek(to time: TimeInterval) {
         guard let player = player else { return }
         player.currentTime = max(0, min(time, duration))

--- a/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribe.swift
+++ b/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribe.swift
@@ -760,7 +760,7 @@ extension CohereTranscribeModel {
         config: StreamingConfig,
         confirmedTokenIds: [Int] = []
     ) -> CohereStreamingDecodeResult {
-        let language = config.language.trimmingCharacters(in: .whitespacesAndNewlines)
+        let language = config.language?.trimmingCharacters(in: .whitespacesAndNewlines)
         let defaultParameters = defaultGenerationParameters
         let parameters = STTGenerateParameters(
             maxTokens: config.maxTokensPerPass,
@@ -768,7 +768,7 @@ extension CohereTranscribeModel {
             topP: defaultParameters.topP,
             topK: defaultParameters.topK,
             verbose: false,
-            language: language.isEmpty ? defaultParameters.language : language,
+            language: language?.isEmpty == false ? language : defaultParameters.language,
             chunkDuration: defaultParameters.chunkDuration,
             minChunkDuration: defaultParameters.minChunkDuration,
             repetitionPenalty: defaultParameters.repetitionPenalty,

--- a/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribe.swift
+++ b/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribe.swift
@@ -13,6 +13,14 @@ private struct CoherePrefillContext {
     let startTime: Date
 }
 
+struct CohereStreamingDecodeResult: Sendable {
+    let tokenIds: [Int]
+    let promptLength: Int
+    let decodeTime: Double
+    let totalTime: Double
+    let peakMemoryUsage: Double
+}
+
 private let cohereWeightPrefixAliases: [(source: String, target: String)] = [
     ("encoder.pre_encode.", "encoder.subsampling."),
     ("encoder_decoder_proj.", "bridge_proj."),
@@ -709,6 +717,90 @@ private extension CohereTranscribeModel {
             chunkDuration: generationParameters.chunkDuration,
             minChunkDuration: generationParameters.minChunkDuration
         )
+    }
+}
+
+extension CohereTranscribeModel {
+    func streamingDecodeTokenIds(audio: MLXArray, config: StreamingConfig) -> CohereStreamingDecodeResult {
+        let language = config.language.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultParameters = defaultGenerationParameters
+        let parameters = STTGenerateParameters(
+            maxTokens: config.maxTokensPerPass,
+            temperature: config.temperature,
+            topP: defaultParameters.topP,
+            topK: defaultParameters.topK,
+            verbose: false,
+            language: language.isEmpty ? defaultParameters.language : language,
+            chunkDuration: defaultParameters.chunkDuration,
+            minChunkDuration: defaultParameters.minChunkDuration,
+            repetitionPenalty: defaultParameters.repetitionPenalty,
+            repetitionContextSize: defaultParameters.repetitionContextSize
+        )
+
+        let audio1D = audio.ndim > 1 ? audio.mean(axis: -1) : audio
+        var context = encodeAndPrefill(audio: audio1D, generationParameters: parameters)
+        var generated: [Int] = []
+        generated.reserveCapacity(parameters.maxTokens)
+        let decodeStart = Date()
+
+        let eosTokenId = tokenizer?.encode(text: "<|endoftext|>").first ?? 0
+        let maxGenerationTokens = effectiveMaxGenerationTokens(
+            promptLength: context.promptLength,
+            requestedMaxTokens: parameters.maxTokens
+        )
+
+        for pos in context.promptLength..<(context.promptLength + maxGenerationTokens) {
+            if Task.isCancelled { break }
+
+            let token = sample(logits: context.logits, temperature: parameters.temperature)
+            generated.append(token)
+
+            if token == eosTokenId {
+                break
+            }
+
+            let inputIds = MLXArray([Int32(token)]).expandedDimensions(axis: 0)
+            let positions = MLXArray([Int32(pos)]).expandedDimensions(axis: 0)
+
+            let next = decoder(
+                inputIds: inputIds,
+                positions: positions,
+                encoderHiddenStates: context.adapterOut,
+                selfAttentionMask: nil,
+                crossAttentionMask: nil,
+                cache: context.cache
+            )
+
+            context.cache = next.1
+            context.logits = lmHead(next.0[0, -1])
+
+            eval(context.logits)
+            if generated.count % 256 == 0 {
+                Memory.clearCache()
+            }
+        }
+
+        if generated.last == eosTokenId {
+            _ = generated.popLast()
+        }
+
+        let end = Date()
+        let decodeTime = end.timeIntervalSince(decodeStart)
+        let totalTime = end.timeIntervalSince(context.startTime)
+        let peakMemoryUsage = Double(Memory.peakMemory) / 1e9
+        Memory.clearCache()
+
+        return CohereStreamingDecodeResult(
+            tokenIds: generated,
+            promptLength: context.promptLength,
+            decodeTime: decodeTime,
+            totalTime: totalTime,
+            peakMemoryUsage: peakMemoryUsage
+        )
+    }
+
+    func streamingDecodeText(tokens: [Int]) -> String {
+        tokenizer?.decode(tokens: tokens).trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 }
 

--- a/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribe.swift
+++ b/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribe.swift
@@ -721,7 +721,11 @@ private extension CohereTranscribeModel {
 }
 
 extension CohereTranscribeModel {
-    func streamingDecodeTokenIds(audio: MLXArray, config: StreamingConfig) -> CohereStreamingDecodeResult {
+    func streamingDecodeTokenIds(
+        audio: MLXArray,
+        config: StreamingConfig,
+        confirmedTokenIds: [Int] = []
+    ) -> CohereStreamingDecodeResult {
         let language = config.language.trimmingCharacters(in: .whitespacesAndNewlines)
         let defaultParameters = defaultGenerationParameters
         let parameters = STTGenerateParameters(
@@ -749,7 +753,44 @@ extension CohereTranscribeModel {
             requestedMaxTokens: parameters.maxTokens
         )
 
-        for pos in context.promptLength..<(context.promptLength + maxGenerationTokens) {
+        for (offset, token) in confirmedTokenIds.prefix(maxGenerationTokens).enumerated() {
+            if Task.isCancelled { break }
+
+            generated.append(token)
+
+            let inputIds = MLXArray([Int32(token)]).expandedDimensions(axis: 0)
+            let positions = MLXArray([Int32(context.promptLength + offset)]).expandedDimensions(axis: 0)
+
+            let next = decoder(
+                inputIds: inputIds,
+                positions: positions,
+                encoderHiddenStates: context.adapterOut,
+                selfAttentionMask: nil,
+                crossAttentionMask: nil,
+                cache: context.cache
+            )
+
+            context.cache = next.1
+            context.logits = lmHead(next.0[0, -1])
+            eval(context.logits)
+        }
+
+        let generationStart = context.promptLength + generated.count
+        let generationEnd = context.promptLength + maxGenerationTokens
+        guard generationStart < generationEnd else {
+            let end = Date()
+            let peakMemoryUsage = Double(Memory.peakMemory) / 1e9
+            Memory.clearCache()
+            return CohereStreamingDecodeResult(
+                tokenIds: generated,
+                promptLength: context.promptLength,
+                decodeTime: end.timeIntervalSince(decodeStart),
+                totalTime: end.timeIntervalSince(context.startTime),
+                peakMemoryUsage: peakMemoryUsage
+            )
+        }
+
+        for pos in generationStart..<generationEnd {
             if Task.isCancelled { break }
 
             let token = sample(logits: context.logits, temperature: parameters.temperature)

--- a/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribeConfig.swift
+++ b/Sources/MLXAudioSTT/Models/CohereTranscribe/CohereTranscribeConfig.swift
@@ -42,6 +42,14 @@ public struct CohereTranscribeTextDecoderConfig: Codable, Sendable {
     }
 }
 
+private struct CohereTranscribeHeadConfig: Decodable {
+    let numClasses: Int
+
+    enum CodingKeys: String, CodingKey {
+        case numClasses = "num_classes"
+    }
+}
+
 public struct CohereTranscribeConfig: Decodable, Sendable {
     public let modelType: String
     public let vocabSize: Int
@@ -72,6 +80,7 @@ public struct CohereTranscribeConfig: Decodable, Sendable {
         case maxAudioClipS = "max_audio_clip_s"
         case encoder
         case transfDecoder = "transf_decoder"
+        case head
         case quantization
         case quantizationConfig = "quantization_config"
     }
@@ -79,7 +88,11 @@ public struct CohereTranscribeConfig: Decodable, Sendable {
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         modelType = try container.decode(String.self, forKey: .modelType)
-        vocabSize = try container.decode(Int.self, forKey: .vocabSize)
+        if let topLevelVocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize) {
+            vocabSize = topLevelVocabSize
+        } else {
+            vocabSize = try container.decode(CohereTranscribeHeadConfig.self, forKey: .head).numClasses
+        }
         sampleRate = try container.decode(Int.self, forKey: .sampleRate)
         maxAudioClipS = try container.decode(Int.self, forKey: .maxAudioClipS)
         encoder = try container.decode(CohereTranscribeAudioEncoderConfig.self, forKey: .encoder)

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -256,6 +256,8 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
             audio: audio,
             maxTokens: generationParameters.maxTokens,
             temperature: generationParameters.temperature,
+            chunkDuration: generationParameters.chunkDuration,
+            minChunkDuration: generationParameters.minChunkDuration,
             repetitionPenalty: generationParameters.repetitionPenalty,
             repetitionContextSize: generationParameters.repetitionContextSize
         )
@@ -273,44 +275,51 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
                 let audio = sendableAudio.value
                 do {
                     let start = Date()
-                    let prepared = try model.prepareGenerationInputs(audio: audio, prompt: nil)
-                    var generatedTokens: [Int] = []
-                    var streamedText = ""
-                    for token in try model.generateTokenIds(
-                        promptIds: prepared.promptIds,
-                        inputEmbeddings: prepared.inputEmbeddings,
-                        maxTokens: generationParameters.maxTokens,
-                        temperature: generationParameters.temperature,
-                        repetitionPenalty: generationParameters.repetitionPenalty,
-                        repetitionContextSize: generationParameters.repetitionContextSize
-                    ) {
-                        generatedTokens.append(token)
-                        let text = model.tokenizer?.decode(tokens: [token], skipSpecialTokens: true) ?? ""
-                        streamedText += text
-                        continuation.yield(.token(text))
+                    let chunks = model.audioChunks(
+                        audio,
+                        chunkDuration: generationParameters.chunkDuration,
+                        minChunkDuration: generationParameters.minChunkDuration
+                    )
+                    var outputs: [STTOutput] = []
+                    outputs.reserveCapacity(chunks.count)
+                    var emittedText = false
+
+                    for (chunkAudio, offsetSeconds) in chunks {
+                        try Task.checkCancellation()
+
+                        // MOSS emits verbose timestamped diarization text, so the UI's
+                        // maxTokens setting is a per-chunk decode cap for long audio.
+                        let output = try model.generateSingleChunk(
+                            audio: chunkAudio,
+                            maxTokens: generationParameters.maxTokens,
+                            temperature: generationParameters.temperature,
+                            repetitionPenalty: generationParameters.repetitionPenalty,
+                            repetitionContextSize: generationParameters.repetitionContextSize,
+                            prompt: nil,
+                            offsetSeconds: Double(offsetSeconds)
+                        )
+                        outputs.append(output)
+
+                        let text = output.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !text.isEmpty {
+                            continuation.yield(.token(emittedText ? "\n" + text : text))
+                            emittedText = true
+                        }
+
+                        Memory.clearCache()
                     }
+
                     let totalTime = Date().timeIntervalSince(start)
+                    let combined = Self.combineChunkOutputs(outputs, totalTime: totalTime)
                     continuation.yield(.info(STTGenerationInfo(
-                        promptTokenCount: prepared.promptTokenCount,
-                        generationTokenCount: generatedTokens.count,
+                        promptTokenCount: combined.promptTokens,
+                        generationTokenCount: combined.generationTokens,
                         prefillTime: 0,
                         generateTime: totalTime,
-                        tokensPerSecond: totalTime > 0 ? Double(generatedTokens.count) / totalTime : 0,
-                        peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+                        tokensPerSecond: combined.generationTps,
+                        peakMemoryUsage: combined.peakMemoryUsage
                     )))
-                    continuation.yield(.result(STTOutput(
-                        text: streamedText.trimmingCharacters(in: .whitespacesAndNewlines),
-                        segments: MossTranscribeDiarizeModel.parseSegments(
-                            text: streamedText,
-                            fallbackEnd: prepared.duration
-                        ),
-                        promptTokens: prepared.promptTokenCount,
-                        generationTokens: generatedTokens.count,
-                        totalTokens: prepared.promptTokenCount + generatedTokens.count,
-                        generationTps: totalTime > 0 ? Double(generatedTokens.count) / totalTime : 0,
-                        totalTime: totalTime,
-                        peakMemoryUsage: Double(Memory.peakMemory) / 1e9
-                    )))
+                    continuation.yield(.result(combined))
                     continuation.finish()
                 } catch is CancellationError {
                     continuation.finish()
@@ -326,40 +335,39 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
         audio: MLXArray,
         maxTokens: Int = 2048,
         temperature: Float = 0.0,
+        chunkDuration: Float = 1800.0,
+        minChunkDuration: Float = 0.0,
         repetitionPenalty: Float = 1.0,
         repetitionContextSize: Int = 100,
         prompt: String? = nil
     ) -> STTOutput {
         let start = Date()
         do {
-            let prefillStart = Date()
-            let prepared = try prepareGenerationInputs(audio: audio, prompt: prompt)
-            let prefillTime = Date().timeIntervalSince(prefillStart)
-            let genStart = Date()
-            let generatedTokens = try generateTokenIds(
-                promptIds: prepared.promptIds,
-                inputEmbeddings: prepared.inputEmbeddings,
-                maxTokens: maxTokens,
-                temperature: temperature,
-                repetitionPenalty: repetitionPenalty,
-                repetitionContextSize: repetitionContextSize
+            let chunks = audioChunks(
+                audio,
+                chunkDuration: chunkDuration,
+                minChunkDuration: minChunkDuration
             )
-            let genTime = Date().timeIntervalSince(genStart)
-            let text = tokenizer?
-                .decode(tokens: generatedTokens, skipSpecialTokens: true)
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let totalTime = Date().timeIntervalSince(start)
-            return STTOutput(
-                text: text,
-                segments: Self.parseSegments(text: text, fallbackEnd: prepared.duration),
-                promptTokens: prepared.promptTokenCount,
-                generationTokens: generatedTokens.count,
-                totalTokens: prepared.promptTokenCount + generatedTokens.count,
-                promptTps: prefillTime > 0 ? Double(prepared.promptTokenCount) / prefillTime : 0,
-                generationTps: genTime > 0 ? Double(generatedTokens.count) / genTime : 0,
-                totalTime: totalTime,
-                peakMemoryUsage: Double(Memory.peakMemory) / 1e9
-            )
+            var outputs: [STTOutput] = []
+            outputs.reserveCapacity(chunks.count)
+
+            for (chunkAudio, offsetSeconds) in chunks {
+                // MOSS emits verbose timestamped diarization text, so maxTokens is a
+                // per-chunk decode cap instead of a whole-file budget.
+                let output = try generateSingleChunk(
+                    audio: chunkAudio,
+                    maxTokens: maxTokens,
+                    temperature: temperature,
+                    repetitionPenalty: repetitionPenalty,
+                    repetitionContextSize: repetitionContextSize,
+                    prompt: prompt,
+                    offsetSeconds: Double(offsetSeconds)
+                )
+                outputs.append(output)
+                Memory.clearCache()
+            }
+
+            return Self.combineChunkOutputs(outputs, totalTime: Date().timeIntervalSince(start))
         } catch {
             fatalError("MOSS-Transcribe-Diarize generation failed: \(error)")
         }
@@ -525,6 +533,65 @@ private extension MossTranscribeDiarizeModel {
         )
     }
 
+    func audioChunks(
+        _ audio: MLXArray,
+        chunkDuration: Float,
+        minChunkDuration: Float
+    ) -> [(MLXArray, Float)] {
+        let safeChunkDuration = chunkDuration > 0 ? chunkDuration : defaultGenerationParameters.chunkDuration
+        return splitAudioIntoChunks(
+            audio,
+            sampleRate: sampleRate,
+            chunkDuration: safeChunkDuration,
+            minChunkDuration: max(0, minChunkDuration)
+        )
+    }
+
+    func generateSingleChunk(
+        audio: MLXArray,
+        maxTokens: Int,
+        temperature: Float,
+        repetitionPenalty: Float,
+        repetitionContextSize: Int,
+        prompt: String?,
+        offsetSeconds: Double
+    ) throws -> STTOutput {
+        let start = Date()
+        let prefillStart = Date()
+        let prepared = try prepareGenerationInputs(audio: audio, prompt: prompt)
+        let prefillTime = Date().timeIntervalSince(prefillStart)
+        let genStart = Date()
+        let generatedTokens = try generateTokenIds(
+            promptIds: prepared.promptIds,
+            inputEmbeddings: prepared.inputEmbeddings,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            repetitionPenalty: repetitionPenalty,
+            repetitionContextSize: repetitionContextSize
+        )
+        let genTime = Date().timeIntervalSince(genStart)
+        let rawText = tokenizer?
+            .decode(tokens: generatedTokens, skipSpecialTokens: true)
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let text = Self.offsetTimestampTags(in: rawText, by: offsetSeconds)
+        let totalTime = Date().timeIntervalSince(start)
+        return STTOutput(
+            text: text,
+            segments: Self.parseSegments(
+                text: rawText,
+                fallbackEnd: prepared.duration,
+                offsetSeconds: offsetSeconds
+            ),
+            promptTokens: prepared.promptTokenCount,
+            generationTokens: generatedTokens.count,
+            totalTokens: prepared.promptTokenCount + generatedTokens.count,
+            promptTps: prefillTime > 0 ? Double(prepared.promptTokenCount) / prefillTime : 0,
+            generationTps: genTime > 0 ? Double(generatedTokens.count) / genTime : 0,
+            totalTime: totalTime,
+            peakMemoryUsage: Double(Memory.peakMemory) / 1e9
+        )
+    }
+
     func eosTokenIds() -> Set<Int> {
         [151643, 151645]
     }
@@ -612,10 +679,72 @@ private extension MossTranscribeDiarizeModel {
 }
 
 extension MossTranscribeDiarizeModel {
-    static func parseSegments(text: String, fallbackEnd: Double) -> [[String: Any]] {
-        let pattern = #"\[(\d+(?:\.\d+)?)\]\[(S\d+)\](.*?)\[(\d+(?:\.\d+)?)\]"#
+    static func combineChunkOutputs(_ outputs: [STTOutput], totalTime: TimeInterval) -> STTOutput {
+        let text = outputs
+            .map(\.text)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let segments = outputs.flatMap { $0.segments ?? [] }
+        let promptTokens = outputs.reduce(0) { $0 + $1.promptTokens }
+        let generationTokens = outputs.reduce(0) { $0 + $1.generationTokens }
+        let totalTokens = outputs.reduce(0) { $0 + $1.totalTokens }
+        let peakMemoryUsage = outputs.map(\.peakMemoryUsage).max() ?? 0
+
+        return STTOutput(
+            text: text,
+            segments: segments.isEmpty ? nil : segments,
+            promptTokens: promptTokens,
+            generationTokens: generationTokens,
+            totalTokens: totalTokens,
+            promptTps: totalTime > 0 ? Double(promptTokens) / totalTime : 0,
+            generationTps: totalTime > 0 ? Double(generationTokens) / totalTime : 0,
+            totalTime: totalTime,
+            peakMemoryUsage: peakMemoryUsage
+        )
+    }
+
+    static func offsetTimestampTags(in text: String, by offsetSeconds: Double) -> String {
+        guard offsetSeconds != 0 else { return text }
+        let pattern = #"\[(\d+(?:[\.,]\d+)?)\]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        let timestampLocale = Locale(identifier: "en_US_POSIX")
+
+        let nsText = text as NSString
+        let matches = regex.matches(
+            in: text,
+            options: [],
+            range: NSRange(location: 0, length: nsText.length)
+        )
+        guard !matches.isEmpty else { return text }
+
+        var output = ""
+        var cursor = text.startIndex
+        for match in matches {
+            guard
+                let fullRange = Range(match.range, in: text),
+                let valueRange = Range(match.range(at: 1), in: text),
+                let value = Self.timestampValue(String(text[valueRange]))
+            else {
+                continue
+            }
+
+            output += text[cursor..<fullRange.lowerBound]
+            output += String(format: "[%.2f]", locale: timestampLocale, value + offsetSeconds)
+            cursor = fullRange.upperBound
+        }
+        output += text[cursor..<text.endIndex]
+        return output
+    }
+
+    static func parseSegments(
+        text: String,
+        fallbackEnd: Double,
+        offsetSeconds: Double = 0
+    ) -> [[String: Any]] {
+        let pattern = #"\[(\d+(?:[\.,]\d+)?)\]\[(S\d+)\](.*?)\[(\d+(?:[\.,]\d+)?)\]"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]) else {
-            return [["start": 0.0, "end": max(fallbackEnd, 0.0), "text": text]]
+            return [["start": offsetSeconds, "end": offsetSeconds + max(fallbackEnd, 0.0), "text": text]]
         }
 
         let nsText = text as NSString
@@ -627,8 +756,8 @@ extension MossTranscribeDiarizeModel {
         var segments: [[String: Any]] = []
         for match in matches {
             guard match.numberOfRanges == 5,
-                  let start = Double(nsText.substring(with: match.range(at: 1))),
-                  let end = Double(nsText.substring(with: match.range(at: 4))),
+                  let start = Self.timestampValue(nsText.substring(with: match.range(at: 1))),
+                  let end = Self.timestampValue(nsText.substring(with: match.range(at: 4))),
                   end >= start
             else {
                 continue
@@ -640,8 +769,8 @@ extension MossTranscribeDiarizeModel {
                 continue
             }
             segments.append([
-                "start": start,
-                "end": end,
+                "start": start + offsetSeconds,
+                "end": end + offsetSeconds,
                 "text": "[\(speaker)] \(segmentText)",
                 "speaker_id": speaker,
             ])
@@ -650,7 +779,11 @@ extension MossTranscribeDiarizeModel {
         if !segments.isEmpty {
             return segments
         }
-        return [["start": 0.0, "end": max(fallbackEnd, 0.0), "text": text]]
+        return [["start": offsetSeconds, "end": offsetSeconds + max(fallbackEnd, 0.0), "text": text]]
+    }
+
+    private static func timestampValue(_ text: String) -> Double? {
+        Double(text.replacingOccurrences(of: ",", with: "."))
     }
 
     static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -369,19 +369,20 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
                             emittedChunkText = true
                         }
                         outputs.append(output)
+                        let elapsed = Date().timeIntervalSince(start)
+                        continuation.yield(.info(Self.generationInfo(
+                            for: outputs,
+                            elapsedTime: elapsed
+                        )))
 
                         Memory.clearCache()
                     }
 
                     let totalTime = Date().timeIntervalSince(start)
                     let combined = Self.combineChunkOutputs(outputs, totalTime: totalTime)
-                    continuation.yield(.info(STTGenerationInfo(
-                        promptTokenCount: combined.promptTokens,
-                        generationTokenCount: combined.generationTokens,
-                        prefillTime: 0,
-                        generateTime: totalTime,
-                        tokensPerSecond: combined.generationTps,
-                        peakMemoryUsage: combined.peakMemoryUsage
+                    continuation.yield(.info(Self.generationInfo(
+                        for: outputs,
+                        elapsedTime: totalTime
                     )))
                     continuation.yield(.result(combined))
                     continuation.finish()
@@ -621,6 +622,8 @@ private extension MossTranscribeDiarizeModel {
         offsetSeconds: Double,
         onText: ((String) -> Void)? = nil
     ) throws -> STTOutput {
+        defer { Memory.clearCache() }
+
         let start = Date()
         let prefillStart = Date()
         let prepared = try prepareGenerationInputs(audio: audio, prompt: prompt)
@@ -687,6 +690,8 @@ private extension MossTranscribeDiarizeModel {
         var processedTokens = 0
 
         while totalTokens - processedTokens > 1 {
+            try Task.checkCancellation()
+
             let remaining = (totalTokens - processedTokens) - 1
             let n = min(prefillStepSize, remaining)
             let chunkIds = promptIds[0..., processedTokens..<(processedTokens + n)]
@@ -711,6 +716,8 @@ private extension MossTranscribeDiarizeModel {
         let eos = eosTokenIds()
 
         for tokenIndex in 0..<maxTokens {
+            try Task.checkCancellation()
+
             let token = nextTokenArray.item(Int.self)
             if eos.contains(token) {
                 break
@@ -797,6 +804,21 @@ extension MossTranscribeDiarizeModel {
             promptTps: totalTime > 0 ? Double(promptTokens) / totalTime : 0,
             generationTps: totalTime > 0 ? Double(generationTokens) / totalTime : 0,
             totalTime: totalTime,
+            peakMemoryUsage: peakMemoryUsage
+        )
+    }
+
+    static func generationInfo(for outputs: [STTOutput], elapsedTime: TimeInterval) -> STTGenerationInfo {
+        let promptTokens = outputs.reduce(0) { $0 + $1.promptTokens }
+        let generationTokens = outputs.reduce(0) { $0 + $1.generationTokens }
+        let peakMemoryUsage = outputs.map(\.peakMemoryUsage).max() ?? 0
+
+        return STTGenerationInfo(
+            promptTokenCount: promptTokens,
+            generationTokenCount: generationTokens,
+            prefillTime: 0,
+            generateTime: elapsedTime,
+            tokensPerSecond: elapsedTime > 0 ? Double(generationTokens) / elapsedTime : 0,
             peakMemoryUsage: peakMemoryUsage
         )
     }

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -679,6 +679,25 @@ private extension MossTranscribeDiarizeModel {
 }
 
 extension MossTranscribeDiarizeModel {
+    func streamingTranscribeWindow(
+        audio: MLXArray,
+        offsetSeconds: Double,
+        config: StreamingConfig
+    ) throws -> STTOutput {
+        let defaults = defaultGenerationParameters
+        let audioSeconds = Double(audio.dim(0)) / Double(sampleRate)
+        let estimatedWindowTokens = max(96, Int(ceil(audioSeconds * 32.0)))
+        return try generateSingleChunk(
+            audio: audio,
+            maxTokens: min(max(1, config.maxTokensPerPass), estimatedWindowTokens),
+            temperature: config.temperature,
+            repetitionPenalty: defaults.repetitionPenalty,
+            repetitionContextSize: defaults.repetitionContextSize,
+            prompt: nil,
+            offsetSeconds: offsetSeconds
+        )
+    }
+
     static func combineChunkOutputs(_ outputs: [STTOutput], totalTime: TimeInterval) -> STTOutput {
         let text = outputs
             .map(\.text)

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -767,19 +767,23 @@ extension MossTranscribeDiarizeModel {
     func streamingTranscribeWindow(
         audio: MLXArray,
         offsetSeconds: Double,
-        config: StreamingConfig
+        config: StreamingConfig,
+        maxTokens: Int? = nil,
+        onText: ((String) -> Void)? = nil
     ) throws -> STTOutput {
         let defaults = defaultGenerationParameters
         let audioSeconds = Double(audio.dim(0)) / Double(sampleRate)
         let estimatedWindowTokens = max(96, Int(ceil(audioSeconds * 32.0)))
+        let requestedMaxTokens = maxTokens ?? min(max(1, config.maxTokensPerPass), estimatedWindowTokens)
         return try generateSingleChunk(
             audio: audio,
-            maxTokens: min(max(1, config.maxTokensPerPass), estimatedWindowTokens),
+            maxTokens: max(1, requestedMaxTokens),
             temperature: config.temperature,
             repetitionPenalty: defaults.repetitionPenalty,
             repetitionContextSize: defaults.repetitionContextSize,
             prompt: nil,
-            offsetSeconds: offsetSeconds
+            offsetSeconds: offsetSeconds,
+            onText: onText
         )
     }
 

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -17,6 +17,64 @@ private let mossDefaultPrompt = """
 Transcribe the audio into text. Start each segment with the start timestamp and speaker label ([S01], [S02], [S03], ...), write the corresponding spoken content, and end each segment with the ending timestamp to clearly mark the segment range.
 """
 
+private struct MossTimestampTagOffsetter {
+    let offsetSeconds: Double
+    private var bufferedTag = ""
+    private var isBufferingTag = false
+
+    init(offsetSeconds: Double) {
+        self.offsetSeconds = offsetSeconds
+    }
+
+    mutating func consume(_ text: String) -> String {
+        guard offsetSeconds != 0 else { return text }
+
+        var output = ""
+        for character in text {
+            if isBufferingTag {
+                bufferedTag.append(character)
+                if character == "]" {
+                    output += offsetTag(bufferedTag)
+                    bufferedTag = ""
+                    isBufferingTag = false
+                } else if bufferedTag.count > 24 {
+                    output += bufferedTag
+                    bufferedTag = ""
+                    isBufferingTag = false
+                }
+            } else if character == "[" {
+                bufferedTag = "["
+                isBufferingTag = true
+            } else {
+                output.append(character)
+            }
+        }
+
+        return output
+    }
+
+    mutating func finish() -> String {
+        guard isBufferingTag else { return "" }
+        defer {
+            bufferedTag = ""
+            isBufferingTag = false
+        }
+        return bufferedTag
+    }
+
+    private func offsetTag(_ tag: String) -> String {
+        guard
+            tag.hasPrefix("["),
+            tag.hasSuffix("]"),
+            let value = Double(tag.dropFirst().dropLast().replacingOccurrences(of: ",", with: "."))
+        else {
+            return tag
+        }
+
+        return String(format: "[%.2f]", locale: Locale(identifier: "en_US_POSIX"), value + offsetSeconds)
+    }
+}
+
 public struct MossTranscribeDiarizeStreamingResult: Sendable {
     public let text: String
     public let isFinal: Bool
@@ -286,6 +344,7 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
 
                     for (chunkAudio, offsetSeconds) in chunks {
                         try Task.checkCancellation()
+                        var emittedChunkText = false
 
                         // MOSS emits verbose timestamped diarization text, so the UI's
                         // maxTokens setting is a per-chunk decode cap for long audio.
@@ -297,14 +356,19 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
                             repetitionContextSize: generationParameters.repetitionContextSize,
                             prompt: nil,
                             offsetSeconds: Double(offsetSeconds)
-                        )
-                        outputs.append(output)
-
-                        let text = output.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !text.isEmpty {
-                            continuation.yield(.token(emittedText ? "\n" + text : text))
-                            emittedText = true
+                        ) { text in
+                            guard !text.isEmpty else { return }
+                            if !emittedText {
+                                continuation.yield(.token(text))
+                                emittedText = true
+                            } else if !emittedChunkText {
+                                continuation.yield(.token("\n" + text))
+                            } else {
+                                continuation.yield(.token(text))
+                            }
+                            emittedChunkText = true
                         }
+                        outputs.append(output)
 
                         Memory.clearCache()
                     }
@@ -554,13 +618,15 @@ private extension MossTranscribeDiarizeModel {
         repetitionPenalty: Float,
         repetitionContextSize: Int,
         prompt: String?,
-        offsetSeconds: Double
+        offsetSeconds: Double,
+        onText: ((String) -> Void)? = nil
     ) throws -> STTOutput {
         let start = Date()
         let prefillStart = Date()
         let prepared = try prepareGenerationInputs(audio: audio, prompt: prompt)
         let prefillTime = Date().timeIntervalSince(prefillStart)
         let genStart = Date()
+        var offsetter = MossTimestampTagOffsetter(offsetSeconds: offsetSeconds)
         let generatedTokens = try generateTokenIds(
             promptIds: prepared.promptIds,
             inputEmbeddings: prepared.inputEmbeddings,
@@ -568,7 +634,17 @@ private extension MossTranscribeDiarizeModel {
             temperature: temperature,
             repetitionPenalty: repetitionPenalty,
             repetitionContextSize: repetitionContextSize
-        )
+        ) { token in
+            let rawDelta = self.tokenizer?.decode(tokens: [token], skipSpecialTokens: true) ?? ""
+            let shiftedDelta = offsetter.consume(rawDelta)
+            if !shiftedDelta.isEmpty {
+                onText?(shiftedDelta)
+            }
+        }
+        let bufferedText = offsetter.finish()
+        if !bufferedText.isEmpty {
+            onText?(bufferedText)
+        }
         let genTime = Date().timeIntervalSince(genStart)
         let rawText = tokenizer?
             .decode(tokens: generatedTokens, skipSpecialTokens: true)
@@ -602,7 +678,8 @@ private extension MossTranscribeDiarizeModel {
         maxTokens: Int,
         temperature: Float,
         repetitionPenalty: Float,
-        repetitionContextSize: Int
+        repetitionContextSize: Int,
+        onToken: ((Int) -> Void)? = nil
     ) throws -> [Int] {
         let cache = makeCache()
         let prefillStepSize = 2048
@@ -639,6 +716,7 @@ private extension MossTranscribeDiarizeModel {
                 break
             }
             generated.append(token)
+            onToken?(token)
 
             if repetitionPenalty == 1.0 && generated.count >= 24 {
                 let tail = generated.suffix(24)

--- a/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
+++ b/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
@@ -60,16 +60,23 @@ private struct StopSnapshot: Sendable {
 }
 
 private struct CohereStreamingSharedState: Sendable {
-    var samples: [Float] = []
+    var pendingSamples: [Float] = []
     var totalSamplesFed: Int = 0
     var lastDecodeTime: Date?
     var isDecoding: Bool = false
+    var finalizedWindowCount: Int = 0
+}
+
+private enum CohereDecodePassKind: Sendable {
+    case partial
+    case finalWindow
 }
 
 private struct CohereDecodePassParams: Sendable {
     let audio: UncheckedSendableBox<MLXArray>
     let model: UncheckedSendableBox<CohereTranscribeModel>
     let config: StreamingConfig
+    let kind: CohereDecodePassKind
     let confirmedTokenIds: [Int]
     let displayPrefix: String
     let prevProvisional: [Int]
@@ -77,6 +84,13 @@ private struct CohereDecodePassParams: Sendable {
     let prevAgreementCounts: [Int]
     let minAgreementPasses: Int
     let totalSamples: Int
+}
+
+private struct CohereDecodeLaunch: Sendable {
+    let samples: [Float]
+    let kind: CohereDecodePassKind
+    let totalSamples: Int
+    let encodedWindowCount: Int
 }
 
 private protocol StreamingInferenceSessionCore: AnyObject, Sendable {
@@ -134,6 +148,9 @@ public final class StreamingInferenceSession: @unchecked Sendable {
 private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, StreamingInferenceSessionCore {
     private let model: CohereTranscribeModel
     private let config: StreamingConfig
+    private let sampleRate: Int
+    private let windowSamples: Int
+    private let overlapSamples: Int
     private let shared = OSAllocatedUnfairLock(initialState: SessionSharedState())
     private let audioState = OSAllocatedUnfairLock(initialState: CohereStreamingSharedState())
     private let sessionLock = OSAllocatedUnfairLock(initialState: 0)
@@ -148,6 +165,16 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
     init(model: CohereTranscribeModel, config: StreamingConfig = StreamingConfig()) {
         self.model = model
         self.config = config
+        self.sampleRate = model.config.sampleRate
+        let windowSamples = model.config.sampleRate * 8
+        self.windowSamples = windowSamples
+        self.overlapSamples = max(
+            0,
+            min(
+                Int(round(config.encoderWindowOverlapSeconds * Double(model.config.sampleRate))),
+                max(0, windowSamples - 1)
+            )
+        )
 
         var continuation: AsyncStream<TranscriptionEvent>.Continuation!
         self.events = AsyncStream { continuation = $0 }
@@ -156,41 +183,57 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
     }
 
     func feedAudio(samples: [Float]) {
-        let decodeSnapshot: ([Float], Int)? = sessionLock.withLock { _ in
+        let launch: CohereDecodeLaunch? = sessionLock.withLock { _ in
             guard isActive else { return nil }
 
             let now = Date()
             audioState.withLock { state in
-                state.samples.append(contentsOf: samples)
+                state.pendingSamples.append(contentsOf: samples)
                 state.totalSamplesFed += samples.count
             }
 
-            let shouldDecode = audioState.withLock { state -> Bool in
-                guard state.totalSamplesFed >= 8_000 else { return false }
-                guard !state.isDecoding else { return false }
+            return audioState.withLock { state -> CohereDecodeLaunch? in
+                guard !state.isDecoding else { return nil }
+
+                if state.pendingSamples.count >= windowSamples {
+                    let window = Array(state.pendingSamples.prefix(windowSamples))
+                    let keepStart = max(0, windowSamples - overlapSamples)
+                    state.pendingSamples = Array(state.pendingSamples[keepStart...])
+                    state.finalizedWindowCount += 1
+                    state.isDecoding = true
+                    state.lastDecodeTime = now
+                    return CohereDecodeLaunch(
+                        samples: window,
+                        kind: .finalWindow,
+                        totalSamples: state.totalSamplesFed,
+                        encodedWindowCount: state.finalizedWindowCount
+                    )
+                }
+
+                guard state.pendingSamples.count >= sampleRate / 2 else { return nil }
                 if let lastDecode = state.lastDecodeTime,
                    now.timeIntervalSince(lastDecode) < max(0.2, config.decodeIntervalSeconds)
                 {
-                    return false
+                    return nil
                 }
 
                 state.isDecoding = true
                 state.lastDecodeTime = now
-                return true
-            }
-
-            guard shouldDecode else { return nil }
-            return audioState.withLock { state in
-                (state.samples, state.totalSamplesFed)
+                return CohereDecodeLaunch(
+                    samples: state.pendingSamples,
+                    kind: .partial,
+                    totalSamples: state.totalSamplesFed,
+                    encodedWindowCount: state.finalizedWindowCount
+                )
             }
         }
 
-        if let decodeSnapshot {
-            launchDecodePassLocked(samples: decodeSnapshot.0, totalSamples: decodeSnapshot.1)
+        if let launch {
+            launchDecodePass(launch)
         }
     }
 
-    private func launchDecodePassLocked(samples: [Float], totalSamples: Int) {
+    private func launchDecodePass(_ launch: CohereDecodeLaunch) {
         let snapshot = shared.withLock { state -> ([Int], String, [Int], [Date], [Int]) in
             let prefix = QwenStreamingInferenceSessionCore.concatText(state.completedText, state.confirmedText)
             return (state.confirmedTokenIds,
@@ -201,20 +244,22 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
         }
         let (confirmedTokenIds, displayPrefix, prevProvisional, prevFirstSeen, prevAgreementCounts) = snapshot
         let params = CohereDecodePassParams(
-            audio: UncheckedSendableBox(MLXArray(samples)),
+            audio: UncheckedSendableBox(MLXArray(launch.samples)),
             model: UncheckedSendableBox(model),
             config: config,
-            confirmedTokenIds: confirmedTokenIds,
-            displayPrefix: displayPrefix,
-            prevProvisional: prevProvisional,
-            prevFirstSeen: prevFirstSeen,
-            prevAgreementCounts: prevAgreementCounts,
-            minAgreementPasses: max(1, config.minAgreementPasses),
-            totalSamples: totalSamples
+            kind: launch.kind,
+            confirmedTokenIds: launch.kind == .partial ? confirmedTokenIds : [],
+            displayPrefix: launch.kind == .partial ? displayPrefix : "",
+            prevProvisional: launch.kind == .partial ? prevProvisional : [],
+            prevFirstSeen: launch.kind == .partial ? prevFirstSeen : [],
+            prevAgreementCounts: launch.kind == .partial ? prevAgreementCounts : [],
+            minAgreementPasses: launch.kind == .partial ? max(1, config.minAgreementPasses) : 1,
+            totalSamples: launch.totalSamples
         )
         let continuation = self.continuation
         let sharedState = self.shared
         let audioState = self.audioState
+        let encodedWindowCount = launch.encodedWindowCount
 
         decodeTask = Task.detached {
             defer {
@@ -225,7 +270,8 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
             Self.runDecodePass(
                 params: params,
                 continuation: continuation,
-                sharedState: sharedState
+                sharedState: sharedState,
+                encodedWindowCount: encodedWindowCount
             )
         }
     }
@@ -233,33 +279,68 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
     private static func runDecodePass(
         params: CohereDecodePassParams,
         continuation: AsyncStream<TranscriptionEvent>.Continuation?,
-        sharedState: OSAllocatedUnfairLock<SessionSharedState>
+        sharedState: OSAllocatedUnfairLock<SessionSharedState>,
+        encodedWindowCount: Int
     ) {
         if Task.isCancelled { return }
 
         let result = params.model.value.streamingDecodeTokenIds(
             audio: params.audio.value,
-            config: params.config
+            config: params.config,
+            confirmedTokenIds: params.confirmedTokenIds
         )
 
         if Task.isCancelled { return }
 
-        promoteTokens(
-            allTokenIds: result.tokenIds,
-            params: params,
-            continuation: continuation,
-            sharedState: sharedState
-        )
+        switch params.kind {
+        case .partial:
+            promoteTokens(
+                allTokenIds: result.tokenIds,
+                params: params,
+                continuation: continuation,
+                sharedState: sharedState
+            )
+        case .finalWindow:
+            finalizeWindow(
+                tokenIds: result.tokenIds,
+                model: params.model.value,
+                continuation: continuation,
+                sharedState: sharedState
+            )
+        }
 
-        let totalAudioSeconds = Double(params.totalSamples) / 16_000.0
+        let totalAudioSeconds = Double(params.totalSamples) / Double(params.model.value.config.sampleRate)
         let tokenCount = max(0, result.tokenIds.count - params.confirmedTokenIds.count)
         continuation?.yield(.stats(StreamingStats(
-            encodedWindowCount: max(1, Int(ceil(totalAudioSeconds / 8.0))),
+            encodedWindowCount: max(encodedWindowCount, Int(ceil(totalAudioSeconds / 8.0))),
             totalAudioSeconds: totalAudioSeconds,
             tokensPerSecond: result.decodeTime > 0 ? Double(tokenCount) / result.decodeTime : 0,
             realTimeFactor: result.totalTime / max(totalAudioSeconds, 0.001),
             peakMemoryGB: result.peakMemoryUsage
         )))
+    }
+
+    private static func finalizeWindow(
+        tokenIds: [Int],
+        model: CohereTranscribeModel,
+        continuation: AsyncStream<TranscriptionEvent>.Continuation?,
+        sharedState: OSAllocatedUnfairLock<SessionSharedState>
+    ) {
+        let windowText = model.streamingDecodeText(tokens: tokenIds)
+        let completedText = sharedState.withLock { state in
+            state.completedText = QwenStreamingInferenceSessionCore.concatText(state.completedText, windowText)
+            state.confirmedTokenIds = []
+            state.provisionalTokenIds = []
+            state.provisionalFirstSeen = []
+            state.provisionalAgreementCounts = []
+            state.confirmedText = ""
+            return state.completedText
+        }
+
+        continuation?.yield(.displayUpdate(
+            confirmedText: completedText,
+            provisionalText: ""
+        ))
     }
 
     private static func promoteTokens(
@@ -344,7 +425,13 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
     }
 
     func stop() {
-        let stopContext: (previousStopTask: Task<Void, Never>?, inFlightDecode: Task<Void, Never>?, snapshot: ([Float], Int, String)?)? =
+        let stopContext: (
+            previousStopTask: Task<Void, Never>?,
+            inFlightDecode: Task<Void, Never>?,
+            pendingSamples: [Float],
+            totalSamples: Int,
+            encodedWindowCount: Int
+        )? =
             sessionLock.withLock { _ in
                 guard isActive else { return nil }
                 isActive = false
@@ -353,22 +440,33 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
                 decodeTask = nil
 
                 let snapshot = audioState.withLock { state in
-                    let latestText = shared.withLock {
-                        QwenStreamingInferenceSessionCore.concatText($0.completedText, $0.confirmedText)
-                    }
-                    return (state.samples, state.totalSamplesFed, latestText)
+                    (
+                        state.pendingSamples,
+                        state.totalSamplesFed,
+                        state.finalizedWindowCount
+                    )
                 }
 
                 let previousStopTask = stopTask
                 stopTask = nil
-                return (previousStopTask, inFlightDecode, snapshot)
+                return (previousStopTask, inFlightDecode, snapshot.0, snapshot.1, snapshot.2)
             }
 
         guard let stopContext else { return }
         stopContext.previousStopTask?.cancel()
 
-        let task = Task.detached { [self, inFlightDecode = stopContext.inFlightDecode, snapshot = stopContext.snapshot] in
-            await finishStop(waitingFor: inFlightDecode, snapshot: snapshot)
+        let task = Task.detached {
+            [self,
+             inFlightDecode = stopContext.inFlightDecode,
+             pendingSamples = stopContext.pendingSamples,
+             totalSamples = stopContext.totalSamples,
+             encodedWindowCount = stopContext.encodedWindowCount] in
+            await finishStop(
+                waitingFor: inFlightDecode,
+                pendingSamples: pendingSamples,
+                totalSamples: totalSamples,
+                encodedWindowCount: encodedWindowCount
+            )
         }
 
         sessionLock.withLock { _ in
@@ -380,7 +478,9 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
 
     private func finishStop(
         waitingFor inFlightDecode: Task<Void, Never>?,
-        snapshot: ([Float], Int, String)?
+        pendingSamples: [Float],
+        totalSamples: Int,
+        encodedWindowCount: Int
     ) async {
         if let inFlightDecode {
             _ = await inFlightDecode.value
@@ -390,23 +490,25 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
             return
         }
 
-        if let snapshot, !snapshot.0.isEmpty {
+        if !pendingSamples.isEmpty {
             let params = CohereDecodePassParams(
-                audio: UncheckedSendableBox(MLXArray(snapshot.0)),
+                audio: UncheckedSendableBox(MLXArray(pendingSamples)),
                 model: UncheckedSendableBox(model),
                 config: config,
+                kind: .finalWindow,
                 confirmedTokenIds: [],
                 displayPrefix: "",
                 prevProvisional: [],
                 prevFirstSeen: [],
                 prevAgreementCounts: [],
                 minAgreementPasses: 1,
-                totalSamples: snapshot.1
+                totalSamples: totalSamples
             )
             Self.runDecodePass(
                 params: params,
                 continuation: continuation,
-                sharedState: shared
+                sharedState: shared,
+                encodedWindowCount: encodedWindowCount + 1
             )
         }
 
@@ -432,7 +534,7 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
             continuation = nil
             stopTask = nil
             audioState.withLock { state in
-                state.samples = []
+                state.pendingSamples = []
                 state.isDecoding = false
             }
         }
@@ -450,7 +552,7 @@ private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, St
             continuation?.finish()
             continuation = nil
             audioState.withLock { state in
-                state.samples = []
+                state.pendingSamples = []
                 state.isDecoding = false
             }
         }

--- a/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
+++ b/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
@@ -191,6 +191,7 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
     private let config: StreamingConfig
     private let sampleRate: Int
     private let windowSamples: Int
+    private let partialWindowSamples: Int
     private let minimumPartialSamples: Int
     private let shared = OSAllocatedUnfairLock(initialState: MossStreamingSharedState())
     private let audioState = OSAllocatedUnfairLock(initialState: MossAudioStreamingSharedState())
@@ -207,9 +208,13 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
         self.model = model
         self.config = config
         self.sampleRate = model.sampleRate
-        let windowSeconds = max(6.0, min(20.0, Double(max(1, config.maxDecodeWindows)) * 8.0))
+        let windowSeconds = max(3.0, min(6.0, Double(max(1, config.maxDecodeWindows)) * 4.0))
         self.windowSamples = max(model.sampleRate, Int(round(windowSeconds * Double(model.sampleRate))))
-        self.minimumPartialSamples = max(model.sampleRate, Int(round(2.0 * Double(model.sampleRate))))
+        self.minimumPartialSamples = max(model.sampleRate, Int(round(1.25 * Double(model.sampleRate))))
+        self.partialWindowSamples = max(
+            self.minimumPartialSamples,
+            Int(round(min(windowSeconds, 2.5) * Double(model.sampleRate)))
+        )
 
         var continuation: AsyncStream<TranscriptionEvent>.Continuation!
         self.events = AsyncStream { continuation = $0 }
@@ -256,10 +261,14 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
 
                 state.isDecoding = true
                 state.lastDecodeTime = now
+                let pendingCount = state.pendingSamples.count
+                let partialCount = min(pendingCount, partialWindowSamples)
+                let partialStart = pendingCount - partialCount
+                let partialSamples = Array(state.pendingSamples[partialStart..<pendingCount])
                 return MossDecodeLaunch(
-                    samples: state.pendingSamples,
+                    samples: partialSamples,
                     kind: .partial,
-                    offsetSeconds: Double(state.pendingStartSample) / Double(sampleRate),
+                    offsetSeconds: Double(state.pendingStartSample + partialStart) / Double(sampleRate),
                     totalSamples: state.totalSamplesFed,
                     encodedWindowCount: state.finalizedWindowCount
                 )
@@ -307,11 +316,38 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
 
         let decodeStart = Date()
         let output: STTOutput
+        var liveText = ""
+        let currentWindowSeconds = Double(params.audio.value.dim(0)) / Double(params.model.value.sampleRate)
+        let maxTokens: Int?
+        switch params.kind {
+        case .partial:
+            maxTokens = min(params.config.maxTokensPerPass, max(48, Int(ceil(currentWindowSeconds * 16.0))))
+        case .finalWindow:
+            maxTokens = nil
+        }
+        let onText: (String) -> Void = { delta in
+            guard !Task.isCancelled, !delta.isEmpty else { return }
+            liveText += delta
+            let provisional = liveText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !provisional.isEmpty else { return }
+            let completed = sharedState.withLock { state -> String in
+                state.provisionalText = provisional
+                return state.completedText
+            }
+            yieldMossDisplayUpdate(
+                completedText: completed,
+                provisionalText: provisional,
+                continuation: continuation
+            )
+        }
+
         do {
             output = try params.model.value.streamingTranscribeWindow(
                 audio: params.audio.value,
                 offsetSeconds: params.offsetSeconds,
-                config: params.config
+                config: params.config,
+                maxTokens: maxTokens,
+                onText: onText
             )
         } catch {
             return
@@ -326,10 +362,11 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
                 state.provisionalText = text
                 return state.completedText
             }
-            continuation?.yield(.displayUpdate(
-                confirmedText: completed,
-                provisionalText: text
-            ))
+            yieldMossDisplayUpdate(
+                completedText: completed,
+                provisionalText: text,
+                continuation: continuation
+            )
 
         case .finalWindow:
             let completed = sharedState.withLock { state -> String in
@@ -345,7 +382,6 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
 
         let decodeTime = Date().timeIntervalSince(decodeStart)
         let totalAudioSeconds = Double(params.totalSamples) / Double(params.model.value.sampleRate)
-        let currentWindowSeconds = Double(params.audio.value.dim(0)) / Double(params.model.value.sampleRate)
         continuation?.yield(.stats(StreamingStats(
             encodedWindowCount: max(params.encodedWindowCount, Int(ceil(totalAudioSeconds / max(currentWindowSeconds, 0.001)))),
             totalAudioSeconds: totalAudioSeconds,
@@ -353,6 +389,22 @@ private final class MossStreamingInferenceSessionCore: @unchecked Sendable, Stre
             realTimeFactor: decodeTime / max(currentWindowSeconds, 0.001),
             peakMemoryGB: output.peakMemoryUsage
         )))
+    }
+
+    private static func yieldMossDisplayUpdate(
+        completedText: String,
+        provisionalText: String,
+        continuation: AsyncStream<TranscriptionEvent>.Continuation?
+    ) {
+        let confirmedText = !completedText.isEmpty
+            && !provisionalText.isEmpty
+            && !provisionalText.hasPrefix("\n")
+            ? completedText + "\n"
+            : completedText
+        continuation?.yield(.displayUpdate(
+            confirmedText: confirmedText,
+            provisionalText: provisionalText
+        ))
     }
 
     private static func appendMossText(_ segment: String, to base: inout String) {

--- a/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
+++ b/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
@@ -59,6 +59,34 @@ private struct StopSnapshot: Sendable {
     let fallbackFinalText: String?
 }
 
+private struct CohereStreamingSharedState: Sendable {
+    var samples: [Float] = []
+    var totalSamplesFed: Int = 0
+    var lastDecodeTime: Date?
+    var isDecoding: Bool = false
+}
+
+private struct CohereDecodePassParams: Sendable {
+    let audio: UncheckedSendableBox<MLXArray>
+    let model: UncheckedSendableBox<CohereTranscribeModel>
+    let config: StreamingConfig
+    let confirmedTokenIds: [Int]
+    let displayPrefix: String
+    let prevProvisional: [Int]
+    let prevFirstSeen: [Date]
+    let prevAgreementCounts: [Int]
+    let minAgreementPasses: Int
+    let totalSamples: Int
+}
+
+private protocol StreamingInferenceSessionCore: AnyObject, Sendable {
+    var events: AsyncStream<TranscriptionEvent> { get }
+
+    func feedAudio(samples: [Float])
+    func stop()
+    func cancel()
+}
+
 /// Orchestrates streaming speech-to-text inference.
 ///
 /// Streaming decode runs on the current **pending** (partial) encoder window for
@@ -66,7 +94,370 @@ private struct StopSnapshot: Sendable {
 /// optionally run a one-shot decode for that completed window
 /// (`StreamingConfig.finalizeCompletedWindows`) to improve accuracy, then resets
 /// decode state for the next window.
-public class StreamingInferenceSession: @unchecked Sendable {
+public final class StreamingInferenceSession: @unchecked Sendable {
+    private let core: any StreamingInferenceSessionCore
+
+    public let events: AsyncStream<TranscriptionEvent>
+
+    private init(core: any StreamingInferenceSessionCore) {
+        self.core = core
+        self.events = core.events
+    }
+
+    public convenience init(model: Qwen3ASRModel, config: StreamingConfig = StreamingConfig()) {
+        self.init(core: QwenStreamingInferenceSessionCore(model: model, config: config))
+    }
+
+    public convenience init(model: any STTGenerationModel, config: StreamingConfig = StreamingConfig()) {
+        if let qwenModel = model as? Qwen3ASRModel {
+            self.init(model: qwenModel, config: config)
+        } else if let cohereModel = model as? CohereTranscribeModel {
+            self.init(core: CohereStreamingInferenceSessionCore(model: cohereModel, config: config))
+        } else {
+            preconditionFailure("StreamingInferenceSession requires Qwen3ASRModel or CohereTranscribeModel")
+        }
+    }
+
+    public func feedAudio(samples: [Float]) {
+        core.feedAudio(samples: samples)
+    }
+
+    public func stop() {
+        core.stop()
+    }
+
+    public func cancel() {
+        core.cancel()
+    }
+}
+
+private final class CohereStreamingInferenceSessionCore: @unchecked Sendable, StreamingInferenceSessionCore {
+    private let model: CohereTranscribeModel
+    private let config: StreamingConfig
+    private let shared = OSAllocatedUnfairLock(initialState: SessionSharedState())
+    private let audioState = OSAllocatedUnfairLock(initialState: CohereStreamingSharedState())
+    private let sessionLock = OSAllocatedUnfairLock(initialState: 0)
+
+    private var isActive: Bool = false
+    private var continuation: AsyncStream<TranscriptionEvent>.Continuation?
+    private var decodeTask: Task<Void, Never>?
+    private var stopTask: Task<Void, Never>?
+
+    let events: AsyncStream<TranscriptionEvent>
+
+    init(model: CohereTranscribeModel, config: StreamingConfig = StreamingConfig()) {
+        self.model = model
+        self.config = config
+
+        var continuation: AsyncStream<TranscriptionEvent>.Continuation!
+        self.events = AsyncStream { continuation = $0 }
+        self.continuation = continuation
+        self.isActive = true
+    }
+
+    func feedAudio(samples: [Float]) {
+        let decodeSnapshot: ([Float], Int)? = sessionLock.withLock { _ in
+            guard isActive else { return nil }
+
+            let now = Date()
+            audioState.withLock { state in
+                state.samples.append(contentsOf: samples)
+                state.totalSamplesFed += samples.count
+            }
+
+            let shouldDecode = audioState.withLock { state -> Bool in
+                guard state.totalSamplesFed >= 8_000 else { return false }
+                guard !state.isDecoding else { return false }
+                if let lastDecode = state.lastDecodeTime,
+                   now.timeIntervalSince(lastDecode) < max(0.2, config.decodeIntervalSeconds)
+                {
+                    return false
+                }
+
+                state.isDecoding = true
+                state.lastDecodeTime = now
+                return true
+            }
+
+            guard shouldDecode else { return nil }
+            return audioState.withLock { state in
+                (state.samples, state.totalSamplesFed)
+            }
+        }
+
+        if let decodeSnapshot {
+            launchDecodePassLocked(samples: decodeSnapshot.0, totalSamples: decodeSnapshot.1)
+        }
+    }
+
+    private func launchDecodePassLocked(samples: [Float], totalSamples: Int) {
+        let snapshot = shared.withLock { state -> ([Int], String, [Int], [Date], [Int]) in
+            let prefix = QwenStreamingInferenceSessionCore.concatText(state.completedText, state.confirmedText)
+            return (state.confirmedTokenIds,
+                    prefix,
+                    state.provisionalTokenIds,
+                    state.provisionalFirstSeen,
+                    state.provisionalAgreementCounts)
+        }
+        let (confirmedTokenIds, displayPrefix, prevProvisional, prevFirstSeen, prevAgreementCounts) = snapshot
+        let params = CohereDecodePassParams(
+            audio: UncheckedSendableBox(MLXArray(samples)),
+            model: UncheckedSendableBox(model),
+            config: config,
+            confirmedTokenIds: confirmedTokenIds,
+            displayPrefix: displayPrefix,
+            prevProvisional: prevProvisional,
+            prevFirstSeen: prevFirstSeen,
+            prevAgreementCounts: prevAgreementCounts,
+            minAgreementPasses: max(1, config.minAgreementPasses),
+            totalSamples: totalSamples
+        )
+        let continuation = self.continuation
+        let sharedState = self.shared
+        let audioState = self.audioState
+
+        decodeTask = Task.detached {
+            defer {
+                sharedState.withLock { $0.isDecoding = false }
+                audioState.withLock { $0.isDecoding = false }
+            }
+
+            Self.runDecodePass(
+                params: params,
+                continuation: continuation,
+                sharedState: sharedState
+            )
+        }
+    }
+
+    private static func runDecodePass(
+        params: CohereDecodePassParams,
+        continuation: AsyncStream<TranscriptionEvent>.Continuation?,
+        sharedState: OSAllocatedUnfairLock<SessionSharedState>
+    ) {
+        if Task.isCancelled { return }
+
+        let result = params.model.value.streamingDecodeTokenIds(
+            audio: params.audio.value,
+            config: params.config
+        )
+
+        if Task.isCancelled { return }
+
+        promoteTokens(
+            allTokenIds: result.tokenIds,
+            params: params,
+            continuation: continuation,
+            sharedState: sharedState
+        )
+
+        let totalAudioSeconds = Double(params.totalSamples) / 16_000.0
+        let tokenCount = max(0, result.tokenIds.count - params.confirmedTokenIds.count)
+        continuation?.yield(.stats(StreamingStats(
+            encodedWindowCount: max(1, Int(ceil(totalAudioSeconds / 8.0))),
+            totalAudioSeconds: totalAudioSeconds,
+            tokensPerSecond: result.decodeTime > 0 ? Double(tokenCount) / result.decodeTime : 0,
+            realTimeFactor: result.totalTime / max(totalAudioSeconds, 0.001),
+            peakMemoryGB: result.peakMemoryUsage
+        )))
+    }
+
+    private static func promoteTokens(
+        allTokenIds: [Int],
+        params: CohereDecodePassParams,
+        continuation: AsyncStream<TranscriptionEvent>.Continuation?,
+        sharedState: OSAllocatedUnfairLock<SessionSharedState>
+    ) {
+        let confirmedCount = params.confirmedTokenIds.count
+        let prevProvisional = params.prevProvisional
+        let prevFirstSeen = params.prevFirstSeen
+        let prevAgreementCounts = params.prevAgreementCounts
+
+        let newProvisional = Array(allTokenIds.dropFirst(min(confirmedCount, allTokenIds.count)))
+        let now = Date()
+        let delaySeconds = Double(params.config.delayPreset.delayMs) / 1000.0
+
+        var matchLen = 0
+        let compareLen = min(prevProvisional.count, newProvisional.count)
+        for i in 0..<compareLen {
+            if prevProvisional[i] == newProvisional[i] {
+                matchLen = i + 1
+            } else {
+                break
+            }
+        }
+
+        var nextFirstSeen: [Date] = []
+        nextFirstSeen.reserveCapacity(newProvisional.count)
+        var nextAgreementCounts: [Int] = []
+        nextAgreementCounts.reserveCapacity(newProvisional.count)
+
+        for i in 0..<newProvisional.count {
+            if i < matchLen {
+                let firstSeen = i < prevFirstSeen.count ? prevFirstSeen[i] : now
+                let prevAgreement = i < prevAgreementCounts.count ? prevAgreementCounts[i] : 1
+                nextFirstSeen.append(firstSeen)
+                nextAgreementCounts.append(max(1, prevAgreement + 1))
+            } else {
+                nextFirstSeen.append(now)
+                nextAgreementCounts.append(1)
+            }
+        }
+
+        var promotionCount = 0
+        for i in 0..<newProvisional.count {
+            let hasDelay = i < nextFirstSeen.count && now.timeIntervalSince(nextFirstSeen[i]) >= delaySeconds
+            let hasAgreement = i < nextAgreementCounts.count && nextAgreementCounts[i] >= params.minAgreementPasses
+            if hasDelay && hasAgreement {
+                promotionCount = i + 1
+            } else {
+                break
+            }
+        }
+
+        let promoteCount = promotionCount
+        let finalProvisional = Array(newProvisional.dropFirst(promoteCount))
+        let finalFirstSeen = Array(nextFirstSeen.dropFirst(promoteCount))
+        let finalAgreementCounts = Array(nextAgreementCounts.dropFirst(promoteCount))
+
+        let displayPrefix: String = sharedState.withLock { state in
+            if promoteCount > 0 {
+                let promoted = Array(newProvisional.prefix(promoteCount))
+                state.confirmedTokenIds.append(contentsOf: promoted)
+                state.confirmedText = params.model.value.streamingDecodeText(tokens: state.confirmedTokenIds)
+                continuation?.yield(.confirmed(text: QwenStreamingInferenceSessionCore.concatText(
+                    state.completedText,
+                    state.confirmedText
+                )))
+            }
+            state.provisionalTokenIds = finalProvisional
+            state.provisionalFirstSeen = finalFirstSeen
+            state.provisionalAgreementCounts = finalAgreementCounts
+            return QwenStreamingInferenceSessionCore.concatText(state.completedText, state.confirmedText)
+        }
+
+        let finalProvText = params.model.value.streamingDecodeText(tokens: finalProvisional)
+        continuation?.yield(.displayUpdate(
+            confirmedText: displayPrefix,
+            provisionalText: finalProvText
+        ))
+    }
+
+    func stop() {
+        let stopContext: (previousStopTask: Task<Void, Never>?, inFlightDecode: Task<Void, Never>?, snapshot: ([Float], Int, String)?)? =
+            sessionLock.withLock { _ in
+                guard isActive else { return nil }
+                isActive = false
+
+                let inFlightDecode = decodeTask
+                decodeTask = nil
+
+                let snapshot = audioState.withLock { state in
+                    let latestText = shared.withLock {
+                        QwenStreamingInferenceSessionCore.concatText($0.completedText, $0.confirmedText)
+                    }
+                    return (state.samples, state.totalSamplesFed, latestText)
+                }
+
+                let previousStopTask = stopTask
+                stopTask = nil
+                return (previousStopTask, inFlightDecode, snapshot)
+            }
+
+        guard let stopContext else { return }
+        stopContext.previousStopTask?.cancel()
+
+        let task = Task.detached { [self, inFlightDecode = stopContext.inFlightDecode, snapshot = stopContext.snapshot] in
+            await finishStop(waitingFor: inFlightDecode, snapshot: snapshot)
+        }
+
+        sessionLock.withLock { _ in
+            if continuation != nil {
+                stopTask = task
+            }
+        }
+    }
+
+    private func finishStop(
+        waitingFor inFlightDecode: Task<Void, Never>?,
+        snapshot: ([Float], Int, String)?
+    ) async {
+        if let inFlightDecode {
+            _ = await inFlightDecode.value
+        }
+
+        if Task.isCancelled {
+            return
+        }
+
+        if let snapshot, !snapshot.0.isEmpty {
+            let params = CohereDecodePassParams(
+                audio: UncheckedSendableBox(MLXArray(snapshot.0)),
+                model: UncheckedSendableBox(model),
+                config: config,
+                confirmedTokenIds: [],
+                displayPrefix: "",
+                prevProvisional: [],
+                prevFirstSeen: [],
+                prevAgreementCounts: [],
+                minAgreementPasses: 1,
+                totalSamples: snapshot.1
+            )
+            Self.runDecodePass(
+                params: params,
+                continuation: continuation,
+                sharedState: shared
+            )
+        }
+
+        let finalText = shared.withLock { state -> String in
+            if !state.provisionalTokenIds.isEmpty {
+                state.confirmedTokenIds.append(contentsOf: state.provisionalTokenIds)
+                state.provisionalTokenIds = []
+                state.provisionalFirstSeen = []
+                state.provisionalAgreementCounts = []
+            }
+            state.confirmedText = model.streamingDecodeText(tokens: state.confirmedTokenIds)
+            return QwenStreamingInferenceSessionCore.concatText(state.completedText, state.confirmedText)
+        }
+
+        if Task.isCancelled {
+            return
+        }
+
+        continuation?.yield(.ended(fullText: finalText))
+        continuation?.finish()
+
+        sessionLock.withLock { _ in
+            continuation = nil
+            stopTask = nil
+            audioState.withLock { state in
+                state.samples = []
+                state.isDecoding = false
+            }
+        }
+
+        Memory.clearCache()
+    }
+
+    func cancel() {
+        sessionLock.withLock { _ in
+            isActive = false
+            decodeTask?.cancel()
+            decodeTask = nil
+            stopTask?.cancel()
+            stopTask = nil
+            continuation?.finish()
+            continuation = nil
+            audioState.withLock { state in
+                state.samples = []
+                state.isDecoding = false
+            }
+        }
+    }
+}
+
+private final class QwenStreamingInferenceSessionCore: @unchecked Sendable, StreamingInferenceSessionCore {
     private let model: Qwen3ASRModel
     private let config: StreamingConfig
     private let melProcessor: IncrementalMelSpectrogram
@@ -87,9 +478,9 @@ public class StreamingInferenceSession: @unchecked Sendable {
     private var decodeTask: Task<Void, Never>?
     private var stopTask: Task<Void, Never>?
 
-    public let events: AsyncStream<TranscriptionEvent>
+    let events: AsyncStream<TranscriptionEvent>
 
-    public init(model: Qwen3ASRModel, config: StreamingConfig = StreamingConfig()) {
+    init(model: Qwen3ASRModel, config: StreamingConfig = StreamingConfig()) {
         self.model = model
         self.config = config
         let overlapFrames = max(0, Int(round(config.encoderWindowOverlapSeconds * Double(model.sampleRate) / 160.0)))
@@ -111,7 +502,7 @@ public class StreamingInferenceSession: @unchecked Sendable {
         self.isActive = true
     }
 
-    public func feedAudio(samples: [Float]) {
+    func feedAudio(samples: [Float]) {
         sessionLock.withLock { _ in
             guard isActive else { return }
 
@@ -441,7 +832,7 @@ public class StreamingInferenceSession: @unchecked Sendable {
         return remainder.joined(separator: " ")
     }
 
-    private static func concatText(_ a: String, _ b: String) -> String {
+    fileprivate static func concatText(_ a: String, _ b: String) -> String {
         var result = a
         appendText(b, to: &result)
         return result

--- a/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
+++ b/Sources/MLXAudioSTT/Streaming/StreamingInferenceSession.swift
@@ -93,6 +93,43 @@ private struct CohereDecodeLaunch: Sendable {
     let encodedWindowCount: Int
 }
 
+private struct MossStreamingSharedState: Sendable {
+    var completedText: String = ""
+    var provisionalText: String = ""
+}
+
+private struct MossAudioStreamingSharedState: Sendable {
+    var pendingSamples: [Float] = []
+    var pendingStartSample: Int = 0
+    var totalSamplesFed: Int = 0
+    var lastDecodeTime: Date?
+    var isDecoding: Bool = false
+    var finalizedWindowCount: Int = 0
+}
+
+private enum MossDecodePassKind: Sendable {
+    case partial
+    case finalWindow
+}
+
+private struct MossDecodePassParams: Sendable {
+    let audio: UncheckedSendableBox<MLXArray>
+    let model: UncheckedSendableBox<MossTranscribeDiarizeModel>
+    let config: StreamingConfig
+    let kind: MossDecodePassKind
+    let offsetSeconds: Double
+    let totalSamples: Int
+    let encodedWindowCount: Int
+}
+
+private struct MossDecodeLaunch: Sendable {
+    let samples: [Float]
+    let kind: MossDecodePassKind
+    let offsetSeconds: Double
+    let totalSamples: Int
+    let encodedWindowCount: Int
+}
+
 private protocol StreamingInferenceSessionCore: AnyObject, Sendable {
     var events: AsyncStream<TranscriptionEvent> { get }
 
@@ -127,8 +164,12 @@ public final class StreamingInferenceSession: @unchecked Sendable {
             self.init(model: qwenModel, config: config)
         } else if let cohereModel = model as? CohereTranscribeModel {
             self.init(core: CohereStreamingInferenceSessionCore(model: cohereModel, config: config))
+        } else if let mossModel = model as? MossTranscribeDiarizeModel {
+            self.init(core: MossStreamingInferenceSessionCore(model: mossModel, config: config))
         } else {
-            preconditionFailure("StreamingInferenceSession requires Qwen3ASRModel or CohereTranscribeModel")
+            preconditionFailure(
+                "StreamingInferenceSession requires Qwen3ASRModel, CohereTranscribeModel, or MossTranscribeDiarizeModel"
+            )
         }
     }
 
@@ -142,6 +183,317 @@ public final class StreamingInferenceSession: @unchecked Sendable {
 
     public func cancel() {
         core.cancel()
+    }
+}
+
+private final class MossStreamingInferenceSessionCore: @unchecked Sendable, StreamingInferenceSessionCore {
+    private let model: MossTranscribeDiarizeModel
+    private let config: StreamingConfig
+    private let sampleRate: Int
+    private let windowSamples: Int
+    private let minimumPartialSamples: Int
+    private let shared = OSAllocatedUnfairLock(initialState: MossStreamingSharedState())
+    private let audioState = OSAllocatedUnfairLock(initialState: MossAudioStreamingSharedState())
+    private let sessionLock = OSAllocatedUnfairLock(initialState: 0)
+
+    private var isActive: Bool = false
+    private var continuation: AsyncStream<TranscriptionEvent>.Continuation?
+    private var decodeTask: Task<Void, Never>?
+    private var stopTask: Task<Void, Never>?
+
+    let events: AsyncStream<TranscriptionEvent>
+
+    init(model: MossTranscribeDiarizeModel, config: StreamingConfig = StreamingConfig()) {
+        self.model = model
+        self.config = config
+        self.sampleRate = model.sampleRate
+        let windowSeconds = max(6.0, min(20.0, Double(max(1, config.maxDecodeWindows)) * 8.0))
+        self.windowSamples = max(model.sampleRate, Int(round(windowSeconds * Double(model.sampleRate))))
+        self.minimumPartialSamples = max(model.sampleRate, Int(round(2.0 * Double(model.sampleRate))))
+
+        var continuation: AsyncStream<TranscriptionEvent>.Continuation!
+        self.events = AsyncStream { continuation = $0 }
+        self.continuation = continuation
+        self.isActive = true
+    }
+
+    func feedAudio(samples: [Float]) {
+        let launch: MossDecodeLaunch? = sessionLock.withLock { _ in
+            guard isActive else { return nil }
+
+            let now = Date()
+            audioState.withLock { state in
+                state.pendingSamples.append(contentsOf: samples)
+                state.totalSamplesFed += samples.count
+            }
+
+            return audioState.withLock { state -> MossDecodeLaunch? in
+                guard !state.isDecoding else { return nil }
+
+                if state.pendingSamples.count >= windowSamples {
+                    let window = Array(state.pendingSamples.prefix(windowSamples))
+                    let offsetSeconds = Double(state.pendingStartSample) / Double(sampleRate)
+                    state.pendingSamples = Array(state.pendingSamples.dropFirst(windowSamples))
+                    state.pendingStartSample += windowSamples
+                    state.finalizedWindowCount += 1
+                    state.isDecoding = true
+                    state.lastDecodeTime = now
+                    return MossDecodeLaunch(
+                        samples: window,
+                        kind: .finalWindow,
+                        offsetSeconds: offsetSeconds,
+                        totalSamples: state.totalSamplesFed,
+                        encodedWindowCount: state.finalizedWindowCount
+                    )
+                }
+
+                guard state.pendingSamples.count >= minimumPartialSamples else { return nil }
+                if let lastDecode = state.lastDecodeTime,
+                   now.timeIntervalSince(lastDecode) < max(1.0, config.decodeIntervalSeconds)
+                {
+                    return nil
+                }
+
+                state.isDecoding = true
+                state.lastDecodeTime = now
+                return MossDecodeLaunch(
+                    samples: state.pendingSamples,
+                    kind: .partial,
+                    offsetSeconds: Double(state.pendingStartSample) / Double(sampleRate),
+                    totalSamples: state.totalSamplesFed,
+                    encodedWindowCount: state.finalizedWindowCount
+                )
+            }
+        }
+
+        if let launch {
+            launchDecodePass(launch)
+        }
+    }
+
+    private func launchDecodePass(_ launch: MossDecodeLaunch) {
+        let params = MossDecodePassParams(
+            audio: UncheckedSendableBox(MLXArray(launch.samples)),
+            model: UncheckedSendableBox(model),
+            config: config,
+            kind: launch.kind,
+            offsetSeconds: launch.offsetSeconds,
+            totalSamples: launch.totalSamples,
+            encodedWindowCount: launch.encodedWindowCount
+        )
+        let continuation = self.continuation
+        let sharedState = self.shared
+        let audioState = self.audioState
+
+        decodeTask = Task.detached {
+            defer {
+                audioState.withLock { $0.isDecoding = false }
+            }
+
+            Self.runDecodePass(
+                params: params,
+                continuation: continuation,
+                sharedState: sharedState
+            )
+        }
+    }
+
+    private static func runDecodePass(
+        params: MossDecodePassParams,
+        continuation: AsyncStream<TranscriptionEvent>.Continuation?,
+        sharedState: OSAllocatedUnfairLock<MossStreamingSharedState>
+    ) {
+        if Task.isCancelled { return }
+
+        let decodeStart = Date()
+        let output: STTOutput
+        do {
+            output = try params.model.value.streamingTranscribeWindow(
+                audio: params.audio.value,
+                offsetSeconds: params.offsetSeconds,
+                config: params.config
+            )
+        } catch {
+            return
+        }
+
+        if Task.isCancelled { return }
+
+        let text = output.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch params.kind {
+        case .partial:
+            let completed = sharedState.withLock { state -> String in
+                state.provisionalText = text
+                return state.completedText
+            }
+            continuation?.yield(.displayUpdate(
+                confirmedText: completed,
+                provisionalText: text
+            ))
+
+        case .finalWindow:
+            let completed = sharedState.withLock { state -> String in
+                appendMossText(text, to: &state.completedText)
+                state.provisionalText = ""
+                return state.completedText
+            }
+            continuation?.yield(.displayUpdate(
+                confirmedText: completed,
+                provisionalText: ""
+            ))
+        }
+
+        let decodeTime = Date().timeIntervalSince(decodeStart)
+        let totalAudioSeconds = Double(params.totalSamples) / Double(params.model.value.sampleRate)
+        let currentWindowSeconds = Double(params.audio.value.dim(0)) / Double(params.model.value.sampleRate)
+        continuation?.yield(.stats(StreamingStats(
+            encodedWindowCount: max(params.encodedWindowCount, Int(ceil(totalAudioSeconds / max(currentWindowSeconds, 0.001)))),
+            totalAudioSeconds: totalAudioSeconds,
+            tokensPerSecond: decodeTime > 0 ? Double(output.generationTokens) / decodeTime : 0,
+            realTimeFactor: decodeTime / max(currentWindowSeconds, 0.001),
+            peakMemoryGB: output.peakMemoryUsage
+        )))
+    }
+
+    private static func appendMossText(_ segment: String, to base: inout String) {
+        let normalizedSegment = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedSegment.isEmpty else { return }
+        if base.isEmpty {
+            base = normalizedSegment
+        } else {
+            base += "\n" + normalizedSegment
+        }
+    }
+
+    func stop() {
+        let stopContext: (
+            previousStopTask: Task<Void, Never>?,
+            inFlightDecode: Task<Void, Never>?,
+            pendingSamples: [Float],
+            pendingStartSample: Int,
+            totalSamples: Int,
+            encodedWindowCount: Int
+        )? =
+            sessionLock.withLock { _ in
+                guard isActive else { return nil }
+                isActive = false
+
+                let inFlightDecode = decodeTask
+                decodeTask = nil
+
+                let snapshot = audioState.withLock { state in
+                    (
+                        state.pendingSamples,
+                        state.pendingStartSample,
+                        state.totalSamplesFed,
+                        state.finalizedWindowCount
+                    )
+                }
+
+                let previousStopTask = stopTask
+                stopTask = nil
+                return (previousStopTask, inFlightDecode, snapshot.0, snapshot.1, snapshot.2, snapshot.3)
+            }
+
+        guard let stopContext else { return }
+        stopContext.previousStopTask?.cancel()
+
+        let task = Task.detached {
+            [self,
+             inFlightDecode = stopContext.inFlightDecode,
+             pendingSamples = stopContext.pendingSamples,
+             pendingStartSample = stopContext.pendingStartSample,
+             totalSamples = stopContext.totalSamples,
+             encodedWindowCount = stopContext.encodedWindowCount] in
+            await finishStop(
+                waitingFor: inFlightDecode,
+                pendingSamples: pendingSamples,
+                pendingStartSample: pendingStartSample,
+                totalSamples: totalSamples,
+                encodedWindowCount: encodedWindowCount
+            )
+        }
+
+        sessionLock.withLock { _ in
+            if continuation != nil {
+                stopTask = task
+            }
+        }
+    }
+
+    private func finishStop(
+        waitingFor inFlightDecode: Task<Void, Never>?,
+        pendingSamples: [Float],
+        pendingStartSample: Int,
+        totalSamples: Int,
+        encodedWindowCount: Int
+    ) async {
+        if let inFlightDecode {
+            _ = await inFlightDecode.value
+        }
+
+        if Task.isCancelled {
+            return
+        }
+
+        if !pendingSamples.isEmpty {
+            let params = MossDecodePassParams(
+                audio: UncheckedSendableBox(MLXArray(pendingSamples)),
+                model: UncheckedSendableBox(model),
+                config: config,
+                kind: .finalWindow,
+                offsetSeconds: Double(pendingStartSample) / Double(sampleRate),
+                totalSamples: totalSamples,
+                encodedWindowCount: encodedWindowCount + 1
+            )
+            Self.runDecodePass(
+                params: params,
+                continuation: continuation,
+                sharedState: shared
+            )
+        }
+
+        let finalText = shared.withLock { state in
+            if state.completedText.isEmpty {
+                return state.provisionalText
+            }
+            return state.completedText
+        }
+
+        if Task.isCancelled {
+            return
+        }
+
+        continuation?.yield(.ended(fullText: finalText))
+        continuation?.finish()
+
+        sessionLock.withLock { _ in
+            continuation = nil
+            stopTask = nil
+            audioState.withLock { state in
+                state.pendingSamples = []
+                state.pendingStartSample = totalSamples
+                state.isDecoding = false
+            }
+        }
+
+        Memory.clearCache()
+    }
+
+    func cancel() {
+        sessionLock.withLock { _ in
+            isActive = false
+            decodeTask?.cancel()
+            decodeTask = nil
+            stopTask?.cancel()
+            stopTask = nil
+            continuation?.finish()
+            continuation = nil
+            audioState.withLock { state in
+                state.pendingSamples = []
+                state.isDecoding = false
+            }
+        }
     }
 }
 

--- a/Sources/MLXAudioSTT/Streaming/StreamingTypes.swift
+++ b/Sources/MLXAudioSTT/Streaming/StreamingTypes.swift
@@ -46,8 +46,8 @@ public struct StreamingConfig: Sendable {
     public var maxCachedWindows: Int
     /// Delay preset controlling provisional → confirmed promotion
     public var delayPreset: DelayPreset
-    /// Language for transcription
-    public var language: String
+    /// Language hint for transcription. `nil` uses the model default/auto behavior.
+    public var language: String?
     /// Sampling temperature (0 = greedy)
     public var temperature: Float
     /// Maximum tokens per decode pass
@@ -68,7 +68,7 @@ public struct StreamingConfig: Sendable {
         encoderWindowOverlapSeconds: Double = 1.0,
         maxCachedWindows: Int = 60,
         delayPreset: DelayPreset = .agent,
-        language: String = "English",
+        language: String? = "English",
         temperature: Float = 0.0,
         maxTokensPerPass: Int = 512,
         minAgreementPasses: Int = 2,

--- a/Sources/Tools/mlx-audio-swift-stt/App.swift
+++ b/Sources/Tools/mlx-audio-swift-stt/App.swift
@@ -450,50 +450,7 @@ enum App {
         if lower.contains("forcedalign") || lower.contains("forced-align") {
             return .forcedAligner(try await Qwen3ForcedAlignerModel.fromPretrained(repo))
         }
-        if lower.contains("glmasr") || lower.contains("glm-asr") {
-            return .stt(try await GLMASRModel.fromPretrained(repo))
-        }
-        if lower.contains("qwen3-asr") || lower.contains("qwen3_asr") {
-            return .stt(try await Qwen3ASRModel.fromPretrained(repo))
-        }
-        if lower.contains("moss_transcribe_diarize") {
-            return .stt(try await MossTranscribeDiarizeModel.fromPretrained(repo))
-        }
-        if lower.contains("voxtral") {
-            return .stt(try await VoxtralRealtimeModel.fromPretrained(repo))
-        }
-        if lower.contains("cohere") {
-            return .stt(try await CohereTranscribeModel.fromPretrained(repo))
-        }
-        if lower.contains("parakeet") {
-            return .stt(try await ParakeetModel.fromPretrained(repo))
-        }
-        if lower.contains("canary") {
-            return .stt(try await CanaryModel.fromPretrained(repo))
-        }
-        if lower.contains("wav2vec") || lower.contains("wav2vec2") || lower.contains("/mms-") || lower.contains("mms_") || lower.contains("mms-") {
-            return .stt(try await Wav2Vec2CTCModel.fromPretrained(repo))
-        }
-        if lower.contains("lasr") {
-            return .stt(try await LasrCTCModel.fromPretrained(repo))
-        }
-        if lower.contains("moonshine") {
-            return .stt(try await MoonshineModel.fromPretrained(repo))
-        }
-        if lower.contains("nemotron") {
-            return .stt(try await NemotronASRModel.fromPretrained(repo))
-        }
-        if lower.contains("firered") || lower.contains("fire-red") {
-            return .stt(try await FireRedASR2Model.fromPretrained(repo))
-        }
-        if lower.contains("sensevoice") {
-            return .stt(try await SenseVoiceModel.fromPretrained(repo))
-        }
-        if lower.contains("whisper") {
-            return .stt(try await WhisperModel.fromPretrained(repo))
-        }
-
-        throw AppError.unsupportedModelRepo(repo)
+        return .stt(try await STT.loadModel(modelRepo: repo))
     }
 
     private static func normalizeLanguage(_ language: String?) -> String? {

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -1935,6 +1935,41 @@ struct MossTranscribeDiarizeModuleSetupTests {
         #expect(segments[1]["speaker_id"] as? String == "S02")
     }
 
+    @Test func mossParseSegmentsAppliesChunkOffset() {
+        let text = "[0.48][S01]hello[1.66]"
+
+        let segments = MossTranscribeDiarizeModel.parseSegments(
+            text: text,
+            fallbackEnd: 10.0,
+            offsetSeconds: 30.0
+        )
+
+        #expect(segments.count == 1)
+        #expect(segments[0]["start"] as? Double == 30.48)
+        #expect(segments[0]["end"] as? Double == 31.66)
+        #expect(segments[0]["speaker_id"] as? String == "S01")
+    }
+
+    @Test func mossOffsetTimestampTags() {
+        let text = "[0.48][S01]hello[1.66][2.00][S02]world[3.50]"
+
+        let shifted = MossTranscribeDiarizeModel.offsetTimestampTags(in: text, by: 60.0)
+
+        #expect(shifted == "[60.48][S01]hello[61.66][62.00][S02]world[63.50]")
+    }
+
+    @Test func mossTimestampHelpersHandleCommaDecimals() {
+        let text = "[0,48][S01]hello[1,66]"
+
+        let shifted = MossTranscribeDiarizeModel.offsetTimestampTags(in: text, by: 30.0)
+        let segments = MossTranscribeDiarizeModel.parseSegments(text: text, fallbackEnd: 10.0, offsetSeconds: 30.0)
+
+        #expect(shifted == "[30.48][S01]hello[31.66]")
+        #expect(segments.count == 1)
+        #expect(segments[0]["start"] as? Double == 30.48)
+        #expect(segments[0]["end"] as? Double == 31.66)
+    }
+
     @Test func mossParseSegmentsFallback() {
         let text = "[S01] hello world"
 

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -1347,6 +1347,43 @@ struct CohereTranscribeModuleSetupTests {
         #expect(config.quantization?.bits == 8)
     }
 
+    @Test func cohereConfigDecodingUsesHeadClassCountWhenVocabSizeMissing() throws {
+        let json = """
+        {
+          "model_type": "cohere_asr",
+          "sample_rate": 16000,
+          "max_audio_clip_s": 35,
+          "head": {
+            "num_classes": 16384
+          },
+          "encoder": {
+            "d_model": 1280,
+            "ff_expansion_factor": 4,
+            "n_heads": 8,
+            "conv_kernel_size": 9,
+            "n_layers": 48,
+            "pos_emb_max_len": 5000,
+            "subsampling_conv_channels": 256,
+            "subsampling_factor": 8,
+            "feat_in": 128
+          },
+          "transf_decoder": {
+            "config_dict": {
+              "hidden_size": 1024,
+              "inner_size": 4096,
+              "num_attention_heads": 8,
+              "num_layers": 8,
+              "max_sequence_length": 1024,
+              "vocab_size": "None"
+            }
+          }
+        }
+        """
+
+        let config = try JSONDecoder().decode(CohereTranscribeConfig.self, from: Data(json.utf8))
+        #expect(config.vocabSize == 16384)
+    }
+
     @Test func cohereAudioFeaturesShape() {
         let audio = MLXArray(Array(repeating: Float(0), count: 16_000))
         let filters = CohereTranscribeAudio.computeMelFilters()


### PR DESCRIPTION
## Summary

- Adds clear/remove controls for STT transcriptions and imported audio in VoicesApp.
- Persists STT settings and lets an empty language setting use the model default/auto behavior.
- Improves Cohere and MOSS realtime STT behavior, including MOSS token streaming, shorter realtime windows, and formatted timestamp/speaker transcript rendering.
- Adds playback highlighting for timestamped transcript sections.

## Notes

This branch intentionally leaves local Xcode project/user-state files out of the PR. MOSS still has known limitations for mixed-language/code-switch transcription; the current implementation preserves model-default language behavior when the UI language field is blank.

## Validation

- `swift build --target MLXAudioSTT`
- `xcodebuild -project Examples/VoicesApp/VoicesApp.xcodeproj -scheme VoicesApp -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build`