### PR TITLE
Hoist per-layer-invariant attention inputs out of the Voxtral layer loops

### DIFF
--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
@@ -80,7 +80,7 @@ final class VoxtralRealtimeDecoderAttention: Module {
     /// launches per decoded token. The operations are unchanged, so the tables
     /// (and therefore the layer outputs) are bit-identical to the previous
     /// per-layer construction.
-    static func ropeFrequencies(
+    fileprivate static func ropeFrequencies(
         positions: MLXArray,
         headDim: Int,
         ropeTheta: Float

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
@@ -72,14 +72,10 @@ final class VoxtralRealtimeDecoderAttention: Module {
 
     }
 
-    /// Interleaved-RoPE cos/sin tables for `positions`.
-    ///
-    /// Every decoder layer rotates by the same tables, so the decoder computes
-    /// them once per forward pass and hands them to each layer — rebuilding them
-    /// inside all `nLayers` attentions cost hundreds of identical tiny kernel
-    /// launches per decoded token. The operations are unchanged, so the tables
-    /// (and therefore the layer outputs) are bit-identical to the previous
-    /// per-layer construction.
+    /// Interleaved-RoPE cos/sin tables for `positions`. Every decoder layer rotates
+    /// by the same tables, so the decoder builds them once per forward pass instead
+    /// of once per layer — same operations, bit-identical outputs, `nLayers`× fewer
+    /// tiny kernel launches per decoded token.
     fileprivate static func ropeFrequencies(
         positions: MLXArray,
         headDim: Int,

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
@@ -72,7 +72,19 @@ final class VoxtralRealtimeDecoderAttention: Module {
 
     }
 
-    private func ropeFrequencies(positions: MLXArray) -> (MLXArray, MLXArray) {
+    /// Interleaved-RoPE cos/sin tables for `positions`.
+    ///
+    /// Every decoder layer rotates by the same tables, so the decoder computes
+    /// them once per forward pass and hands them to each layer — rebuilding them
+    /// inside all `nLayers` attentions cost hundreds of identical tiny kernel
+    /// launches per decoded token. The operations are unchanged, so the tables
+    /// (and therefore the layer outputs) are bit-identical to the previous
+    /// per-layer construction.
+    static func ropeFrequencies(
+        positions: MLXArray,
+        headDim: Int,
+        ropeTheta: Float
+    ) -> (MLXArray, MLXArray) {
         let idx = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
         let ropeInvFreq = 1.0 / MLX.pow(MLXArray(ropeTheta), idx / Float(headDim))
         let angles = positions.asType(.float32).expandedDimensions(axis: 1) * ropeInvFreq.expandedDimensions(axis: 0)
@@ -82,6 +94,8 @@ final class VoxtralRealtimeDecoderAttention: Module {
     func callAsFunction(
         _ x: MLXArray,
         positions: MLXArray,
+        ropeCos: MLXArray,
+        ropeSin: MLXArray,
         cache: VoxtralRealtimeDecoderKVCache?
     ) -> (MLXArray, VoxtralRealtimeDecoderKVCache) {
         let seqLen = x.shape[0]
@@ -90,9 +104,8 @@ final class VoxtralRealtimeDecoderAttention: Module {
         var k = wk(x)
         var v = wv(x)
 
-        let (cos, sin) = ropeFrequencies(positions: positions)
-        q = voxtralApplyInterleavedRoPE(q, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
-        k = voxtralApplyInterleavedRoPE(k, cos: cos, sin: sin, nHeads: nKvHeads, headDim: headDim)
+        q = voxtralApplyInterleavedRoPE(q, cos: ropeCos, sin: ropeSin, nHeads: nHeads, headDim: headDim)
+        k = voxtralApplyInterleavedRoPE(k, cos: ropeCos, sin: ropeSin, nHeads: nKvHeads, headDim: headDim)
 
         var positionOffset = cache?.positionOffset ?? 0
         if let cache {
@@ -181,13 +194,15 @@ final class VoxtralRealtimeDecoderLayer: Module {
     func callAsFunction(
         _ x: MLXArray,
         positions: MLXArray,
+        ropeCos: MLXArray,
+        ropeSin: MLXArray,
         adaScale: MLXArray?,
         cache: VoxtralRealtimeDecoderKVCache?
     ) -> (MLXArray, VoxtralRealtimeDecoderKVCache) {
         var out = x
 
         var h = attentionNorm(out)
-        let attn = attention(h, positions: positions, cache: cache)
+        let attn = attention(h, positions: positions, ropeCos: ropeCos, ropeSin: ropeSin, cache: cache)
         h = attn.0
         out = out + h
 
@@ -256,6 +271,12 @@ final class VoxtralRealtimeDecoder: Module {
         var h = embeds
         let seqLen = h.shape[0]
         let positions = MLXArray(startPos..<(startPos + seqLen)).asType(.int32)
+        // Shared by every layer — see `VoxtralRealtimeDecoderAttention.ropeFrequencies`.
+        let (ropeCos, ropeSin) = VoxtralRealtimeDecoderAttention.ropeFrequencies(
+            positions: positions,
+            headDim: config.headDim,
+            ropeTheta: config.ropeTheta
+        )
 
         var newCache: [VoxtralRealtimeDecoderKVCache?] = []
         newCache.reserveCapacity(layers.count)
@@ -263,7 +284,9 @@ final class VoxtralRealtimeDecoder: Module {
         for i in layers.indices {
             let layerCache = cache?[i]
             let adaScale = adaScales?[i]
-            let next = layers[i](h, positions: positions, adaScale: adaScale, cache: layerCache)
+            let next = layers[i](
+                h, positions: positions, ropeCos: ropeCos, ropeSin: ropeSin,
+                adaScale: adaScale, cache: layerCache)
             h = next.0
             newCache.append(next.1)
         }

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
@@ -92,32 +92,21 @@ final class VoxtralRealtimeCausalConv1d: Module {
     }
 }
 
-/// Attention inputs that are identical for every transformer layer of a single
-/// encoder forward pass: the interleaved-RoPE cos/sin tables for `positions` and
-/// the scaled-dot-product-attention mask.
-///
-/// The per-layer attention used to rebuild these from scratch — `nLayers` copies
-/// of the same ~15 tiny kernels per pass. For the realtime streaming session the
-/// encoder runs every audio chunk over only a handful of new frames, so those
-/// redundant launches (not bandwidth) dominate encoder step time. The caller now
-/// builds the shared inputs once per pass and every layer reuses them. The values
-/// are produced by exactly the same operations as before, in the same order, so
-/// every layer output is bit-identical to the per-layer construction.
+/// Attention inputs identical for every transformer layer of one encoder forward
+/// pass: the interleaved-RoPE cos/sin tables for `positions` and the SDPA mask.
+/// Built once per pass instead of per layer — same operations, so layer outputs
+/// are bit-identical; only the `nLayers` redundant kernel launches go away (which
+/// dominate streaming encoder steps, where each pass covers a few new frames).
 struct VoxtralRealtimeEncoderAttentionInputs {
     let ropeCos: MLXArray
     let ropeSin: MLXArray
     let mask: MLXFast.ScaledDotProductAttentionMaskMode
 
     /// Build the shared inputs for one forward pass of `seqLen` frames at
-    /// `positions`.
-    ///
-    /// `caches` are the per-layer KV-caches this pass is about to extend (empty,
-    /// or all `nil`, for a cache-less pass). One mask can serve every layer
-    /// because the encoder always advances its layer caches in lockstep — they
-    /// are created, extended, trimmed, and reset together — which is asserted
-    /// here. `dtype` is the activation (q/k) dtype the mask must match; passing
-    /// the encoder input dtype relies on every layer's q/k projections
-    /// preserving it, which holds for the uniform-precision `Linear` weights.
+    /// `positions`, extending `caches`. One mask can serve every layer because the
+    /// encoder always advances its layer caches in lockstep (created, extended,
+    /// trimmed, and reset together — asserted here). `dtype` is the q/k dtype the
+    /// mask must match; the uniform-precision projections preserve the input dtype.
     static func build(
         positions: MLXArray,
         seqLen: Int,
@@ -133,10 +122,9 @@ struct VoxtralRealtimeEncoderAttentionInputs {
             theta: ropeTheta
         )
 
-        // `caches.first ?? nil` collapses "no caches" and "[nil, ...]" into one
-        // cache-less case. Nil-ness must also be uniform across layers: a
-        // present-but-empty cache selects the explicit-array mask branch below,
-        // while a nil cache can take the `.causal` branch.
+        // Collapses "no caches" and "[nil, ...]" into one cache-less case. Nil-ness
+        // must be uniform across layers: nil and present-but-empty caches select
+        // different mask branches below.
         let cache = caches.first ?? nil
         let cachedLen = cache?.keys.shape[0] ?? 0
         let cachedOffset = cache?.positionOffset ?? 0

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
@@ -115,7 +115,9 @@ struct VoxtralRealtimeEncoderAttentionInputs {
     /// or all `nil`, for a cache-less pass). One mask can serve every layer
     /// because the encoder always advances its layer caches in lockstep — they
     /// are created, extended, trimmed, and reset together — which is asserted
-    /// here. `dtype` is the activation (q/k) dtype the mask must match.
+    /// here. `dtype` is the activation (q/k) dtype the mask must match; passing
+    /// the encoder input dtype relies on every layer's q/k projections
+    /// preserving it, which holds for the uniform-precision `Linear` weights.
     static func build(
         positions: MLXArray,
         seqLen: Int,
@@ -131,12 +133,17 @@ struct VoxtralRealtimeEncoderAttentionInputs {
             theta: ropeTheta
         )
 
+        // `caches.first ?? nil` collapses "no caches" and "[nil, ...]" into one
+        // cache-less case. Nil-ness must also be uniform across layers: a
+        // present-but-empty cache selects the explicit-array mask branch below,
+        // while a nil cache can take the `.causal` branch.
         let cache = caches.first ?? nil
         let cachedLen = cache?.keys.shape[0] ?? 0
         let cachedOffset = cache?.positionOffset ?? 0
         precondition(
             caches.allSatisfy {
-                ($0?.keys.shape[0] ?? 0) == cachedLen
+                ($0 == nil) == (cache == nil)
+                    && ($0?.keys.shape[0] ?? 0) == cachedLen
                     && ($0?.positionOffset ?? 0) == cachedOffset
             },
             "encoder layer caches must advance in lockstep to share one attention mask"
@@ -441,6 +448,8 @@ final class VoxtralRealtimeAudioEncoder: Module {
             let chunkEnd = min(chunkStart + sw, seqLen)
             var x = convOut[chunkStart..<chunkEnd, 0...]
             let positions = MLXArray(chunkStart..<chunkEnd).asType(.int32)
+            // Per-chunk, not per-pass: the caches' offset/history advance between
+            // chunks, so these inputs cannot be hoisted out of this loop.
             let inputs = attentionInputs(
                 positions: positions, seqLen: chunkEnd - chunkStart, caches: caches,
                 dtype: x.dtype)

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeEncoder.swift
@@ -92,6 +92,89 @@ final class VoxtralRealtimeCausalConv1d: Module {
     }
 }
 
+/// Attention inputs that are identical for every transformer layer of a single
+/// encoder forward pass: the interleaved-RoPE cos/sin tables for `positions` and
+/// the scaled-dot-product-attention mask.
+///
+/// The per-layer attention used to rebuild these from scratch — `nLayers` copies
+/// of the same ~15 tiny kernels per pass. For the realtime streaming session the
+/// encoder runs every audio chunk over only a handful of new frames, so those
+/// redundant launches (not bandwidth) dominate encoder step time. The caller now
+/// builds the shared inputs once per pass and every layer reuses them. The values
+/// are produced by exactly the same operations as before, in the same order, so
+/// every layer output is bit-identical to the per-layer construction.
+struct VoxtralRealtimeEncoderAttentionInputs {
+    let ropeCos: MLXArray
+    let ropeSin: MLXArray
+    let mask: MLXFast.ScaledDotProductAttentionMaskMode
+
+    /// Build the shared inputs for one forward pass of `seqLen` frames at
+    /// `positions`.
+    ///
+    /// `caches` are the per-layer KV-caches this pass is about to extend (empty,
+    /// or all `nil`, for a cache-less pass). One mask can serve every layer
+    /// because the encoder always advances its layer caches in lockstep — they
+    /// are created, extended, trimmed, and reset together — which is asserted
+    /// here. `dtype` is the activation (q/k) dtype the mask must match.
+    static func build(
+        positions: MLXArray,
+        seqLen: Int,
+        caches: [VoxtralRealtimeEncoderKVCache?],
+        slidingWindow: Int,
+        headDim: Int,
+        ropeTheta: Float,
+        dtype: DType
+    ) -> VoxtralRealtimeEncoderAttentionInputs {
+        let (cos, sin) = voxtralComputeRopeFrequencies(
+            positions: positions,
+            headDim: headDim,
+            theta: ropeTheta
+        )
+
+        let cache = caches.first ?? nil
+        let cachedLen = cache?.keys.shape[0] ?? 0
+        let cachedOffset = cache?.positionOffset ?? 0
+        precondition(
+            caches.allSatisfy {
+                ($0?.keys.shape[0] ?? 0) == cachedLen
+                    && ($0?.positionOffset ?? 0) == cachedOffset
+            },
+            "encoder layer caches must advance in lockstep to share one attention mask"
+        )
+
+        // Mirror the concat + sliding-window trim the attention applies to its
+        // cache, so the mask covers the exact key positions each layer will use.
+        var positionOffset = cachedOffset
+        var kvLen = cachedLen + seqLen
+        if kvLen > slidingWindow {
+            positionOffset += kvLen - slidingWindow
+            kvLen = slidingWindow
+        }
+
+        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
+        if seqLen == 1 {
+            maskMode = .none
+        } else if cache == nil && seqLen <= slidingWindow {
+            maskMode = .causal
+        } else {
+            let qPos = positions.expandedDimensions(axis: 1)
+            let kPos = MLXArray(positionOffset..<(positionOffset + kvLen)).asType(.int32).expandedDimensions(axis: 0)
+            let causal = kPos .<= qPos
+            let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
+            let allowed = logicalAnd(causal, window)
+            // Match the activation dtype: a float32 mask over fp16 q/k aborts SDPA.
+            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(dtype)
+            maskMode = .array(mask)
+        }
+
+        return VoxtralRealtimeEncoderAttentionInputs(
+            ropeCos: cos,
+            ropeSin: sin,
+            mask: maskMode
+        )
+    }
+}
+
 final class VoxtralRealtimeEncoderAttention: Module {
     let nHeads: Int
     let headDim: Int
@@ -120,7 +203,7 @@ final class VoxtralRealtimeEncoderAttention: Module {
 
     func callAsFunction(
         _ x: MLXArray,
-        positions: MLXArray,
+        inputs: VoxtralRealtimeEncoderAttentionInputs,
         cache: VoxtralRealtimeEncoderKVCache?
     ) -> (MLXArray, VoxtralRealtimeEncoderKVCache) {
         let seqLen = x.shape[0]
@@ -129,14 +212,10 @@ final class VoxtralRealtimeEncoderAttention: Module {
         var k = wk(x)
         var v = wv(x)
 
-        let (cos, sin) = voxtralComputeRopeFrequencies(
-            positions: positions,
-            headDim: headDim,
-            theta: ropeTheta
-        )
-
-        q = voxtralApplyInterleavedRoPE(q, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
-        k = voxtralApplyInterleavedRoPE(k, cos: cos, sin: sin, nHeads: nHeads, headDim: headDim)
+        q = voxtralApplyInterleavedRoPE(
+            q, cos: inputs.ropeCos, sin: inputs.ropeSin, nHeads: nHeads, headDim: headDim)
+        k = voxtralApplyInterleavedRoPE(
+            k, cos: inputs.ropeCos, sin: inputs.ropeSin, nHeads: nHeads, headDim: headDim)
 
         var positionOffset = cache?.positionOffset ?? 0
         if let cache {
@@ -163,28 +242,12 @@ final class VoxtralRealtimeEncoderAttention: Module {
         let k4 = k.reshaped(1, kvLen, nHeads, headDim).transposed(0, 2, 1, 3)
         let v4 = v.reshaped(1, kvLen, nHeads, headDim).transposed(0, 2, 1, 3)
 
-        let maskMode: MLXFast.ScaledDotProductAttentionMaskMode
-        if seqLen == 1 {
-            maskMode = .none
-        } else if cache == nil && seqLen <= slidingWindow {
-            maskMode = .causal
-        } else {
-            let qPos = positions.expandedDimensions(axis: 1)
-            let kPos = MLXArray(positionOffset..<(positionOffset + kvLen)).asType(.int32).expandedDimensions(axis: 0)
-            let causal = kPos .<= qPos
-            let window = kPos .>= (qPos - MLXArray(Int32(slidingWindow - 1)))
-            let allowed = logicalAnd(causal, window)
-            // Match the activation dtype: a float32 mask over fp16 q/k aborts SDPA.
-            let mask = MLX.where(allowed, MLXArray(0.0), MLXArray(-1e9)).asType(q.dtype)
-            maskMode = .array(mask)
-        }
-
         let attn = MLXFast.scaledDotProductAttention(
             queries: q4,
             keys: k4,
             values: v4,
             scale: scale,
-            mask: maskMode
+            mask: inputs.mask
         )
 
         let out = attn.transposed(0, 2, 1, 3).reshaped(seqLen, nHeads * headDim)
@@ -213,13 +276,13 @@ final class VoxtralRealtimeEncoderLayer: Module {
 
     func callAsFunction(
         _ x: MLXArray,
-        positions: MLXArray,
+        inputs: VoxtralRealtimeEncoderAttentionInputs,
         cache: VoxtralRealtimeEncoderKVCache?
     ) -> (MLXArray, VoxtralRealtimeEncoderKVCache) {
         var out = x
 
         var h = attentionNorm(out)
-        let attnOut = attention(h, positions: positions, cache: cache)
+        let attnOut = attention(h, inputs: inputs, cache: cache)
         h = attnOut.0
         out = out + h
 
@@ -287,6 +350,26 @@ final class VoxtralRealtimeAudioEncoder: Module {
         return x
     }
 
+    /// Shared per-pass attention inputs (RoPE tables + mask) for `seqLen` frames
+    /// at `positions`, extending `caches` — see
+    /// `VoxtralRealtimeEncoderAttentionInputs`.
+    private func attentionInputs(
+        positions: MLXArray,
+        seqLen: Int,
+        caches: [VoxtralRealtimeEncoderKVCache?],
+        dtype: DType
+    ) -> VoxtralRealtimeEncoderAttentionInputs {
+        VoxtralRealtimeEncoderAttentionInputs.build(
+            positions: positions,
+            seqLen: seqLen,
+            caches: caches,
+            slidingWindow: config.slidingWindow,
+            headDim: config.headDim,
+            ropeTheta: config.ropeTheta,
+            dtype: dtype
+        )
+    }
+
     /// Incremental counterpart of `convStem`: consume new mel columns
     /// (`[nMels, nNew]`) and return every conv-stem row (`[nNewRows, dim]`) they
     /// complete, matching the rows `convStem` produces at the same absolute indices.
@@ -330,10 +413,12 @@ final class VoxtralRealtimeAudioEncoder: Module {
     func encodeFull(_ convOut: MLXArray) -> MLXArray {
         let seqLen = convOut.shape[0]
         let positions = MLXArray(0..<seqLen).asType(.int32)
+        let inputs = attentionInputs(
+            positions: positions, seqLen: seqLen, caches: [], dtype: convOut.dtype)
 
         var x = convOut
         for layer in transformerLayers {
-            x = layer(x, positions: positions, cache: nil).0
+            x = layer(x, inputs: inputs, cache: nil).0
         }
 
         x = transformerNorm(x)
@@ -356,9 +441,12 @@ final class VoxtralRealtimeAudioEncoder: Module {
             let chunkEnd = min(chunkStart + sw, seqLen)
             var x = convOut[chunkStart..<chunkEnd, 0...]
             let positions = MLXArray(chunkStart..<chunkEnd).asType(.int32)
+            let inputs = attentionInputs(
+                positions: positions, seqLen: chunkEnd - chunkStart, caches: caches,
+                dtype: x.dtype)
 
             for i in transformerLayers.indices {
-                let next = transformerLayers[i](x, positions: positions, cache: caches[i])
+                let next = transformerLayers[i](x, inputs: inputs, cache: caches[i])
                 x = next.0
                 caches[i] = next.1
             }
@@ -383,8 +471,10 @@ final class VoxtralRealtimeAudioEncoder: Module {
     ) -> MLXArray {
         var x = convBlock
         let positions = MLXArray(startPos..<(startPos + convBlock.shape[0])).asType(.int32)
+        let inputs = attentionInputs(
+            positions: positions, seqLen: convBlock.shape[0], caches: caches, dtype: x.dtype)
         for i in transformerLayers.indices {
-            let next = transformerLayers[i](x, positions: positions, cache: caches[i])
+            let next = transformerLayers[i](x, inputs: inputs, cache: caches[i])
             x = next.0
             caches[i] = next.1
         }


### PR DESCRIPTION
Every Voxtral Realtime transformer layer rebuilt identical per-forward values inside its attention: the interleaved-RoPE cos/sin tables (encoder and decoder) and the SDPA sliding-window mask (encoder cached paths) — O(nLayers) copies of the same tiny kernels per pass, pure launch overhead in streaming where a pass covers a few new frames or a single decoded token. The encoder now builds a shared `VoxtralRealtimeEncoderAttentionInputs` once per pass in `encodeFull` / `encodeChunked` / `encodeIncremental`; the decoder computes its RoPE tables once per forward. The offline/batch path gets the same reduction.

Sharing one mask relies on the per-layer KV caches advancing in lockstep, which is how all three encode paths drive them; the builder `precondition`s it (including nil-ness uniformity). This also matches the Python reference (voxmlx), which builds mask and RoPE once per forward — the per-layer rebuild was porting overhead, not intent.

Outputs are unchanged: same operations, same inputs, same order — only the number of identical subgraph instantiations changes, so every layer consumes bit-identical arrays. Covered by the existing streaming/offline equivalence tests; no public API changes.

## Evidence

M1 Pro, 60 s stream at 100 ms cadence, Voxtral-Mini-4B-Realtime 4-bit: encoder graph build 3.5–5.0 → 1.7–2.1 ms/step, whole step ~99.8 → ~96.6 ms (~3%). Modest but strict — fewer kernel launches for identical outputs, simpler per-layer attention bodies, and the lockstep invariant now explicit and loudly enforced.

Notes: textually conflicts with #230 in `VoxtralRealtimeEncoder.swift` (content-independent) — happy to rebase whichever lands second. Staged at T0mSIlver#4.
