### PR TITLE
VoxtralRealtime streaming: stop clearing the Metal buffer pool on every step

### DIFF
--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
@@ -166,8 +166,13 @@ public final class VoxtralRealtimeStreamSession {
         // re-allocated cold from the Metal driver 10x/s in live streaming and defeats
         // any `Memory.cacheLimit` the host process sets. Match the offline `generate`
         // loop instead: clear every 256 decoded tokens (see `decode`), plus once when
-        // the utterance finishes so memory returns to the weight floor between
-        // sessions. Callers that need a hard bound set `Memory.cacheLimit`.
+        // the utterance finishes to trim decode transients. Note this final clear
+        // CANNOT return the process to the weight floor by itself: the session's KV
+        // caches and carried front-end state are still live here and fall into the
+        // pool when the caller releases the session. A host that wants idle memory
+        // back at the weight floor between utterances must call `Memory.clearCache()`
+        // again AFTER releasing the session. Callers that need a hard bound set
+        // `Memory.cacheLimit`.
         if final {
             Memory.clearCache()
         }

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
@@ -166,7 +166,10 @@ public final class VoxtralRealtimeStreamSession {
         // re-allocated cold from the Metal driver 10x/s in live streaming and defeats
         // any `Memory.cacheLimit` the host process sets. Match the offline `generate`
         // loop instead: clear every 256 decoded tokens (see `decode`), plus once when
-        // the utterance finishes to trim decode transients. Note this final clear
+        // `finish()` flushes the tail to trim decode transients (an utterance that
+        // ends by EOS mid-stream never reaches this clear — `finish()` returns early
+        // via the `done` guard; the caller-side contract below covers it). Note this
+        // final clear
         // CANNOT return the process to the weight floor by itself: the session's KV
         // caches and carried front-end state are still live here and fall into the
         // pool when the caller releases the session. A host that wants idle memory

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
@@ -162,20 +162,12 @@ public final class VoxtralRealtimeStreamSession {
         prefillIfNeeded(adapter: adapter)
         let delta = decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
 
-        // Clearing the buffer pool every step forces the whole working set to be
-        // re-allocated cold from the Metal driver 10x/s in live streaming and defeats
-        // any `Memory.cacheLimit` the host process sets. Match the offline `generate`
-        // loop instead: clear every 256 decoded tokens (see `decode`), plus once when
-        // `finish()` flushes the tail to trim decode transients (an utterance that
-        // ends by EOS mid-stream never reaches this clear — `finish()` returns early
-        // via the `done` guard; the caller-side contract below covers it). Note this
-        // final clear
-        // CANNOT return the process to the weight floor by itself: the session's KV
-        // caches and carried front-end state are still live here and fall into the
-        // pool when the caller releases the session. A host that wants idle memory
-        // back at the weight floor between utterances must call `Memory.clearCache()`
-        // again AFTER releasing the session. Callers that need a hard bound set
-        // `Memory.cacheLimit`.
+        // Per-step clears re-allocate the working set cold 10x/s and defeat the
+        // host's `Memory.cacheLimit`. Match the offline `generate` loop instead:
+        // clear every 256 decoded tokens (see `decode`) plus once on the finish()
+        // flush. The session's KV caches and carried state are still live here, so
+        // a host that wants idle memory back at the weight floor must clear again
+        // after releasing the session.
         if final {
             Memory.clearCache()
         }

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeStreamSession.swift
@@ -157,13 +157,20 @@ public final class VoxtralRealtimeStreamSession {
         }
 
         guard let adapter = adapterBuf else {
-            Memory.clearCache()
             return Delta(text: "", tokenIds: [])
         }
         prefillIfNeeded(adapter: adapter)
         let delta = decode(adapter: adapter, upTo: min(emitLimit, adapter.shape[0]))
 
-        Memory.clearCache()
+        // Clearing the buffer pool every step forces the whole working set to be
+        // re-allocated cold from the Metal driver 10x/s in live streaming and defeats
+        // any `Memory.cacheLimit` the host process sets. Match the offline `generate`
+        // loop instead: clear every 256 decoded tokens (see `decode`), plus once when
+        // the utterance finishes so memory returns to the weight floor between
+        // sessions. Callers that need a hard bound set `Memory.cacheLimit`.
+        if final {
+            Memory.clearCache()
+        }
         return delta
     }
 
@@ -228,6 +235,10 @@ public final class VoxtralRealtimeStreamSession {
             lastLogits = model.decoder.logits(next.0[0])
             decPos += 1
             MLX.eval(lastLogits!)
+            // Same cadence as the offline `generate` loop.
+            if generated.count % 256 == 0 {
+                Memory.clearCache()
+            }
         }
 
         let textSoFar = model.decodeStreaming(generated)


### PR DESCRIPTION
`VoxtralRealtimeStreamSession.advance()` calls `Memory.clearCache()` on both exit paths — 10×/s at a live 100 ms feed cadence. Every step re-allocates its working set cold from the Metal driver, and any `Memory.cacheLimit` the host sets is defeated (the pool never lives long enough to be bounded by it). Field-observed as a 10 Hz RSS sawtooth between the ~3.4 GB weight floor and 5+ GB.

The offline paths already handle this right: `generate()` / `generateStream()` clear every 256 tokens. This PR makes the streaming session match — clear every 256 decoded tokens plus once on the `finish()` flush, otherwise leave pool management to the host via `Memory.cacheLimit` (the mlx-lm / voxmlx policy). No computation changes.

## Evidence

M1 Pro, Voxtral-Mini-4B 4-bit, 60 s stream at 100 ms cadence, `cacheLimit` 4 GB; measured together with #230:

| mark | step ms (main) | step ms (this + #230) |
|---|---|---|
| 5s | 183.2 | 80.1 |
| 15s | 162.7 | 74.2 |
| 30s | 165.8 | 76.6 |
| 60s | 162.5 | 80.3 |

`main` streams 60 s of audio in 114.7 s (1.9× slower than realtime); fixed is flat at ≈0.76 RTF with the pool held at the 4 GB limit (memory moves only at the intended 256-token clears). Word accuracy on a live-audio integration suite unchanged (0.789).

Companion PR: #230 (independent, merge cleanly together). Staged with full evidence at T0mSIlver#2.
