### PR TITLE
Stream Fish Speech progressively

### DIFF
--- a/Sources/MLXAudioCore/Generation/GenerationTypes.swift
+++ b/Sources/MLXAudioCore/Generation/GenerationTypes.swift
@@ -52,7 +52,7 @@ public enum AudioGeneration: Sendable {
     case token(Int)
     /// Generation statistics
     case info(AudioGenerationInfo)
-    /// Final generated audio
+    /// Generated audio chunk. Concatenate repeated values for the complete waveform.
     case audio(MLXArray)
 }
 

--- a/Sources/MLXAudioTTS/Models/FishSpeech/FishSpeechModel.swift
+++ b/Sources/MLXAudioTTS/Models/FishSpeech/FishSpeechModel.swift
@@ -399,6 +399,13 @@ private func fishSpeechAdjustSpeed(_ audio: MLXArray, speed: Float) -> MLXArray 
     return leftWeight * audio[left] + rightWeight * audio[right]
 }
 
+func fishSpeechStreamingChunkBytes(interval: Double) throws -> Int {
+    guard interval.isFinite, interval > 0 else {
+        throw AudioGenerationError.invalidInput("Streaming interval must be a finite positive number")
+    }
+    return max(40, Int(min(interval, 60) * 40))
+}
+
 private func fishSpeechSampleToken(
     logits: MLXArray,
     temperature: Float,
@@ -586,7 +593,6 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
     ) -> AsyncThrowingStream<AudioGeneration, Error> {
         _ = voice
         _ = language
-        _ = streamingInterval
 
         let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
         let task = Task { @Sendable [weak self] in
@@ -596,7 +602,12 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
             }
 
             do {
-                let segments = try self.generateSegments(
+                let chunkLength = try fishSpeechStreamingChunkBytes(interval: streamingInterval)
+                var totalPromptTokens = 0
+                var totalGenerationTokens = 0
+                var totalTime = 0.0
+                var peakMemory = 0.0
+                _ = try self.generateSegments(
                     text: text,
                     refAudio: refAudio,
                     refText: refText,
@@ -605,24 +616,31 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
                     topP: generationParameters.topP,
                     topK: 30,
                     speed: 1.0,
-                    chunkLength: 300
+                    chunkLength: chunkLength,
+                    onSegment: { segment in
+                        try Task.checkCancellation()
+                        totalPromptTokens += segment.promptTokenCount
+                        totalGenerationTokens += segment.generationTokenCount
+                        totalTime += segment.elapsed
+                        peakMemory = max(peakMemory, segment.peakMemoryUsage)
+                        if case .terminated = continuation.yield(.audio(segment.audio)) {
+                            throw CancellationError()
+                        }
+                    }
                 )
                 try Task.checkCancellation()
-                let audio = self.concatenateAudioSegments(segments)
-                let totalPromptTokens = segments.reduce(into: 0) { $0 += $1.promptTokenCount }
-                let totalGenerationTokens = segments.reduce(into: 0) { $0 += $1.generationTokenCount }
-                let totalTime = segments.reduce(0.0) { $0 + $1.elapsed }
-                let peakMemory = segments.map(\.peakMemoryUsage).max() ?? 0
-
-                continuation.yield(.info(AudioGenerationInfo(
+                if case .terminated = continuation.yield(.info(AudioGenerationInfo(
                     promptTokenCount: totalPromptTokens,
                     generationTokenCount: totalGenerationTokens,
                     prefillTime: 0,
                     generateTime: totalTime,
-                    tokensPerSecond: totalTime > 0 ? Double(totalGenerationTokens) / totalTime : 0,
+                    tokensPerSecond: totalTime > 0
+                        ? Double(totalGenerationTokens) / totalTime
+                        : 0,
                     peakMemoryUsage: peakMemory
-                )))
-                continuation.yield(.audio(audio))
+                ))) {
+                    throw CancellationError()
+                }
                 continuation.finish()
             } catch {
                 continuation.finish(throwing: error)
@@ -914,7 +932,8 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
         topP: Float,
         topK: Int,
         speed: Float,
-        chunkLength: Int
+        chunkLength: Int,
+        onSegment: ((FishSpeechGeneratedSegment) throws -> Void)? = nil
     ) throws -> [FishSpeechGeneratedSegment] {
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AudioGenerationError.invalidInput("Text prompt cannot be empty")
@@ -937,10 +956,7 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
         }
 
         let baseConversation = buildConversation(promptTexts: promptTexts, promptTokens: promptTokens)
-        let turns = fishSpeechSplitTextBySpeaker(text)
-        let batches = turns.isEmpty
-            ? [text]
-            : fishSpeechGroupTurnsIntoBatches(turns, maxSpeakers: 5, maxBytes: chunkLength)
+        let batches = fishSpeechGenerationBatches(text, maxBytes: chunkLength)
 
         var conversation = baseConversation
         var segments: [FishSpeechGeneratedSegment] = []
@@ -981,13 +997,17 @@ public final class FishSpeechModel: Module, SpeechGenerationModel, @unchecked Se
             ))
 
             let elapsed = max(CFAbsoluteTimeGetCurrent() - startTime, 1e-6)
