### PR TITLE
fix(package): exclude SileroVAD README from the MLXAudioVAD target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -169,6 +169,7 @@ let package = Package(
             ],
             path: "Sources/MLXAudioVAD",
             exclude: [
+                "Models/SileroVAD/README.md",
                 "Models/SmartTurn/README.md",
                 "Models/Sortformer/README.md",
             ]


### PR DESCRIPTION
## What

Adds `Models/SileroVAD/README.md` to the `MLXAudioVAD` target's `exclude` list, next to the SmartTurn and Sortformer READMEs that are already there.

## Why

SwiftPM treats any non-source file inside a target directory as an unhandled resource unless it is declared or excluded. Because this README is missing from the list, every downstream package that depends on `mlx-audio-swift` (v0.1.3 and `main`) builds with:

```
warning: 'mlx-audio-swift': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    .../checkouts/mlx-audio-swift/Sources/MLXAudioVAD/Models/SileroVAD/README.md
```

## Verification

Consumer package building against this branch: the warning is gone; no other change (`swift build` diff is only this line).

Fixes #251.