### PR TITLE
Route Qwen3-ASR text attention through attentionWithCacheUpdate

### DIFF
--- a/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/MLXAudioSTT/Models/Qwen3ASR/Qwen3ASR.swift
@@ -790,20 +790,23 @@ class Qwen3ASRTextAttention: Module {
         keys = keys.transposed(0, 2, 1, 3)
         values = values.transposed(0, 2, 1, 3)
 
-        // Apply RoPE
+        // Apply RoPE using the pre-update cache offset, matching the previous
+        // manual cache.update + scaledDotProductAttention sequence.
         if let cache = cache {
             queries = rope(queries, offset: cache.offset)
             keys = rope(keys, offset: cache.offset)
-            (keys, values) = cache.update(keys: keys, values: values)
         } else {
             queries = rope(queries)
             keys = rope(keys)
         }
 
-        let output = MLXFast.scaledDotProductAttention(
+        // Routes to quantized attention when the cache is a QuantizedKVCache,
+        // and performs the cache update internally for all cache types.
+        let output = attentionWithCacheUpdate(
             queries: queries,
             keys: keys,
             values: values,
+            cache: cache,
             scale: scale,
             mask: mask
         ).transposed(0, 2, 1, 3).reshaped(B, L, -1)


### PR DESCRIPTION
Split out of #225 at the maintainer's request.

Routes `Qwen3ASRTextAttention` through `MLXLMCommon`'s `attentionWithCacheUpdate` instead of calling `cache.update(keys:values:)` directly. With standard caches this is behavior-neutral (the dispatcher takes the same path); with a `QuantizedKVCache` it dispatches to `updateQuantized` + `quantizedScaledDotProductAttention` instead of hitting the `fatalError` in `QuantizedKVCache.update()`.

Note on ordering: #225's opt-in KV quantization for MOSS-Transcribe-Diarize reaches the cache through this same dispatcher (the MOSS backbone is `Qwen3ASRTextModel`), so this PR should merge **first** — #225 alone would leave the quantized path hitting that `fatalError`. With quantization off (the default), both PRs are behavior-neutral in any order.