-            segments.append(FishSpeechGeneratedSegment(
+            let segment = FishSpeechGeneratedSegment(
                 audio: audio,
                 promptTokenCount: tokenizer.encode(batchText, addSpecialTokens: false).count,
                 generationTokenCount: codes.dim(1),
                 elapsed: elapsed,
                 peakMemoryUsage: Double(Memory.peakMemory) / 1e9
-            ))
+            )
+            if onSegment == nil {
+                segments.append(segment)
+            }
+            try onSegment?(segment)
         }
 
         return segments

--- a/Sources/MLXAudioTTS/Models/FishSpeech/FishSpeechPrompt.swift
+++ b/Sources/MLXAudioTTS/Models/FishSpeech/FishSpeechPrompt.swift
@@ -141,6 +141,105 @@ func fishSpeechSplitTextBySpeaker(_ text: String) -> [String] {
     return turns
 }
 
+func fishSpeechSplitTextIntoBatches(_ text: String, maxBytes: Int) -> [String] {
+    let limit = max(1, maxBytes)
+    guard text.lengthOfBytes(using: .utf8) > limit else {
+        return text.isEmpty ? [] : [text]
+    }
+
+    var batches: [String] = []
+    var batchStart = text.startIndex
+    var cursor = batchStart
+    var batchBytes = 0
+    var lastWhitespaceEnd: String.Index?
+
+    while cursor < text.endIndex {
+        let next = text.index(after: cursor)
+        let character = text[cursor]
+        let characterBytes = String(character).utf8.count
+        if characterBytes > limit {
+            if cursor > batchStart {
+                batches.append(String(text[batchStart..<cursor]))
+            }
+            var fragment = ""
+            var fragmentBytes = 0
+            for scalar in String(character).unicodeScalars {
+                let scalarText = String(scalar)
+                let scalarBytes = scalarText.utf8.count
+                if !fragment.isEmpty, fragmentBytes + scalarBytes > limit {
+                    batches.append(fragment)
+                    fragment = ""
+                    fragmentBytes = 0
+                }
+                fragment.append(contentsOf: scalarText)
+                fragmentBytes += scalarBytes
+            }
+            if !fragment.isEmpty {
+                batches.append(fragment)
+            }
+            batchStart = next
+            cursor = next
+            batchBytes = 0
+            lastWhitespaceEnd = nil
+            continue
+        }
+        if batchBytes + characterBytes > limit, cursor > batchStart {
+            let whitespaceSplit = lastWhitespaceEnd.flatMap { index -> String.Index? in
+                String(text[batchStart..<index]).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? nil
+                    : index
+            }
+            let split = whitespaceSplit ?? cursor
+            batches.append(String(text[batchStart..<split]))
+            batchStart = split
+            cursor = split
+            batchBytes = 0
+            lastWhitespaceEnd = nil
+            continue
+        }
+
+        batchBytes += characterBytes
+        if character.isWhitespace {
+            lastWhitespaceEnd = next
+        }
+        cursor = next
+    }
+
+    if batchStart < text.endIndex {
+        batches.append(String(text[batchStart...]))
+    }
+    return batches
+}
+
+func fishSpeechSplitSpeakerTurn(_ turn: String, maxBytes: Int) -> [String] {
+    guard turn.hasPrefix("<|speaker:"),
+          let markerEnd = turn.range(of: "|>")?.upperBound
+    else {
+        return fishSpeechSplitTextIntoBatches(turn, maxBytes: maxBytes)
+    }
+
+    let marker = String(turn[..<markerEnd])
+    let payload = String(turn[markerEnd...])
+    let payloadLimit = max(1, maxBytes - marker.lengthOfBytes(using: .utf8))
+    return fishSpeechSplitTextIntoBatches(payload, maxBytes: payloadLimit).map {
+        marker + $0
+    }
+}
+
+func fishSpeechGenerationBatches(_ text: String, maxBytes: Int) -> [String] {
+    let turns = fishSpeechSplitTextBySpeaker(text)
+    let batches = turns.isEmpty
+        ? fishSpeechSplitTextIntoBatches(text, maxBytes: maxBytes)
+        : fishSpeechGroupTurnsIntoBatches(
+            turns.flatMap { fishSpeechSplitSpeakerTurn($0, maxBytes: maxBytes) },
+            maxSpeakers: 5,
+            maxBytes: maxBytes
+        )
+    return batches.filter {
+        !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
 func fishSpeechGroupTurnsIntoBatches(
     _ turns: [String],
     maxSpeakers: Int = 5,
@@ -154,8 +253,10 @@ func fishSpeechGroupTurnsIntoBatches(
 
     for turn in turns {
         let turnBytes = turn.lengthOfBytes(using: .utf8)
+        let separatorBytes = currentBatch.isEmpty ? 0 : 1
         let exceedsSpeakers = currentBatch.count >= maxSpeakers
-        let exceedsBytes = !currentBatch.isEmpty && (currentBytes + turnBytes > maxBytes)
+        let exceedsBytes = !currentBatch.isEmpty
+            && (currentBytes + separatorBytes + turnBytes > maxBytes)
 
         if exceedsSpeakers || exceedsBytes {
             batches.append(currentBatch.joined(separator: "\n"))
@@ -163,7 +264,7 @@ func fishSpeechGroupTurnsIntoBatches(
             currentBytes = turnBytes
         } else {
             currentBatch.append(turn)
-            currentBytes += turnBytes
+            currentBytes += separatorBytes + turnBytes
         }
     }
 

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -1403,6 +1403,68 @@ struct FishSpeechTests {
         #expect(batches == ["<|speaker:0|>hello\n<|speaker:1|>world", "<|speaker:2|>again"])
     }
 
+    @Test func testPlainTextBatchingHonorsByteLimit() {
+        let text = "  one  two\nthree 四五六七 eight  "
+        let batches = fishSpeechSplitTextIntoBatches(text, maxBytes: 10)
+
+        #expect(batches.joined() == text)
+        #expect(batches.allSatisfy { $0.lengthOfBytes(using: .utf8) <= 10 })
+    }
+
+    @Test func testPlainTextBatchingPreservesGraphemesAndSkipsWhitespaceOnlyBatches() {
+        let decomposedE = "e\u{301}"
+        let text = " " + String(repeating: "a", count: 38) + decomposedE + " tail"
+        let batches = fishSpeechSplitTextIntoBatches(text, maxBytes: 40)
+
+        #expect(batches.joined() == text)
+        #expect(batches.allSatisfy { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        #expect(batches.contains(where: { $0.contains(decomposedE) }))
+        #expect(!batches.contains(where: { $0 == "e" || $0 == "\u{301}" }))
+    }
+
+    @Test func testPlainTextBatchingBoundsOversizedGrapheme() {
+        let text = "e" + String(repeating: "\u{301}", count: 50)
+        let batches = fishSpeechSplitTextIntoBatches(text, maxBytes: 40)
+
+        #expect(batches.joined() == text)
+        #expect(batches.allSatisfy { $0.lengthOfBytes(using: .utf8) <= 40 })
+    }
+
+    @Test func testGenerationBatchesSplitLongSpeakerTurnsWithMarker() {
+        let marker = "<|speaker:0|>"
+        let payload = Array(repeating: "word", count: 30).joined(separator: " ")
+        let batches = fishSpeechGenerationBatches(marker + payload, maxBytes: 40)
+
+        #expect(batches.count > 1)
+        #expect(batches.allSatisfy { $0.hasPrefix(marker) })
+        #expect(batches.allSatisfy { $0.lengthOfBytes(using: .utf8) <= 40 })
+        #expect(batches.map { String($0.dropFirst(marker.count)) }.joined() == payload)
+    }
+
+    @Test func testGenerationBatchesDropWhitespaceOnlySlices() {
+        let text = String(repeating: " ", count: 41) + "speak this"
+        let batches = fishSpeechGenerationBatches(text, maxBytes: 40)
+
+        #expect(batches.allSatisfy {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        })
+        #expect(batches.joined().trimmingCharacters(in: .whitespacesAndNewlines) == "speak this")
+    }
+
+    @Test func testStreamingChunkBytesRejectsInvalidIntervals() throws {
+        #expect(try fishSpeechStreamingChunkBytes(interval: 2) == 80)
+        #expect(try fishSpeechStreamingChunkBytes(interval: 1_000) == 2_400)
+        #expect(throws: AudioGenerationError.self) {
+            try fishSpeechStreamingChunkBytes(interval: .infinity)
+        }
+        #expect(throws: AudioGenerationError.self) {
+            try fishSpeechStreamingChunkBytes(interval: .nan)
+        }
+        #expect(throws: AudioGenerationError.self) {
+            try fishSpeechStreamingChunkBytes(interval: 0)
+        }
+    }
+
     @Test func testSanitizeRemapsFishWeightPrefixes() {
         let model = FishSpeechModel(config: makeTinyFishSpeechConfig())
         let sanitized = model.sanitize(weights: [


### PR DESCRIPTION
## Summary

- stream Fish Speech audio as each bounded text segment finishes
- preserve exact plain-text whitespace and speaker markers across batches
- propagate cancellation to the producer without retaining emitted MLX arrays
- keep request-level generation statistics and clarify the existing chunk event contract

## Why

Fish Speech currently ignores `streamingInterval`, generates every segment, concatenates the full waveform, and only then emits one audio event. Consumers therefore cannot begin playback early, and canceling the consumer does not provide a useful progressive boundary.

This keeps the buffered `generate` path unchanged. The streaming path uses byte-bounded, Unicode-aware text batches, yields each decoded segment immediately, and emits one aggregate info event when the request completes.

## Proof

```text
xcodebuild test -scheme MLXAudio-Package \
  -destination 'platform=macOS,arch=arm64' \
  -only-testing:MLXAudioTests/FishSpeechTests

14 tests passed
```

The focused suite covers whitespace preservation, CJK/unspaced input, grapheme boundaries, oversized graphemes, long speaker-tagged turns, invalid intervals, and existing Fish model behavior.
