### PR TITLE
Honor Chatterbox emotion override with default conditioning

### DIFF
--- a/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift
+++ b/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift
@@ -18,6 +18,10 @@ import MLXNN
 @preconcurrency import MLXLMCommon
 import Tokenizers
 
+func resolveChatterboxEmotionAdv(default value: MLXArray, override: Float?) -> MLXArray {
+    override.map { MLXArray(Float($0)) } ?? value
+}
+
 // MARK: - Default Voice Conditioning
 
 /// Pre-computed voice conditioning loaded from conds.safetensors (Turbo default voice).
@@ -704,7 +708,8 @@ public final class ChatterboxModel: Module, SpeechGenerationModel, @unchecked Se
                 speakerEmb: defaults.speakerEmb,
                 condPromptSpeechTokens: defaults.condPromptSpeechTokens,
                 condPromptSpeechEmb: nil,
-                emotionAdv: defaults.emotionAdv
+                emotionAdv: resolveChatterboxEmotionAdv(
+                    default: defaults.emotionAdv, override: emotionAdvOverride)
             )
             xVector = defaults.xVector
             promptTokens = defaults.promptToken

--- a/Tests/ChatterboxTests.swift
+++ b/Tests/ChatterboxTests.swift
@@ -1,0 +1,16 @@
+import MLX
+import Testing
+
+@testable import MLXAudioTTS
+
+@Suite("Chatterbox generation tests")
+struct ChatterboxGenerationTests {
+    @Test func emotionOverrideAppliesToDefaultConditioning() {
+        let defaults = MLXArray(Float(0.5))
+
+        #expect(
+            resolveChatterboxEmotionAdv(default: defaults, override: nil).item(Float.self) == 0.5)
+        #expect(
+            resolveChatterboxEmotionAdv(default: defaults, override: 0.9).item(Float.self) == 0.9)
+    }
+}


### PR DESCRIPTION
## Summary

- apply `emotionAdvOverride` when Chatterbox synthesizes with bundled default conditioning
- preserve the checkpoint emotion value when no override is set
- add a focused regression test for both paths

Previously the override was only consulted while preparing reference-audio conditioning, so callers using the default voice could set it without affecting synthesis.

## Testing

- `xcodebuild build-for-testing -scheme MLXAudio-Package -destination 'platform=macOS' MACOSX_DEPLOYMENT_TARGET=14.0 CODE_SIGNING_ALLOWED=NO`\n- `xcodebuild test-without-building -scheme MLXAudio-Package -destination 'platform=macOS' -only-testing:MLXAudioTests/ChatterboxGenerationTests -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO`