### PR TITLE
OmniVoice: honor task cancellation during generation

### DIFF
--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -245,7 +245,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         let ovParams = OmniVoiceGenerateParameters()
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
-        Task { @Sendable [weak self] in
+        let task = Task { @Sendable [weak self] in
             guard let self else { return }
             do {
                 guard tokenizer != nil else {
@@ -274,6 +274,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
                 continuation.finish(throwing: error)
             }
         }
+        continuation.onTermination = { _ in task.cancel() }
         return stream
     }
 
@@ -368,6 +369,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
 
         // 7. Iterative diffusion generation
         for step in 0..<numSteps {
+            try Task.checkCancellation()
             let k = schedule[step]
             if k <= 0 { continue }
 
@@ -465,6 +467,7 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
         }
 
         // 8. Decode tokens to waveform
+        try Task.checkCancellation()
         var outputTokens = tokens[0, 0..., 0..<targetLen]
 
         // Replace any remaining mask tokens with 0 (matching Python reference)


### PR DESCRIPTION
OmniVoice is currently the only TTS model in the repo whose generation loop never checks for cancellation — Qwen3TTS, EchoTTS, PocketTTS, Qwen3, and the other models all call `try Task.checkCancellation()` inside their sampling/diffusion loops. As a result, cancelling a consumer mid-generation leaves the full diffusion compute running to completion (tens of seconds of GPU work for long utterances) with the result silently dropped.

This PR aligns OmniVoice with the existing convention:

- `try Task.checkCancellation()` at the top of each diffusion step in `generateAudio` (matching `EchoTTSSampling`'s per-step check), and once more before the vocoder decode.
- `generateStream` now holds its compute `Task` and cancels it from `continuation.onTermination`, so dropping the stream actually stops the work (same effect as the proxy-stream wiring in `Generation.swift`).

Purely additive: non-cancelled generations execute identically. Verified on an M4 Mac and an iPhone 17 Pro Max — cancelling mid-generation now interrupts within one diffusion step (~1 s for a 30-word utterance) instead of running the chunk to completion.