### PR TITLE
VoxtralRealtime: load checkpoints with a quantized tied embedding

### DIFF
--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtime.swift
@@ -633,10 +633,13 @@ public extension VoxtralRealtimeModel {
     }
 
     func shouldQuantize(path: String) -> Bool {
+        // tok_embeddings is deliberately not skipped: the loader's quantize pass is
+        // gated on the checkpoint shipping "<path>.scales", so checkpoints with a
+        // quantized tied embedding load directly while fp16-embedding checkpoints
+        // are structured exactly as before.
         let skipPatterns = [
             "norm",
             "ada_rms_norm",
-            "tok_embeddings",
             "conv_layers",
             "audio_language_projection",
         ]

--- a/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
+++ b/Sources/MLXAudioSTT/Models/VoxtralRealtime/VoxtralRealtimeDecoder.swift
@@ -252,7 +252,9 @@ final class VoxtralRealtimeDecoder: Module {
     }
 
     func embedToken(tokenId: Int) -> MLXArray {
-        tokEmbeddings.weight[tokenId]
+        // Module lookup rather than a raw `weight` row: for a QuantizedEmbedding the
+        // weight is bit-packed and only the module's gather dequantizes it.
+        tokEmbeddings(MLXArray([Int32(tokenId)])).squeezed(axis: 0)
     }
 
     func embedTokens(_ tokenIds: MLXArray) -> MLXArray {
@@ -292,6 +294,10 @@ final class VoxtralRealtimeDecoder: Module {
     }
 
     func logits(_ h: MLXArray) -> MLXArray {
-        MLX.matmul(h, tokEmbeddings.weight.transposed(1, 0))
+        // `asLinear` dispatches to the module's tied projection: a plain embedding
+        // computes the same contraction as the previous matmul(h, weight.T), and a
+        // QuantizedEmbedding takes the quantized-matmul path. Callers pass a single
+        // hidden row, so lift to rank 2 for the projection and drop the batch axis.
+        tokEmbeddings.asLinear(h.expandedDimensions(axis: 0)).squeezed(axis: 0)
     }
 }

--- a/Tests/VoxtralRealtimeTiedEmbeddingTests.swift
+++ b/Tests/VoxtralRealtimeTiedEmbeddingTests.swift
@@ -1,0 +1,96 @@
+//  The Voxtral Realtime tied embedding doubles as the LM head. These tests pin the
+//  decoder's tied-head routing: for a plain fp16/fp32 embedding the module-routed
+//  embedToken/logits are value-identical to the raw-weight formulas they replaced,
+//  and a quantized tied embedding (packed weight + scales/biases, as converted
+//  checkpoints ship it) dequantizes through the module instead of exposing packed
+//  bits to the decode path.
+//
+//  Run:
+//    xcodebuild test -scheme MLXAudio-Package -destination 'platform=macOS' \
+//      -only-testing:'MLXAudioTests/VoxtralRealtimeTiedEmbeddingTests' \
+//      CODE_SIGNING_ALLOWED=NO
+
+import Foundation
+import Testing
+import MLX
+import MLXNN
+
+@testable import MLXAudioSTT
+
+struct VoxtralRealtimeTiedEmbeddingTests {
+    private static func smallConfig() -> VoxtralRealtimeDecoderConfig {
+        VoxtralRealtimeDecoderConfig(
+            dim: 64,
+            nLayers: 1,
+            nHeads: 2,
+            nKvHeads: 1,
+            headDim: 32,
+            hiddenDim: 128,
+            vocabSize: 96,
+            normEps: 1e-5,
+            ropeTheta: 1_000_000,
+            slidingWindow: 8,
+            tiedEmbeddings: true,
+            adaRmsNormTCond: false,
+            adaRmsNormTCondDim: 32
+        )
+    }
+
+    @Test func moduleRoutedTiedHeadMatchesRawWeightFormulas() {
+        let decoder = VoxtralRealtimeDecoder(Self.smallConfig())
+        let w = decoder.tokEmbeddings.weight
+        let h = MLXRandom.normal([w.shape[1]]).asType(w.dtype)
+
+        // The raw-weight formulas the module-routed paths replaced.
+        let expectedEmbed = w[7]
+        let expectedLogits = MLX.matmul(h, w.transposed(1, 0))
+
+        // The gather is the identical op — exact. The projection is the same
+        // contraction lifted to rank 2, so allow kernel-order rounding only.
+        #expect(
+            MLX.abs(decoder.embedToken(tokenId: 7) - expectedEmbed)
+                .max().item(Float.self) == 0
+        )
+        let logits = decoder.logits(h)
+        #expect(logits.shape == expectedLogits.shape)
+        #expect(
+            MLX.abs(logits - expectedLogits).max().item(Float.self) < 1e-5
+        )
+    }
+
+    @Test func quantizedTiedEmbeddingRoutesThroughDequantization() {
+        let decoder = VoxtralRealtimeDecoder(Self.smallConfig())
+        let dim = decoder.tokEmbeddings.weight.shape[1]
+
+        quantize(model: decoder, groupSize: 32, bits: 4) { path, module in
+            path == "tok_embeddings" && module is Embedding
+        }
+        guard let quantized = decoder.tokEmbeddings as? QuantizedEmbedding else {
+            Issue.record("tok_embeddings was not replaced by a QuantizedEmbedding")
+            return
+        }
+
+        let dequant = dequantized(
+            quantized.weight,
+            scales: quantized.scales,
+            biases: quantized.biases,
+            groupSize: quantized.groupSize,
+            bits: quantized.bits,
+            mode: quantized.mode
+        )
+        let h = MLXRandom.normal([dim]).asType(dequant.dtype)
+
+        // embedToken must return the dequantized row, not packed bits.
+        #expect(
+            MLX.abs(decoder.embedToken(tokenId: 7) - dequant[7])
+                .max().item(Float.self) == 0
+        )
+
+        // The tied projection must equal the contraction over the dequantized
+        // weight, up to the quantized kernel's accumulation order.
+        let expected = MLX.matmul(h, dequant.transposed(1, 0))
+        let logits = decoder.logits(h)
+        #expect(logits.shape == expected.shape)
+        #expect(MLX.abs(logits - expected).max().item(Float.self) < 1e-2)
+    }
+}


### PR DESCRIPTION
Allows loading Voxtral Realtime models whose tied embedding is quantized. Today such models fail to load — which leaves the most expensive per-token operation of the decode loop stuck in fp16 (see the numbers below).

## Problem

Voxtral Realtime has no separate LM-head weight: the decoder reuses the token-embedding matrix (`tok_embeddings`) both to embed input tokens and to project hidden states to logits ("tied embedding").

A converted checkpoint can store this matrix in one of two forms:

- **fp16**: a single `tok_embeddings.weight` tensor. This is what the current mlx-community conversions ship, and it loads fine.
- **quantized**: three tensors — a bit-packed `weight` plus `scales` and `biases`. This is the form MLX's standard quantization path (`nn.quantize`, which includes embeddings) produces, so converted checkpoints commonly ship it for other model families.

The quantized form cannot be loaded. During model construction the loader runs a quantize pass that turns each `Linear`/`Embedding` into its quantized counterpart when the checkpoint has `scales` for it — but `shouldQuantize` hard-excludes `tok_embeddings`, so the module always stays a plain `Embedding` that expects exactly one fp16 tensor. Weight loading with `verify: .all` then rejects the checkpoint's `tok_embeddings.scales`/`.biases` with an `UpdateError` — a plain `Embedding` has no such parameters.

## Why it matters

For the 4B model the tied head is a 131072×3072 matrix: 768 MiB in fp16, read in full for every decoded token's logits row. In live streaming on an M1 Pro that fp16 gemv is the single largest phase of the decode loop. With a 4-bit/group-64 quantized tied embedding (measured, same machine, same audio):

- LM-head projection: **~30 ms → ~3 ms per decoded token** (quantized-matmul fast path)
- end-to-end 100 ms-cadence streaming step: **92–104 ms → 64–74 ms**
- resident weight memory: **≈ −530 MiB** (768 MiB fp16 → ≈ 240 MiB packed weight + scales/biases)
- transcription quality held level on a 156-case English/French dictation eval with heavy technical vocabulary: 50/156 hard cases fully passing vs 49/156 for the fp16-embedding checkpoint, mean word accuracy 0.73 vs 0.72 on its stress subset

(The streaming numbers are from one realtime workload on one machine; the per-token LM-head saving applies to any decode loop over this model.)

## Why the exclusion existed

The exclusion and the `.scales` gate both date from the original model port (#52), and it looks deliberate:

1. It matches what the reference conversions leave unquantized — norms, conv stem, adapter projection, embeddings.
2. More importantly, two decode paths read the raw `weight` tensor directly: `embedToken` gathers a row with `weight[tokenId]`, and `logits` computes `matmul(h, weight.T)`. On a `QuantizedEmbedding` the `weight` property is the bit-packed tensor, so if a quantized embedding had ever been structured, both paths would have consumed packed bits and produced garbage tokens with no error. Refusing to load was the safer failure mode.

This PR fixes the two paths, at which point the exclusion only blocks legitimate checkpoints.

## Change

Three pieces. For fp16-embedding checkpoints the gather is bit-identical and the projection is the same contraction (within kernel rounding — the tests pin both):

1. `embedToken` gathers through the module call instead of indexing `weight` — on a `QuantizedEmbedding` that dequantizes the row, on a plain `Embedding` it is the same gather.
2. `logits` projects through `Embedding.asLinear` — the same contraction for a plain embedding, the quantized-matmul path for a quantized one.
3. `shouldQuantize` no longer excludes `tok_embeddings`. The quantize pass is still gated on the checkpoint shipping `<path>.scales`, so fp16-embedding checkpoints are structured exactly as before; nothing is quantized that the checkpoint didn't quantize.

## Tests

`Tests/VoxtralRealtimeTiedEmbeddingTests.swift`:

- Plain embedding: module-routed `embedToken`/`logits` match the raw-weight formulas they replaced (gather exactly; projection within kernel rounding).
- Quantized embedding (via the standard `quantize(model:filter:)` machinery): `embedToken` returns exactly the dequantized row, and the tied projection matches the dequantized-weight contraction within the quantized kernel's accumulation error.

Also validated end-to-end on device: a Voxtral-Mini-4B checkpoint with a 4-bit/g64-quantized tied embedding loads and transcribes real audio correctly through the streaming session (the eval above).
