### PR TITLE
Kokoro: expose the per-phoneme durations `generate` already computes

### DIFF
--- a/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
+++ b/Sources/MLXAudioTTS/Models/StyleTTS2/Kokoro/KokoroModel.swift
@@ -136,6 +136,42 @@ public final class KokoroModel: Module, SpeechGenerationModel, @unchecked Sendab
         language: String?,
         generationParameters: GenerateParameters
     ) async throws -> MLXArray {
+        try await generateWithDurations(
+            text: text, voice: voice, refAudio: refAudio, refText: refText,
+            language: language, generationParameters: generationParameters
+        ).audio
+    }
+
+    /// `generate`, plus the per-phoneme durations the model already predicts.
+    ///
+    /// `callAsFunction` computes `predDur` on every synthesis and returns it,
+    /// but `generate` discards it — so callers doing lip-sync, subtitle
+    /// alignment or viseme animation have to re-derive timing from the
+    /// waveform, which is strictly less accurate than the alignment the model
+    /// used to produce that waveform in the first place.
+    ///
+    /// - Returns:
+    ///   - `audio`: identical to what `generate` returns.
+    ///   - `phonemes`: the phonemized string that was tokenized, so callers can
+    ///     line each duration up with the phoneme it belongs to.
+    ///   - `durations`: one entry per input token, in acoustic frames.
+    ///
+    /// Frames are converted to seconds without needing a hop-length constant:
+    /// the whole utterance spans `durations.sum()` frames and
+    /// `audio.count / sampleRate` seconds, so
+    /// `secondsPerFrame = (audio.count / sampleRate) / durations.sum()`.
+    ///
+    /// Note the token sequence is padded with a leading and trailing `0`
+    /// (see below), so `durations` is two longer than the phoneme count and
+    /// the first and last entries are the padding.
+    public func generateWithDurations(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> (audio: MLXArray, phonemes: String, durations: MLXArray) {
         let voiceName = voice ?? "af_heart"
         let voiceEmb: MLXArray
         if let refAudio {
@@ -174,9 +210,9 @@ public final class KokoroModel: Module, SpeechGenerationModel, @unchecked Sendab
         let refS = voiceEmb[refIdx..<(refIdx + 1)]
 
         try Task.checkCancellation()
-        let (audio, _) = self.callAsFunction(inputIds: inputIds, refS: refS, speed: speed)
+        let (audio, predDur) = self.callAsFunction(inputIds: inputIds, refS: refS, speed: speed)
         try Task.checkCancellation()
-        return audio.reshaped([-1])
+        return (audio.reshaped([-1]), phonemized, predDur)
     }
 
     public func generateStream(


### PR DESCRIPTION
`KokoroModel.callAsFunction` predicts per-phoneme durations on every synthesis and returns them as `predDur`, but `generate` discards them:

```swift
let (audio, _) = self.callAsFunction(inputIds: inputIds, refS: refS, speed: speed)
return audio.reshaped([-1])
```

Callers doing lip-sync, viseme animation or subtitle alignment then have to re-derive timing from the waveform — strictly less accurate than the alignment the model just used to *produce* that waveform.

This adds `generateWithDurations(...)`, returning `(audio, phonemes, durations)`. `generate` now delegates to it and is unchanged for existing callers.

Notes:

- The phonemized string is returned alongside the durations because durations alone can't be mapped back to phonemes — `generate` already computes it internally and drops it too.
- Durations are in acoustic frames. The hop length isn't exposed, but callers can derive seconds exactly: the utterance spans `durations.sum()` frames and `audio.count / sampleRate` seconds. Documented on the method.
- The token array is padded with a leading and trailing `0`, so `durations` is two longer than the phoneme count. Also documented.

Purely additive; no behaviour change. Builds clean against `main` (`swift build --target MLXAudioTTS`).

Context: driving avatar visemes on iOS.

Happy to follow up with a test if you'd like one — I held off because covering this properly needs a model download, and I wasn't sure how you'd prefer that handled in CI.