### PR TITLE
Quantized KV cache for MOSS-Transcribe-Diarize (opt-in, memory-bounded long-form)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0de47e2efcfdbd2abb306b485c46d6fc9b94854ac10c7413ede360d5ad7e2260",
+  "originHash" : "4f148e1f0e3958fd3f86560361e4a93ad32a6877d96593d3a361ee25e86da198",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
+        "version" : "0.31.4"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Sources/MLXAudioSTT/Generation.swift
+++ b/Sources/MLXAudioSTT/Generation.swift
@@ -11,8 +11,7 @@ public struct STTGenerateParameters: Sendable {
     public let minChunkDuration: Float
     public let repetitionPenalty: Float
     public let repetitionContextSize: Int
-    /// KV-cache quantization bits. `nil` keeps the cache at model precision
-    /// (bit-for-bit identical to prior behavior).
+    /// KV-cache quantization bits; `nil` keeps model precision.
     public let kvBits: Int?
     /// Group size for KV-cache quantization.
     public let kvGroupSize: Int

--- a/Sources/MLXAudioSTT/Generation.swift
+++ b/Sources/MLXAudioSTT/Generation.swift
@@ -11,6 +11,13 @@ public struct STTGenerateParameters: Sendable {
     public let minChunkDuration: Float
     public let repetitionPenalty: Float
     public let repetitionContextSize: Int
+    /// KV-cache quantization bits. `nil` keeps the cache at model precision
+    /// (bit-for-bit identical to prior behavior).
+    public let kvBits: Int?
+    /// Group size for KV-cache quantization.
+    public let kvGroupSize: Int
+    /// Cache offset that must be exceeded before the KV cache is quantized.
+    public let quantizedKVStart: Int
 
     public init(
         maxTokens: Int = 8192,
@@ -22,7 +29,10 @@ public struct STTGenerateParameters: Sendable {
         chunkDuration: Float = 1200.0,
         minChunkDuration: Float = 1.0,
         repetitionPenalty: Float = 1.0,
-        repetitionContextSize: Int = 32
+        repetitionContextSize: Int = 32,
+        kvBits: Int? = nil,
+        kvGroupSize: Int = 64,
+        quantizedKVStart: Int = 0
     ) {
         self.maxTokens = maxTokens
         self.temperature = temperature
@@ -34,6 +44,9 @@ public struct STTGenerateParameters: Sendable {
         self.minChunkDuration = minChunkDuration
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.kvBits = kvBits
+        self.kvGroupSize = kvGroupSize
+        self.quantizedKVStart = quantizedKVStart
     }
 }
 

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -317,7 +317,10 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
             chunkDuration: generationParameters.chunkDuration,
             minChunkDuration: generationParameters.minChunkDuration,
             repetitionPenalty: generationParameters.repetitionPenalty,
-            repetitionContextSize: generationParameters.repetitionContextSize
+            repetitionContextSize: generationParameters.repetitionContextSize,
+            kvBits: generationParameters.kvBits,
+            kvGroupSize: generationParameters.kvGroupSize,
+            quantizedKVStart: generationParameters.quantizedKVStart
         )
     }
 
@@ -355,7 +358,10 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
                             repetitionPenalty: generationParameters.repetitionPenalty,
                             repetitionContextSize: generationParameters.repetitionContextSize,
                             prompt: nil,
-                            offsetSeconds: Double(offsetSeconds)
+                            offsetSeconds: Double(offsetSeconds),
+                            kvBits: generationParameters.kvBits,
+                            kvGroupSize: generationParameters.kvGroupSize,
+                            quantizedKVStart: generationParameters.quantizedKVStart
                         ) { text in
                             guard !text.isEmpty else { return }
                             if !emittedText {
@@ -404,7 +410,10 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
         minChunkDuration: Float = 0.0,
         repetitionPenalty: Float = 1.0,
         repetitionContextSize: Int = 100,
-        prompt: String? = nil
+        prompt: String? = nil,
+        kvBits: Int? = nil,
+        kvGroupSize: Int = 64,
+        quantizedKVStart: Int = 0
     ) -> STTOutput {
         let start = Date()
         do {
@@ -426,7 +435,10 @@ public final class MossTranscribeDiarizeModel: Module, STTGenerationModel {
                     repetitionPenalty: repetitionPenalty,
                     repetitionContextSize: repetitionContextSize,
                     prompt: prompt,
-                    offsetSeconds: Double(offsetSeconds)
+                    offsetSeconds: Double(offsetSeconds),
+                    kvBits: kvBits,
+                    kvGroupSize: kvGroupSize,
+                    quantizedKVStart: quantizedKVStart
                 )
                 outputs.append(output)
                 Memory.clearCache()
@@ -620,6 +632,9 @@ private extension MossTranscribeDiarizeModel {
         repetitionContextSize: Int,
         prompt: String?,
         offsetSeconds: Double,
+        kvBits: Int? = nil,
+        kvGroupSize: Int = 64,
+        quantizedKVStart: Int = 0,
         onText: ((String) -> Void)? = nil
     ) throws -> STTOutput {
         defer { Memory.clearCache() }
@@ -636,7 +651,10 @@ private extension MossTranscribeDiarizeModel {
             maxTokens: maxTokens,
             temperature: temperature,
             repetitionPenalty: repetitionPenalty,
-            repetitionContextSize: repetitionContextSize
+            repetitionContextSize: repetitionContextSize,
+            kvBits: kvBits,
+            kvGroupSize: kvGroupSize,
+            quantizedKVStart: quantizedKVStart
         ) { token in
             let rawDelta = self.tokenizer?.decode(tokens: [token], skipSpecialTokens: true) ?? ""
             let shiftedDelta = offsetter.consume(rawDelta)
@@ -682,9 +700,12 @@ private extension MossTranscribeDiarizeModel {
         temperature: Float,
         repetitionPenalty: Float,
         repetitionContextSize: Int,
+        kvBits: Int? = nil,
+        kvGroupSize: Int = 64,
+        quantizedKVStart: Int = 0,
         onToken: ((Int) -> Void)? = nil
     ) throws -> [Int] {
-        let cache = makeCache()
+        var cache = makeCache()
         let prefillStepSize = 2048
         let totalTokens = promptIds.dim(1)
         var processedTokens = 0
@@ -711,6 +732,15 @@ private extension MossTranscribeDiarizeModel {
         }
         var nextTokenArray = lastLogits.argMax(axis: -1)
         asyncEval(nextTokenArray)
+
+        // Prefill runs at model precision; quantize only the retained context.
+        // kvBits == nil leaves the cache untouched (bit-for-bit prior behavior).
+        maybeQuantizeKVCache(
+            cache: &cache,
+            kvBits: kvBits,
+            kvGroupSize: kvGroupSize,
+            quantizedKVStart: quantizedKVStart
+        )
 
         var generated: [Int] = []
         let eos = eosTokenIds()
@@ -1010,6 +1040,20 @@ extension MossTranscribeDiarizeModel {
             weights.merge(shard) { _, new in new }
         }
         let sanitized = sanitize(weights: weights)
+        if config.quantization != nil || config.perLayerQuantization != nil {
+            quantize(model: model) { path, _ in
+                // Only layers that ship quantized tensors are swapped; anything
+                // stored dense (e.g. the audio tower) keeps its original module.
+                guard sanitized["\(path).scales"] != nil else {
+                    return nil
+                }
+                if let perLayerQuant = config.perLayerQuantization,
+                   let layerQuant = perLayerQuant.quantization(layer: path) {
+                    return layerQuant.asTuple
+                }
+                return config.quantization?.asTuple
+            }
+        }
         try model.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
         model.train(false)
         eval(model)

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -706,10 +706,8 @@ private extension MossTranscribeDiarizeModel {
         onToken: ((Int) -> Void)? = nil
     ) throws -> [Int] {
         var cache = makeCache()
-        // Quantized prefill attention is unfused (scores materialize as a
-        // [heads, chunk, context] tensor), so its transient memory scales
-        // with the chunk size; a smaller chunk bounds that spike. The
-        // full-precision path keeps its fused kernel and original chunking.
+        // Quantized prefill attention is unfused; its transient scores tensor
+        // scales with chunk size, so a smaller chunk bounds the memory spike.
         let prefillStepSize = kvBits == nil ? 2048 : 512
         let totalTokens = promptIds.dim(1)
         var processedTokens = 0
@@ -723,11 +721,8 @@ private extension MossTranscribeDiarizeModel {
             let chunkEmbeds = inputEmbeddings[0..., processedTokens..<(processedTokens + n), 0...]
             let logits = callAsFunction(inputIds: chunkIds, inputEmbeddings: chunkEmbeds, cache: cache)
             eval(logits)
-            // Quantize the retained context as prefill progresses (mlx-lm
-            // quantizes inside its chunked prompt loop too): a long prompt
-            // otherwise carries its full-precision KV as a transient peak
-            // that can exceed a small machine's memory before the cache is
-            // ever converted. No-op when kvBits == nil or already quantized.
+            // Quantize retained context as prefill progresses (as mlx-lm does):
+            // a long prompt would otherwise peak at full-precision KV.
             maybeQuantizeKVCache(
                 cache: &cache,
                 kvBits: kvBits,
@@ -1056,8 +1051,7 @@ extension MossTranscribeDiarizeModel {
         let sanitized = sanitize(weights: weights)
         if config.quantization != nil || config.perLayerQuantization != nil {
             quantize(model: model) { path, _ in
-                // Only layers that ship quantized tensors are swapped; anything
-                // stored dense (e.g. the audio tower) keeps its original module.
+                // Only layers shipping quantized tensors are swapped.
                 guard sanitized["\(path).scales"] != nil else {
                     return nil
                 }

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -706,7 +706,11 @@ private extension MossTranscribeDiarizeModel {
         onToken: ((Int) -> Void)? = nil
     ) throws -> [Int] {
         var cache = makeCache()
-        let prefillStepSize = 2048
+        // Quantized prefill attention is unfused (scores materialize as a
+        // [heads, chunk, context] tensor), so its transient memory scales
+        // with the chunk size; a smaller chunk bounds that spike. The
+        // full-precision path keeps its fused kernel and original chunking.
+        let prefillStepSize = kvBits == nil ? 2048 : 512
         let totalTokens = promptIds.dim(1)
         var processedTokens = 0
 

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -225,7 +225,7 @@ public final class MossTranscribeDiarizeBackbone: Module {
         var embeds = inputsEmbeds ?? languageModel.embedTokens(inputIds)
         if let inputFeatures,
            let audioFeatureLengths,
-           cache == nil || cache?.first == nil || (cache?.first as? KVCacheSimple)?.offset == 0 {
+           cache == nil || cache?.first == nil || cache?.first?.offset == 0 {
             embeds = try! injectAudioFeatures(
                 inputIds: inputIds,
                 inputsEmbeds: embeds,

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarize.swift
@@ -719,6 +719,17 @@ private extension MossTranscribeDiarizeModel {
             let chunkEmbeds = inputEmbeddings[0..., processedTokens..<(processedTokens + n), 0...]
             let logits = callAsFunction(inputIds: chunkIds, inputEmbeddings: chunkEmbeds, cache: cache)
             eval(logits)
+            // Quantize the retained context as prefill progresses (mlx-lm
+            // quantizes inside its chunked prompt loop too): a long prompt
+            // otherwise carries its full-precision KV as a transient peak
+            // that can exceed a small machine's memory before the cache is
+            // ever converted. No-op when kvBits == nil or already quantized.
+            maybeQuantizeKVCache(
+                cache: &cache,
+                kvBits: kvBits,
+                kvGroupSize: kvGroupSize,
+                quantizedKVStart: quantizedKVStart
+            )
             Memory.clearCache()
             processedTokens += n
         }
@@ -733,8 +744,7 @@ private extension MossTranscribeDiarizeModel {
         var nextTokenArray = lastLogits.argMax(axis: -1)
         asyncEval(nextTokenArray)
 
-        // Prefill runs at model precision; quantize only the retained context.
-        // kvBits == nil leaves the cache untouched (bit-for-bit prior behavior).
+        // Covers prompts short enough that the chunk loop never ran.
         maybeQuantizeKVCache(
             cache: &cache,
             kvBits: kvBits,

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarizeConfig.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarizeConfig.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLXLMCommon
 
 public struct MossTranscribeDiarizeConfig: Codable {
     public var modelType: String
@@ -9,6 +10,11 @@ public struct MossTranscribeDiarizeConfig: Codable {
     public var adaptorInputDim: Int?
     public var tieWordEmbeddings: Bool
     public var sampleRate: Int
+    /// Global quantization parameters for pre-quantized checkpoints
+    /// (decoded from "quantization" or "quantization_config"; not re-encoded).
+    public var quantization: BaseConfiguration.Quantization?
+    /// Per-layer overrides for mixed-precision checkpoints.
+    public var perLayerQuantization: BaseConfiguration.PerLayerQuantization?
 
     enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
@@ -19,6 +25,11 @@ public struct MossTranscribeDiarizeConfig: Codable {
         case adaptorInputDim = "adaptor_input_dim"
         case tieWordEmbeddings = "tie_word_embeddings"
         case sampleRate = "sample_rate"
+    }
+
+    enum QuantizationCodingKeys: String, CodingKey {
+        case quantization
+        case quantizationConfig = "quantization_config"
     }
 
     public init(
@@ -37,7 +48,9 @@ public struct MossTranscribeDiarizeConfig: Codable {
         audioMergeSize: Int = 4,
         adaptorInputDim: Int? = nil,
         tieWordEmbeddings: Bool = true,
-        sampleRate: Int = 16000
+        sampleRate: Int = 16000,
+        quantization: BaseConfiguration.Quantization? = nil,
+        perLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil
     ) {
         self.modelType = modelType
         var resolvedTextConfig = textConfig
@@ -49,6 +62,8 @@ public struct MossTranscribeDiarizeConfig: Codable {
         self.adaptorInputDim = adaptorInputDim ?? audioConfig.dModel * audioMergeSize
         self.tieWordEmbeddings = tieWordEmbeddings
         self.sampleRate = sampleRate
+        self.quantization = quantization
+        self.perLayerQuantization = perLayerQuantization
     }
 
     public init(from decoder: Decoder) throws {
@@ -74,5 +89,16 @@ public struct MossTranscribeDiarizeConfig: Codable {
         adaptorInputDim = try container.decodeIfPresent(Int.self, forKey: .adaptorInputDim)
             ?? audioConfig.dModel * audioMergeSize
         sampleRate = try container.decodeIfPresent(Int.self, forKey: .sampleRate) ?? 16000
+
+        let quantContainer = try decoder.container(keyedBy: QuantizationCodingKeys.self)
+        let globalQuant = try? quantContainer.decodeIfPresent(
+            BaseConfiguration.Quantization.self, forKey: .quantization
+        )
+        let altGlobalQuant = try? quantContainer.decodeIfPresent(
+            BaseConfiguration.Quantization.self, forKey: .quantizationConfig
+        )
+        quantization = globalQuant ?? altGlobalQuant
+        let baseConfig = try? BaseConfiguration(from: decoder)
+        perLayerQuantization = baseConfig?.perLayerQuantization
     }
 }

--- a/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarizeConfig.swift
+++ b/Sources/MLXAudioSTT/Models/MossTranscribeDiarize/MossTranscribeDiarizeConfig.swift
@@ -10,8 +10,7 @@ public struct MossTranscribeDiarizeConfig: Codable {
     public var adaptorInputDim: Int?
     public var tieWordEmbeddings: Bool
     public var sampleRate: Int
-    /// Global quantization parameters for pre-quantized checkpoints
-    /// (decoded from "quantization" or "quantization_config"; not re-encoded).
+    /// Quantization parameters from "quantization"/"quantization_config".
     public var quantization: BaseConfiguration.Quantization?
     /// Per-layer overrides for mixed-precision checkpoints.
     public var perLayerQuantization: BaseConfiguration.PerLayerQuantization?

--- a/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
@@ -900,7 +900,7 @@ public class Qwen3ASRTextModel: Module {
             fatalError("Either inputIds or inputsEmbeds must be provided")
         }
 
-        let mask = createAttentionMask(h: h, cache: cache?.first)
+        let mask = Self.attentionMask(h: h, cache: cache?.first)
 
         let caches = cache ?? [KVCache?](repeating: nil, count: layers.count)
         for (i, layer) in layers.enumerated() {
@@ -908,6 +908,27 @@ public class Qwen3ASRTextModel: Module {
         }
 
         return norm(h)
+    }
+
+    /// Attention mask for one forward step. Multi-token steps over a
+    /// QUANTIZED cache need an additive float mask: the quantized attention
+    /// path substitutes a near-zero constant (not -inf) for masked positions
+    /// of symbolic/boolean masks, which lets future positions leak into the
+    /// softmax; its additive branch applies the mask exactly. All other
+    /// cases keep the standard helper's behavior.
+    static func attentionMask(
+        h: MLXArray, cache: KVCache?
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        let n = h.dim(1)
+        if n > 1, let cache, cache is QuantizedKVCacheProtocol {
+            let offset = cache.offset
+            let boolMask = createCausalMask(n: n, offset: offset)
+            let additive = MLX.where(
+                boolMask, MLXArray(Float(0)), MLXArray(Float(-1e9))
+            ).asType(h.dtype)
+            return .array(additive)
+        }
+        return createAttentionMask(h: h, cache: cache)
     }
 }
 

--- a/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
@@ -910,12 +910,9 @@ public class Qwen3ASRTextModel: Module {
         return norm(h)
     }
 
-    /// Attention mask for one forward step. Multi-token steps over a
-    /// QUANTIZED cache need an additive float mask: the quantized attention
-    /// path substitutes a near-zero constant (not -inf) for masked positions
-    /// of symbolic/boolean masks, which lets future positions leak into the
-    /// softmax; its additive branch applies the mask exactly. All other
-    /// cases keep the standard helper's behavior.
+    /// Multi-token steps over a quantized cache need an exact additive mask:
+    /// the quantized attention path replaces boolean-mask positions with a
+    /// finite constant, letting future positions leak into the softmax.
     static func attentionMask(
         h: MLXArray, cache: KVCache?
     ) -> MLXFast.ScaledDotProductAttentionMaskMode {

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -1980,6 +1980,52 @@ struct MossTranscribeDiarizeModuleSetupTests {
         #expect(segments[0]["end"] as? Double == 4.25)
         #expect(segments[0]["text"] as? String == text)
     }
+
+    @Test func mossConfigDecodesQuantization() throws {
+        let json = """
+        {
+          "model_type": "moss_transcribe_diarize",
+          "quantization": { "group_size": 64, "bits": 8 }
+        }
+        """
+
+        let config = try JSONDecoder().decode(MossTranscribeDiarizeConfig.self, from: Data(json.utf8))
+
+        #expect(config.quantization?.bits == 8)
+        #expect(config.quantization?.groupSize == 64)
+    }
+
+    @Test func mossConfigDecodesQuantizationConfigKey() throws {
+        let json = """
+        {
+          "model_type": "moss_transcribe_diarize",
+          "quantization_config": { "group_size": 32, "bits": 4 }
+        }
+        """
+
+        let config = try JSONDecoder().decode(MossTranscribeDiarizeConfig.self, from: Data(json.utf8))
+
+        #expect(config.quantization?.bits == 4)
+        #expect(config.quantization?.groupSize == 32)
+    }
+
+    @Test func mossConfigWithoutQuantizationStaysDense() throws {
+        let json = """
+        { "model_type": "moss_transcribe_diarize" }
+        """
+
+        let config = try JSONDecoder().decode(MossTranscribeDiarizeConfig.self, from: Data(json.utf8))
+
+        #expect(config.quantization == nil)
+    }
+
+    @Test func sttGenerateParametersDefaultKVBitsIsNil() {
+        let parameters = STTGenerateParameters()
+
+        #expect(parameters.kvBits == nil)
+        #expect(parameters.kvGroupSize == 64)
+        #expect(parameters.quantizedKVStart == 0)
+    }
 }
 
 struct CohereTranscribeModuleSetupTests {


### PR DESCRIPTION
## What this enables

Adds **opt-in quantized KV cache** support to `MOSS-Transcribe-Diarize`. On a small-unified-memory Mac, the full-precision KV cache is what caps how long a clip you can transcribe in a single pass before you're forced to chunk (and lose cross-chunk context). Quantizing the retained context lets the same machine do long single-pass transcription within a much smaller memory budget.

Everything here is **off by default** — with no new parameters set, decoding is bit-for-bit identical to today.

## Design

- **Dispatcher swap (not a reimplementation).** `Qwen3ASRTextAttention` now routes through `MLXLMCommon.attentionWithCacheUpdate` instead of a manual `cache.update` + `scaledDotProductAttention`. This is what makes a `QuantizedKVCache` usable on this path at all — previously it would hit a `fatalError`. RoPE is still applied against the pre-update cache offset, so the standard (non-quantized) path is unchanged. This mirrors how the other Qwen3-based models in the repo already call `attentionWithCacheUpdate`.
- **Protocol-based audio-injection gate.** The prefill audio-feature injection in the MOSS backbone was gated on a concrete `KVCacheSimple` downcast; it now reads `KVCache.offset` directly, so injection fires correctly for any cache type at offset 0 (behavior-preserving for the existing dense path).
- **Correct masking for quantized multi-token steps.** Multi-token forward steps over a quantized cache need an explicit additive float mask — the quantized attention path substitutes a near-zero constant (not `-inf`) for masked positions of a boolean/symbolic mask, which would let future positions leak into the softmax. A small helper builds the additive mask only in that case and otherwise defers to the standard helper.
- **Opt-in parameters, safe defaults.** `STTGenerateParameters` gains `kvBits: Int? = nil`, `kvGroupSize: Int = 64`, `quantizedKVStart: Int = 0`, threaded through `generate` / `generateSingleChunk` / `generateTokenIds`. `kvBits == nil` leaves the cache at model precision. Quantization happens *after* prefill via `MLXLMCommon.maybeQuantizeKVCache`.
- **Bounded prefill memory.** For a long prompt, the full-precision KV would otherwise spike transiently before it's ever converted, so the cache is quantized incrementally inside the chunked prefill loop (matching mlx-lm's chunked-prompt behavior). When quantization is active the prefill chunk size is also reduced (unfused quantized attention materializes a `[heads, chunk, context]` score tensor), which bounds that spike; the full-precision path keeps its original fused kernel and chunk size.
- **Pre-quantized checkpoint loading.** `MossTranscribeDiarizeConfig` decodes a `quantization` / `quantization_config` block (plus per-layer overrides), and `fromModelDirectory` swaps only the layers that ship quantized tensors — the audio tower and adaptor stay dense — mirroring the sibling models in the repo.

## Tooling

- Adds a `mlx-audio-swift-moss-tools` executable under `Sources/Tools/` (same convention as the existing `mlx-audio-swift-*` CLIs): `quantize` converts a local bf16 MOSS checkpoint to MLX-quantized safetensors that `fromModelDirectory` loads directly, and `bench` decodes one 16 kHz WAV in a single pass with optional KV quantization and writes a JSON report. Local directories only, no network.
- Bumps the pinned `mlx-swift` / `mlx-swift-lm` to `0.31.4` / `3.31.4` (already within the existing `upToNextMajor` constraints) — this is the KV-cache revision the quantized path was validated against. Happy to drop this commit if you'd rather bump `Package.resolved` yourself.

## Validation

Validated on a 56-minute multi-speaker meeting recording:

- **8-bit / group size 64 KV** produces a transcript matching the bf16 reference (same speaker structure) at **~30% lower peak memory**.
- **4-bit / group size 32 KV degrades into repetitive output on hour-scale audio and should not be used for long inputs** — it's plumbed through but is not a safe default, hence the honest caveat here.

Unit tests cover config decoding (both `quantization` and `quantization_config` keys, and the dense-by-default case) and the `STTGenerateParameters` defaults.

## Compatibility

**No breaking changes.** All new parameters default to values that reproduce today's exact behavior; existing call sites and the dense checkpoint path are untouched. `swift build` passes and the `MossTranscribeDiarizeModuleSetupTests` suite (including the existing streaming/timestamp tests) is green.

The quantized-attention wiring came out of building a macOS transcription app on top of this library; contributing it back since it's generally useful for long-form MOSS transcription on constrained hardware.
