### PR TITLE
Fix float32 leak in VoxtralRealtime streaming

### DIFF
--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
@@ -36,7 +36,8 @@ final class VoxtralRealtimeAdaRMSNorm: Module {
     }
 
     func callAsFunction(_ x: MLXArray, adaScale: MLXArray) -> MLXArray {
-        x * (1.0 + adaScale)
+        // Cast the float32 adaScale down so it doesn't promote the fp16 hidden state.
+        x * (1.0 + adaScale.asType(x.dtype))
     }
 }
 
@@ -129,7 +130,8 @@ final class VoxtralRealtimeDecoderAttention: Module {
             let causal = kPos .<= qPos
             let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
             let allowed = logicalAnd(causal, window)
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            // Match the activation dtype: a float32 mask over fp16 q/k aborts SDPA.
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
             maskMode = .array(mask)
         }
 

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
@@ -33,8 +33,9 @@ func voxtralApplyInterleavedRoPE(
     let x1 = reshaped[0..., 0..., 0..., 0]
     let x2 = reshaped[0..., 0..., 0..., 1]
 
-    let cosE = cos.expandedDimensions(axis: 1)
-    let sinE = sin.expandedDimensions(axis: 1)
+    // cos/sin are float32 for precision; cast down so rotating fp16 q/k stays fp16.
+    let cosE = cos.expandedDimensions(axis: 1).asType(x.dtype)
+    let sinE = sin.expandedDimensions(axis: 1).asType(x.dtype)
 
     let o1 = x1 * cosE - x2 * sinE
     let o2 = x2 * cosE + x1 * sinE
@@ -165,7 +166,8 @@ final class VoxtralRealtimeEncoderAttention: Module {
             let causal = kPos .<= qPos
             let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
             let allowed = logicalAnd(causal, window)
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9))
+            // Match the activation dtype: a float32 mask over fp16 q/k aborts SDPA.
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
             maskMode = .array(mask)
         }
 
@@ -263,7 +265,8 @@ final class VoxtralRealtimeAudioEncoder: Module {
     }
 
     func convStem(_ mel: MLXArray) -> MLXArray {
-        var x = mel.transposed(1, 0).expandedDimensions(axis: 0)
+        // mel is float32; cast to the conv weight dtype so encoder activations stay fp16.
+        var x = mel.asType(convLayers0Conv.conv.weight.dtype).transposed(1, 0).expandedDimensions(axis: 0)
         x = gelu(convLayers0Conv(x))
         x = gelu(convLayers1Conv(x))
         x = x.squeezed(axis: 0)


### PR DESCRIPTION
## What

`VoxtralRealtime` streaming decode runs the decoder in **float32** instead of the model's fp16. A few float32 helper tensors are multiplied into the fp16 hidden state and promote it:

1. **AdaptiveNorm** — `x * (1.0 + adaScale)`, where `adaScale` is the float32 time-conditioning scale. Applied in every layer.
2. **Manual RoPE** — `cos`/`sin` are built in float32 and rotate q/k, promoting them.
3. (smaller) the float32 mel fed into the fp16 conv weights in `convStem`.

Once the hidden state is float32, the tied fp16 embedding (131072×3072, ~805 MB) is upcast on **every token** for the LM-head projection, and quantized matmuls leave their fast path ([ml-explore/mlx-swift#420](https://github.com/ml-explore/mlx-swift/issues/420)).

**1 and 2 must both be fixed** — fixing only one leaves the hidden state float32 through the other, so the improvement is negligible until both land.

## Fix

Cast each float32 factor to the activation dtype before it touches the hidden state (angles are still computed in float32 for precision). The additive attention mask is built in the activation dtype too — otherwise a float32 mask over the now-fp16 q/k makes `scaledDotProductAttention` abort (`Mask type must promote to output type float16`).

Mirrors the Python `voxmlx` reference (`t_cond.astype(x.dtype)`, `x_mel.astype(conv1.weight.dtype)`). Five casts across two files; no behavior change beyond dtype.

## Impact

Streaming online session, `Voxtral-Mini-4B-Realtime-2602-4bit`, Apple Silicon, batch 1, identical audio / 80 ms chunking / same GPU:

| | before | after |
|---|---|---|
| RTF | ~1.84 | ~0.62 |
| LM-head projection | ~73 ms/token | ~5 ms/token |
| decoder forward | ~20 ms/token | ~13 ms/token |
| peak GPU | 5.1 GB | 3.3 GB |
| word accuracy | 0.804 | 0.804 (unchanged) |

The isolated LM-head op is ~5 ms on an fp16 input but ~73 ms in-loop on the float32 hidden state — same op, same shapes, only the input dtype differs. That op is the bulk of the win and isolates this change directly; word accuracy is unchanged.

## Notes

- RoPE is intentionally left on the existing kernel rather than switched to `MLXFast.RoPE`: the naïve `[H, L, D]` layout hits [ml-explore/mlx-swift#441](https://github.com/ml-explore/mlx-swift/issues/441) (incorrect single-token decode with heads in the batch position). Casting in place keeps the current kernel and avoids that.
- Built and tested locally on macOS / Apple Silicon per `CONTRIBUTING.md`.
