### PR TITLE
Fix quantized Whisper checkpoint loading

### DIFF
--- a/Sources/MLXAudioSTT/Models/Whisper/WhisperLayers.swift
+++ b/Sources/MLXAudioSTT/Models/Whisper/WhisperLayers.swift
@@ -323,7 +323,7 @@ final class WhisperDecoder: Module {
 
     /// Project hidden states to vocab logits using the tied embedding matrix.
     func projectToVocab(_ hidden: MLXArray) -> MLXArray {
-        return hidden.matmul(embedTokens.weight.transposed(1, 0))
+        embedTokens.asLinear(hidden)
     }
 }
 

--- a/Sources/MLXAudioSTT/Models/Whisper/WhisperModel.swift
+++ b/Sources/MLXAudioSTT/Models/Whisper/WhisperModel.swift
@@ -403,8 +403,9 @@ public final class WhisperModel: Module, STTGenerationModel {
         if rawKey == "decoder.positional_embedding" {
             return "model.decoder.embed_positions.weight"
         }
-        if rawKey == "decoder.token_embedding.weight" {
-            return "model.decoder.embed_tokens.weight"
+        if rawKey.hasPrefix("decoder.token_embedding.") {
+            return "model.decoder.embed_tokens."
+                + String(rawKey.dropFirst("decoder.token_embedding.".count))
         }
         if rawKey == "encoder.conv1.weight" || rawKey == "encoder.conv1.bias"
             || rawKey == "encoder.conv2.weight" || rawKey == "encoder.conv2.bias"
@@ -495,6 +496,19 @@ public final class WhisperModel: Module, STTGenerationModel {
         }
 
         let model = WhisperModel(config: config, generationConfig: generationConfig)
+        if let quantization = try? JSONDecoder().decode(
+            WhisperQuantizedModelConfig.self,
+            from: configData
+        ).quantization {
+            quantize(
+                model: model,
+                groupSize: quantization.groupSize,
+                bits: quantization.bits,
+                filter: { path, module in
+                    module is Linear || path.hasSuffix("decoder.embed_tokens")
+                }
+            )
+        }
 
         let files = try FileManager.default.contentsOfDirectory(
             at: modelDirectory,
@@ -646,5 +660,19 @@ public final class WhisperModel: Module, STTGenerationModel {
             cache: cache
         )
         return try await fromDirectory(modelDir, cache: cache)
+    }
+}
+
+private struct WhisperQuantizedModelConfig: Decodable {
+    let quantization: WhisperQuantizationConfig?
+}
+
+private struct WhisperQuantizationConfig: Decodable {
+    let groupSize: Int
+    let bits: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case groupSize = "group_size"
+        case bits
     }
 }

--- a/Tests/WhisperQuantizedTiedEmbeddingTests.swift
+++ b/Tests/WhisperQuantizedTiedEmbeddingTests.swift
@@ -1,0 +1,67 @@
+//  Whisper uses decoder.embed_tokens as both the input embedding and output
+//  projection. These tests pin the module-routed projection for plain and
+//  quantized checkpoints so packed 4-bit weights are never multiplied as if
+//  they were dense floating-point values.
+
+import MLX
+import MLXNN
+import Testing
+
+@testable import MLXAudioSTT
+
+struct WhisperQuantizedTiedEmbeddingTests {
+    private static func smallConfig() -> WhisperConfig {
+        WhisperConfig(
+            vocabSize: 96,
+            numMelBins: 80,
+            dModel: 64,
+            encoderLayers: 1,
+            encoderAttentionHeads: 2,
+            encoderFfnDim: 128,
+            maxSourcePositions: 32,
+            decoderLayers: 1,
+            decoderAttentionHeads: 2,
+            decoderFfnDim: 128,
+            maxTargetPositions: 32
+        )
+    }
+
+    @Test func tiedProjectionMatchesDenseEmbeddingWeight() {
+        let decoder = WhisperDecoder(config: Self.smallConfig())
+        let weight = decoder.embedTokens.weight
+        let hidden = MLXRandom.normal([weight.shape[1]]).asType(weight.dtype)
+        let expected = MLX.matmul(hidden, weight.transposed(1, 0))
+
+        let logits = decoder.projectToVocab(hidden)
+
+        #expect(logits.shape == expected.shape)
+        #expect(MLX.abs(logits - expected).max().item(Float.self) < 1e-5)
+    }
+
+    @Test func tiedProjectionDequantizesPackedEmbedding() {
+        let decoder = WhisperDecoder(config: Self.smallConfig())
+        quantize(model: decoder, groupSize: 32, bits: 4) { path, module in
+            path == "embed_tokens" && module is Embedding
+        }
+        guard let quantized = decoder.embedTokens as? QuantizedEmbedding else {
+            Issue.record("embed_tokens was not replaced by a QuantizedEmbedding")
+            return
+        }
+
+        let dense = dequantized(
+            quantized.weight,
+            scales: quantized.scales,
+            biases: quantized.biases,
+            groupSize: quantized.groupSize,
+            bits: quantized.bits,
+            mode: quantized.mode
+        )
+        let hidden = MLXRandom.normal([dense.shape[1]]).asType(dense.dtype)
+        let expected = MLX.matmul(hidden, dense.transposed(1, 0))
+
+        let logits = decoder.projectToVocab(hidden)
+
+        #expect(logits.shape == expected.shape)
+        #expect(MLX.abs(logits - expected).max().item(Float.self) < 1e-2)
+    }
+}


### PR DESCRIPTION
## Summary

- quantize Whisper linear layers and the tied decoder embedding before loading packed checkpoints
- map tied embedding scales and biases from mlx-whisper checkpoints
- route vocabulary projection through the embedding module so quantized weights dequantize correctly
- add dense and quantized tied-projection tests

## Validation

- `swift build --product mlx-audio-swift-stt`
- transcribed Japanese and English FLEURS clips with `mlx-community/whisper-large-v3-turbo-asr-4bit`; outputs matched the Python MLX checkpoint
- `swift test --filter Whisper` reached test compilation but the selected Command Line Tools environment lacks the Swift `Testing` module