### PR TITLE
Add reproducible OmniVoice generation seed

### DIFF
--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoice.swift
@@ -291,6 +291,10 @@ public final class OmniVoiceModel: Module, SpeechGenerationModel, @unchecked Sen
             throw AudioGenerationError.modelNotInitialized("Audio tokenizer not loaded")
         }
 
+        if let seed = ovParameters.seed {
+            MLXRandom.seed(seed)
+        }
+
         // 1. Encode reference audio to tokens if provided
         var refAudioTokens: MLXArray?
         if let refAudio {

--- a/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceGenerateParameters.swift
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/OmniVoiceGenerateParameters.swift
@@ -63,6 +63,10 @@ public struct OmniVoiceGenerateParameters: Sendable {
     /// Lower values = more deterministic, higher values = more variation.
     public var classTemperature: Float
 
+    /// Optional random seed for reproducible generation.
+    /// When nil, generation continues from MLX's current random state.
+    public var seed: UInt64?
+
     // MARK: - Initialization
 
     public init(
@@ -75,7 +79,8 @@ public struct OmniVoiceGenerateParameters: Sendable {
         postprocessOutput: Bool = true,
         layerPenaltyFactor: Float = 5.0,
         positionTemperature: Float = 5.0,
-        classTemperature: Float = 0.0
+        classTemperature: Float = 0.0,
+        seed: UInt64? = nil
     ) {
         self.numStep = numStep
         self.guidanceScale = guidanceScale
@@ -87,6 +92,7 @@ public struct OmniVoiceGenerateParameters: Sendable {
         self.layerPenaltyFactor = layerPenaltyFactor
         self.positionTemperature = positionTemperature
         self.classTemperature = classTemperature
+        self.seed = seed
     }
 
     /// Default parameters optimized for fast generation.

--- a/Sources/MLXAudioTTS/Models/OmniVoice/README.md
+++ b/Sources/MLXAudioTTS/Models/OmniVoice/README.md
@@ -32,7 +32,7 @@ swift run mlx-audio-swift-tts --model mlx-community/OmniVoice \
     --text "Hello!" --voice "male, british accent" --output out.wav
 ```
 
-Generation knobs live in `OmniVoiceGenerateParameters` (`numStep`, `guidanceScale`, `speed`, `positionTemperature`, `tShift`, ...). Defaults match the Python reference (`num_steps=32`, `guidance_scale=2.0`).
+Generation knobs live in `OmniVoiceGenerateParameters` (`numStep`, `guidanceScale`, `speed`, `positionTemperature`, `tShift`, `seed`, ...). Defaults match the Python reference (`num_steps=32`, `guidance_scale=2.0`). Set `seed` to reproduce generation; leave it `nil` to continue from MLX's current random state.
 
 ## Modes
 

--- a/Tests/OmniVoiceTests.swift
+++ b/Tests/OmniVoiceTests.swift
@@ -94,6 +94,7 @@ struct OmniVoiceConfigTests {
         #expect(params.layerPenaltyFactor == 5.0)
         #expect(params.positionTemperature == 5.0)
         #expect(params.classTemperature == 0.0)
+        #expect(params.seed == nil)
     }
 
     @Test func testFastPreset() {
@@ -121,7 +122,8 @@ struct OmniVoiceConfigTests {
             postprocessOutput: false,
             layerPenaltyFactor: 3.0,
             positionTemperature: 3.0,
-            classTemperature: 0.5
+            classTemperature: 0.5,
+            seed: 42
         )
 
         #expect(params.numStep == 48)
@@ -134,6 +136,7 @@ struct OmniVoiceConfigTests {
         #expect(params.layerPenaltyFactor == 3.0)
         #expect(params.positionTemperature == 3.0)
         #expect(params.classTemperature == 0.5)
+        #expect(params.seed == 42)
     }
 }
 


### PR DESCRIPTION
## Summary

- add an optional `UInt64` seed to `OmniVoiceGenerateParameters`
- seed MLX before OmniVoice preprocessing and diffusion when callers request reproducible generation
- preserve current random-state behavior when the seed is `nil`
- document the setting and cover its default and custom values

## Testing

- `swift test --filter OmniVoiceTests`
- `xcodebuild build-for-testing -scheme MLXAudio-Package -destination 'platform=macOS' MACOSX_DEPLOYMENT_TARGET=14.0 CODE_SIGNING_ALLOWED=NO`