### PR TITLE
Add DramaBox TTS (Gemma 3 encoder + LTX DiT, 48 kHz stereo)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -123,6 +123,7 @@ let package = Package(
                 "Models/Soprano/README.md",
                 "Models/StyleTTS2/KittenTTS/README.md",
                 "Models/StyleTTS2/Kokoro/README.md",
+                "Models/DramaBox/README.md",
             ]
         ),
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MLXAudio follows a modular design allowing you to import only what you need:
 
 - **MLXAudioCore**: Base types, protocols, and utilities
 - **MLXAudioCodecs**: Audio codec implementations (SNAC, Encodec, Vocos, Mimi, DACVAE, Descript DAC, Fish S1 DAC, S3TokenizerV2, MOSS Audio Tokenizer, Higgs Audio Tokenizer, Step-Audio-2 token-to-wav)
-- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, OmniVoice, Fish Audio S2 Pro, IndexTTS, Soprano, VyvoTTS, Orpheus, MOSS-TTS, Marvis TTS, Pocket TTS, Irodori TTS)
+- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, OmniVoice, Fish Audio S2 Pro, IndexTTS, Soprano, VyvoTTS, Orpheus, MOSS-TTS, Marvis TTS, Pocket TTS, Irodori TTS, DramaBox)
 - **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Qwen3-ForcedAligner, Voxtral Realtime, Cohere Transcribe, Parakeet, Nemotron ASR, GLMASR, FireRedASR2, SenseVoice, Granite Speech, Whisper, Canary, Moonshine, Wav2Vec2, MMS)
 - **MLXAudioVAD**: Voice Activity Detection & Speaker Diarization (Sortformer, SmartTurn, FSMN VAD, Silero VAD)
 - **MLXAudioSTS**: Speech-to-Speech models (LFM2.5-Audio, SAM-Audio, MossFormer2-SE, DeepFilterNet)
@@ -129,6 +129,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 | Marvis TTS | [Marvis TTS README](Sources/MLXAudioTTS/Models/Marvis/README.md) | [Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit](https://huggingface.co/Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit) |
 | Pocket TTS | [Pocket TTS README](Sources/MLXAudioTTS/Models/PocketTTS/README.md) | [mlx-community/pocket-tts](https://huggingface.co/mlx-community/pocket-tts) |
 | Irodori TTS | [Irodori TTS README](Sources/MLXAudioTTS/Models/IrodoriTTS/README.md) | [mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit) |
+| DramaBox | [DramaBox README](Sources/MLXAudioTTS/Models/DramaBox/README.md) | [appautomaton/dramabox-tts-3.3b-bf16-mlx](https://huggingface.co/appautomaton/dramabox-tts-3.3b-bf16-mlx) + [appautomaton/gemma-3-12b-it-backbone-4bit-mlx](https://huggingface.co/appautomaton/gemma-3-12b-it-backbone-4bit-mlx) |
 
 ### STT Models
 

--- a/Sources/MLXAudioCore/AudioUtils.swift
+++ b/Sources/MLXAudioCore/AudioUtils.swift
@@ -33,27 +33,55 @@ public class AudioUtils {
     }
 
     public static func writeWavFile(samples: [Float], sampleRate: Double, fileURL: URL) throws {
-        let frameCount = AVAudioFrameCount(samples.count)
+        try writeWavFile(channels: [samples], sampleRate: sampleRate, fileURL: fileURL)
+    }
 
-        guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: 1, interleaved: false),
-              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)
+    /// Write a WAV without downmixing. `channels` is planar `[channel][frame]`.
+    public static func writeWavFile(channels: [[Float]], sampleRate: Double, fileURL: URL) throws {
+        guard let first = channels.first else {
+            throw AudioUtilsErrors.cannotCreateAudioBuffer
+        }
+        let channelCount = channels.count
+        let frameCount = AVAudioFrameCount(first.count)
+        guard channelCount >= 1, channelCount <= 8,
+              channels.allSatisfy({ $0.count == first.count })
+        else {
+            throw AudioUtilsErrors.cannotCreateAudioBuffer
+        }
+
+        guard let bufferFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: AVAudioChannelCount(channelCount),
+            interleaved: false
+        ),
+            let fileFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: AVAudioChannelCount(channelCount),
+                interleaved: true
+            ),
+            let buffer = AVAudioPCMBuffer(pcmFormat: bufferFormat, frameCapacity: frameCount)
         else {
             throw AudioUtilsErrors.cannotCreateAVAudioFormat
         }
 
         buffer.frameLength = frameCount
-        let channelData = buffer.floatChannelData![0]
-        for i in 0 ..< Int(frameCount) {
-            channelData[i] = samples[i]
+        guard let channelData = buffer.floatChannelData else {
+            throw AudioUtilsErrors.cannotReadFloatChannelData
+        }
+        for channel in 0 ..< channelCount {
+            for frame in 0 ..< first.count {
+                channelData[channel][frame] = channels[channel][frame]
+            }
         }
 
         let audioFile = try AVAudioFile(
             forWriting: fileURL,
-            settings: format.settings,
-            commonFormat: format.commonFormat,
-            interleaved: format.isInterleaved
+            settings: fileFormat.settings,
+            commonFormat: bufferFormat.commonFormat,
+            interleaved: bufferFormat.isInterleaved
         )
-
         try audioFile.write(from: buffer)
     }
 }
@@ -95,26 +123,51 @@ public func loadAudioArray(from url: URL, sampleRate: Int? = nil) throws -> (Int
 }
 
 /// Save audio data to a WAV file.
-func saveAudioArray(_ audio: MLXArray, sampleRate: Double, to url: URL) throws {
-    let samples = audio.asArray(Float.self)
+///
+/// Accepts `[T]` mono or `[C, T]` / `[1, C, T]` planar audio. Stereo is
+/// written as stereo — never downmixed.
+public func saveAudioArray(_ audio: MLXArray, sampleRate: Double, to url: URL) throws {
+    let channels = try planarAudioChannels(audio)
+    try AudioUtils.writeWavFile(channels: channels, sampleRate: sampleRate, fileURL: url)
+}
 
-    let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
-    let audioFile = try AVAudioFile(forWriting: url, settings: format.settings)
-
-    let frameCount = AVAudioFrameCount(samples.count)
-    guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+/// Split an MLX waveform into planar channel arrays without downmixing.
+public func planarAudioChannels(_ audio: MLXArray) throws -> [[Float]] {
+    var array = audio.asType(.float32)
+    if array.ndim == 3 {
+        guard array.dim(0) == 1 else {
+            throw AudioUtils.AudioUtilsErrors.cannotCreateAudioBuffer
+        }
+        array = array[0]
+    }
+    switch array.ndim {
+    case 0:
+        return [[array.item(Float.self)]]
+    case 1:
+        return [array.asArray(Float.self)]
+    case 2:
+        let first = array.dim(0)
+        let second = array.dim(1)
+        let values = array.asArray(Float.self)
+        if first <= 8 && first < second {
+            return (0 ..< first).map { channel -> [Float] in
+                let start = channel * second
+                return Array(values[start ..< (start + second)])
+            }
+        }
+        if second <= 8 {
+            var channels = Array(repeating: Array(repeating: Float(0), count: first), count: second)
+            for frame in 0 ..< first {
+                for channel in 0 ..< second {
+                    channels[channel][frame] = values[frame * second + channel]
+                }
+            }
+            return channels
+        }
+        throw AudioUtils.AudioUtilsErrors.cannotCreateAudioBuffer
+    default:
         throw AudioUtils.AudioUtilsErrors.cannotCreateAudioBuffer
     }
-
-    buffer.frameLength = frameCount
-
-    if let channelData = buffer.floatChannelData {
-        for i in 0 ..< samples.count {
-            channelData[0][i] = samples[i]
-        }
-    }
-
-    try audioFile.write(from: buffer)
 }
 
 private final class AudioConverterInputProvider: @unchecked Sendable {

--- a/Sources/MLXAudioCore/ModelUtils.swift
+++ b/Sources/MLXAudioCore/ModelUtils.swift
@@ -73,42 +73,27 @@ public enum ModelUtils {
             ? String(requiredExtension.dropFirst())
             : requiredExtension
 
-        // Store downloaded model snapshots under the configured Hugging Face cache root.
-        let modelSubdir = repoID.description.replacingOccurrences(of: "/", with: "_")
-        let modelDir = cache.cacheDirectory
-            .appendingPathComponent("mlx-audio")
-            .appendingPathComponent(modelSubdir)
-
-        // Check if model already exists with required files
-        if FileManager.default.fileExists(atPath: modelDir.path) {
-            let files = try? FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: [.fileSizeKey])
-            let hasRequiredFile = files?.contains { file in
-                guard file.pathExtension == normalizedRequiredExtension else { return false }
-                let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-                return size > 0
-            } ?? false
-
-            if hasRequiredFile {
-                // Validate that config.json is valid JSON
-                let configPath = modelDir.appendingPathComponent("config.json")
-                if FileManager.default.fileExists(atPath: configPath.path) {
-                    if let configData = try? Data(contentsOf: configPath),
-                       let _ = try? JSONSerialization.jsonObject(with: configData) {
-                        print("Using cached model at: \(modelDir.path)")
-                        return modelDir
-                    } else {
-                        print("Cached config.json is invalid, clearing cache...")
-                        Self.clearCaches(modelDir: modelDir, repoID: repoID, hubCache: cache)
-                    }
-                }
-            } else {
-                print("Cached model appears incomplete, clearing cache...")
-                Self.clearCaches(modelDir: modelDir, repoID: repoID, hubCache: cache)
-            }
+        if let snapshot = existingHubSnapshot(
+            repoID: repoID,
+            cache: cache,
+            requiredExtension: normalizedRequiredExtension
+        ) {
+            print("Using Hub cache at: \(snapshot.path)")
+            return snapshot
         }
 
-        // Create directory if needed
-        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        let modelSubdir = repoID.description.replacingOccurrences(of: "/", with: "_")
+        let mlxAudioDir = cache.cacheDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(modelSubdir)
+        if directoryLooksComplete(mlxAudioDir, requiredExtension: normalizedRequiredExtension) {
+            print("Using cached model at: \(mlxAudioDir.path)")
+            return mlxAudioDir
+        }
+        if FileManager.default.fileExists(atPath: mlxAudioDir.path) {
+            print("Incomplete mlx-audio copy at \(mlxAudioDir.path), ignoring it.")
+            try? FileManager.default.removeItem(at: mlxAudioDir)
+        }
 
         var allowedExtensions: Set<String> = [
             "*.\(normalizedRequiredExtension)",
@@ -119,11 +104,10 @@ public enum ModelUtils {
         ]
         allowedExtensions.formUnion(additionalMatchingPatterns)
 
-        print("Downloading model \(repoID)...")
-        _ = try await client.downloadSnapshot(
+        print("Downloading model \(repoID) into Hugging Face Hub cache...")
+        let snapshot = try await client.downloadSnapshot(
             of: repoID,
             kind: .model,
-            to: modelDir,
             revision: "main",
             matching: Array(allowedExtensions),
             progressHandler: progressHandler ?? { progress in
@@ -131,31 +115,93 @@ public enum ModelUtils {
             }
         )
 
-        // Post-download validation: ensure required files are non-zero
-        let downloadedFiles = try? FileManager.default.contentsOfDirectory(
-            at: modelDir, includingPropertiesForKeys: [.fileSizeKey]
-        )
-        let hasValidFile = downloadedFiles?.contains { file in
-            guard file.pathExtension == normalizedRequiredExtension else { return false }
-            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-            return size > 0
-        } ?? false
-
-        if !hasValidFile {
-            Self.clearCaches(modelDir: modelDir, repoID: repoID, hubCache: cache)
+        guard directoryLooksComplete(snapshot, requiredExtension: normalizedRequiredExtension) else {
             throw ModelUtilsError.incompleteDownload(repoID.description)
         }
 
-        print("Model downloaded to: \(modelDir.path)")
-        return modelDir
+        print("Model downloaded to: \(snapshot.path)")
+        return snapshot
     }
 
-    private static func clearCaches(modelDir: URL, repoID: Repo.ID, hubCache: HubCache) {
-        try? FileManager.default.removeItem(at: modelDir)
-        let hubRepoDir = hubCache.repoDirectory(repo: repoID, kind: .model)
-        if FileManager.default.fileExists(atPath: hubRepoDir.path) {
-            print("Clearing Hub cache at: \(hubRepoDir.path)")
-            try? FileManager.default.removeItem(at: hubRepoDir)
+    /// Hugging Face Hub snapshot (`models--org--name/snapshots/<rev>`), if complete.
+    public static func existingHubSnapshot(
+        repoID: Repo.ID,
+        cache: HubCache = .default,
+        requiredExtension: String = "safetensors"
+    ) -> URL? {
+        let normalized = requiredExtension.hasPrefix(".")
+            ? String(requiredExtension.dropFirst())
+            : requiredExtension
+        let slug = repoID.description.replacingOccurrences(of: "/", with: "--")
+        var roots = [cache.repoDirectory(repo: repoID, kind: .model)]
+        let defaultHub = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub/models--\(slug)")
+        if defaultHub.standardizedFileURL.path != roots[0].standardizedFileURL.path {
+            roots.append(defaultHub)
+        }
+        for repoDir in roots {
+            if let snapshot = latestHubSnapshot(in: repoDir),
+               directoryLooksComplete(snapshot, requiredExtension: normalized)
+            {
+                return snapshot
+            }
+        }
+        return nil
+    }
+
+    public static func latestHubSnapshot(in repoDir: URL) -> URL? {
+        let fm = FileManager.default
+        let snapshotsDir = repoDir.appendingPathComponent("snapshots")
+        let mainRef = repoDir.appendingPathComponent("refs").appendingPathComponent("main")
+        if let revision = try? String(contentsOf: mainRef, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !revision.isEmpty
+        {
+            let snapshot = snapshotsDir.appendingPathComponent(revision)
+            var isDirectory: ObjCBool = false
+            if fm.fileExists(atPath: snapshot.path, isDirectory: &isDirectory), isDirectory.boolValue {
+                return snapshot
+            }
+        }
+        let snapshots = (try? fm.contentsOfDirectory(
+            at: snapshotsDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return snapshots
+            .filter { url in
+                ((try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false)
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .last
+    }
+
+    public static func directoryLooksComplete(_ directory: URL, requiredExtension: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            return false
+        }
+        let configPath = directory.appendingPathComponent("config.json")
+        guard fm.fileExists(atPath: configPath.path),
+              let configData = try? Data(contentsOf: configPath),
+              (try? JSONSerialization.jsonObject(with: configData)) != nil
+        else {
+            return false
+        }
+        let files = (try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey, .isSymbolicLinkKey]
+        )) ?? []
+        return files.contains { file in
+            guard file.pathExtension == requiredExtension else { return false }
+            if (try? file.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true {
+                return fm.fileExists(atPath: file.path)
+            }
+            let size = (try? file.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            return size > 0
         }
     }
 }

--- a/Sources/MLXAudioTTS/Models/DramaBox/AudioVAE/DramaBoxAudioProcessor.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/AudioVAE/DramaBoxAudioProcessor.swift
@@ -1,0 +1,234 @@
+import AVFoundation
+import Foundation
+@preconcurrency import MLX
+import MLXAudioCore
+
+struct DramaBoxReferenceAudio {
+    var waveform: MLXArray
+    var sampleRate: Int
+}
+
+struct DramaBoxAudioProcessor {
+    var targetSampleRate: Int
+    var nFft: Int
+    var winLength: Int
+    var hopLength: Int
+    var nMels: Int
+    var fMin: Float
+    var fMax: Float
+    let window: MLXArray
+    let melFilterbank: MLXArray
+
+    init(
+        targetSampleRate: Int = 16_000,
+        nFft: Int = 1024,
+        winLength: Int = 1024,
+        hopLength: Int = 160,
+        nMels: Int = 64,
+        fMin: Float = 0,
+        fMax: Float? = nil
+    ) {
+        self.targetSampleRate = targetSampleRate
+        self.nFft = nFft
+        self.winLength = winLength
+        self.hopLength = hopLength
+        self.nMels = nMels
+        self.fMin = fMin
+        self.fMax = fMax ?? Float(targetSampleRate) / 2
+        self.window = dramaBoxPeriodicHann(winLength)
+        self.melFilterbank = melFilters(
+            sampleRate: targetSampleRate,
+            nFft: nFft,
+            nMels: nMels,
+            fMin: fMin,
+            fMax: self.fMax,
+            norm: "slaney",
+            melScale: .slaney
+        )
+    }
+
+    func waveformToMel(_ waveform: MLXArray, sampleRate: Int) throws -> MLXArray {
+        guard waveform.ndim == 3 else {
+            throw DramaBoxError.invalidAudioShape(waveform.shape)
+        }
+        var wav = waveform.asType(.float32)
+        if sampleRate != targetSampleRate {
+            wav = try dramaBoxResampleLastAxis(wav, from: sampleRate, to: targetSampleRate)
+        }
+        let B = wav.dim(0)
+        let C = wav.dim(1)
+        var mels: [MLXArray] = []
+        mels.reserveCapacity(B * C)
+        for b in 0..<B {
+            for c in 0..<C {
+                let samples = wav[b, c]
+                let freqs = stft(
+                    audio: samples,
+                    window: window,
+                    nFft: nFft,
+                    hopLength: hopLength,
+                    padMode: .reflect
+                )
+                let magnitude = MLX.abs(freqs)
+                let mel = MLX.matmul(magnitude, melFilterbank)
+                let logMel = MLX.log(MLX.maximum(mel, MLXArray(Float(1e-5))))
+                mels.append(logMel)
+            }
+        }
+        let stackedMel = stacked(mels, axis: 0)
+        return stackedMel.reshaped(B, C, stackedMel.dim(1), stackedMel.dim(-1))
+    }
+}
+
+func dramaBoxPeriodicHann(_ size: Int) -> MLXArray {
+    var window = [Float](repeating: 0, count: size)
+    for n in 0..<size {
+        window[n] = 0.5 - 0.5 * cos(2 * Float.pi * Float(n) / Float(size))
+    }
+    return MLXArray(window)
+}
+
+func dramaBoxResampleLastAxis(_ waveform: MLXArray, from source: Int, to target: Int) throws -> MLXArray {
+    if source == target { return waveform.asType(.float32) }
+    let samples = waveform.asArray(Float.self)
+    let leading = waveform.shape.dropLast().reduce(1, *)
+    let length = waveform.dim(-1)
+    var outRows: [[Float]] = []
+    outRows.reserveCapacity(leading)
+    let duration = Double(length) / Double(source)
+    let targetSamples = max(1, Int((duration * Double(target)).rounded()))
+    let srcPos = (0..<length).map { Double($0) * duration / Double(length) }
+    let dstPos = (0..<targetSamples).map { Double($0) * duration / Double(targetSamples) }
+    for row in 0..<leading {
+        let start = row * length
+        let rowSamples = Array(samples[start ..< (start + length)])
+        var dest = [Float](repeating: 0, count: targetSamples)
+        var j = 0
+        for i in 0..<targetSamples {
+            let t = dstPos[i]
+            while j + 1 < srcPos.count && srcPos[j + 1] <= t { j += 1 }
+            if j + 1 >= srcPos.count {
+                dest[i] = rowSamples[length - 1]
+            } else {
+                let x0 = srcPos[j]
+                let x1 = srcPos[j + 1]
+                let w = x1 > x0 ? (t - x0) / (x1 - x0) : 0
+                dest[i] = Float((1 - w) * Double(rowSamples[j]) + w * Double(rowSamples[j + 1]))
+            }
+        }
+        outRows.append(dest)
+    }
+    let flat = outRows.flatMap { $0 }
+    var shape = waveform.shape
+    shape[shape.count - 1] = targetSamples
+    return MLXArray(flat).reshaped(shape)
+}
+
+func dramaBoxForceStereo(_ waveform: MLXArray) -> MLXArray {
+    var x = waveform.asType(.float32)
+    if x.ndim == 1 {
+        x = stacked([x, x], axis: 0).expandedDimensions(axis: 0)
+        return x
+    }
+    if x.ndim == 2 {
+        if x.dim(0) <= 8 && x.dim(0) < x.dim(1) {
+            if x.dim(0) == 1 {
+                let mono = x[0]
+                return stacked([mono, mono], axis: 0).expandedDimensions(axis: 0)
+            }
+            if x.dim(0) == 2 {
+                return x.expandedDimensions(axis: 0)
+            }
+            let mono = MLX.mean(x, axis: 0)
+            return stacked([mono, mono], axis: 0).expandedDimensions(axis: 0)
+        }
+        let frames = x.dim(0)
+        let ch = x.dim(1)
+        if ch == 1 {
+            let mono = x[0..., 0]
+            return stacked([mono, mono], axis: 0).expandedDimensions(axis: 0)
+        }
+        if ch >= 2 {
+            return x[0..., 0..<2].transposed(1, 0).expandedDimensions(axis: 0)
+        }
+        _ = frames
+    }
+    if x.ndim == 3 {
+        if x.dim(1) == 2 { return x }
+        if x.dim(1) == 1 {
+            let mono = x[0..., 0, 0...]
+            return stacked([mono, mono], axis: 1)
+        }
+        let mono = MLX.mean(x, axis: 1)
+        return stacked([mono, mono], axis: 1)
+    }
+    return x
+}
+
+func dramaBoxCropOrLoop(_ waveform: MLXArray, targetSamples: Int) -> MLXArray {
+    let T = waveform.dim(-1)
+    if T == targetSamples { return waveform }
+    if T > targetSamples {
+        return waveform[.ellipsis, 0..<targetSamples]
+    }
+    let repeats = Int(ceil(Double(targetSamples) / Double(max(T, 1))))
+    let tiled = concatenated(Array(repeating: waveform, count: repeats), axis: -1)
+    return tiled[.ellipsis, 0..<targetSamples]
+}
+
+func dramaBoxPeakNormalize(_ waveform: MLXArray, targetDBFS: Float = -4) throws -> MLXArray {
+    let peak = MLX.abs(waveform).max().item(Float.self)
+    guard peak > 0 else { throw DramaBoxError.silentReferenceAudio }
+    let targetPeak = pow(10.0 as Float, targetDBFS / 20.0)
+    return waveform * (targetPeak / peak)
+}
+
+func prepareDramaBoxReferenceAudio(
+    _ audio: MLXArray,
+    sampleRate: Int,
+    refDurationS: Float = 10,
+    targetSampleRate: Int = 16_000,
+    targetPeakDBFS: Float = -4
+) throws -> DramaBoxReferenceAudio {
+    var waveform = dramaBoxForceStereo(audio)
+    waveform = try dramaBoxResampleLastAxis(waveform, from: sampleRate, to: targetSampleRate)
+    let targetSamples = Int((refDurationS * Float(targetSampleRate)).rounded())
+    waveform = dramaBoxCropOrLoop(waveform, targetSamples: targetSamples)
+    waveform = try dramaBoxPeakNormalize(waveform, targetDBFS: targetPeakDBFS)
+    return DramaBoxReferenceAudio(waveform: waveform.asType(.float32), sampleRate: targetSampleRate)
+}
+
+func prepareDramaBoxReferenceAudio(
+    url: URL,
+    refDurationS: Float = 10,
+    targetSampleRate: Int = 16_000
+) throws -> DramaBoxReferenceAudio {
+    let file = try AVAudioFile(forReading: url)
+    let format = file.processingFormat
+    let frameCount = AVAudioFrameCount(file.length)
+    guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+        throw DramaBoxError.invalidAudioShape([])
+    }
+    try file.read(into: buffer)
+    guard let data = buffer.floatChannelData else {
+        throw DramaBoxError.invalidAudioShape([])
+    }
+    let n = Int(buffer.frameLength)
+    let ch = Int(format.channelCount)
+    var channels: [MLXArray] = []
+    for c in 0..<ch {
+        channels.append(MLXArray(Array(UnsafeBufferPointer(start: data[c], count: n))))
+    }
+    let stacked: MLXArray
+    if channels.count == 1 {
+        stacked = channels[0]
+    } else {
+        stacked = MLX.stacked(channels, axis: 0)
+    }
+    return try prepareDramaBoxReferenceAudio(
+        stacked,
+        sampleRate: Int(format.sampleRate),
+        refDurationS: refDurationS,
+        targetSampleRate: targetSampleRate
+    )
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/AudioVAE/DramaBoxAudioVAE.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/AudioVAE/DramaBoxAudioVAE.swift
@@ -1,0 +1,377 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+struct DramaBoxAudioVAEConfig: Sendable {
+    var inChannels: Int = 2
+    var outCh: Int = 2
+    var zChannels: Int = 8
+    var ch: Int = 128
+    var chMult: [Int] = [1, 2, 4]
+    var numResBlocks: Int = 2
+    var doubleZ: Bool = true
+    var samplingRate: Int = 16_000
+    var melBins: Int = 64
+    var melHopLength: Int = 160
+    var nFft: Int = 1024
+    var audioLatentDownsampleFactor: Int = 4
+
+    var numResolutions: Int { chMult.count }
+}
+
+func dramaBoxPixelNorm(_ x: MLXArray, eps: Float = 1e-6) -> MLXArray {
+    let orig = x.dtype
+    let x32 = x.asType(.float32)
+    let meanSq = MLX.mean(x32 * x32, axis: -1, keepDims: true)
+    return (x32 / MLX.sqrt(meanSq + eps)).asType(orig)
+}
+
+final class DramaBoxCausalConv2d: Module {
+    let padTop: Int
+    let padBottom: Int
+    let padLeft: Int
+    let padRight: Int
+    @ModuleInfo var conv: Conv2d
+
+    init(
+        inChannels: Int,
+        outChannels: Int,
+        kernelSize: Int = 3,
+        stride: Int = 1,
+        dilation: Int = 1,
+        bias: Bool = true
+    ) {
+        let padH = (kernelSize - 1) * dilation
+        let padW = (kernelSize - 1) * dilation
+        self.padTop = padH
+        self.padBottom = 0
+        self.padLeft = padW / 2
+        self.padRight = padW - padW / 2
+        self._conv.wrappedValue = Conv2d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: IntOrPair(kernelSize),
+            stride: IntOrPair(stride),
+            padding: IntOrPair(0),
+            dilation: IntOrPair(dilation),
+            bias: bias
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let padded = MLX.padded(
+            x,
+            widths: [.init(0), .init((padTop, padBottom)), .init((padLeft, padRight)), .init(0)]
+        )
+        return conv(padded)
+    }
+}
+
+final class DramaBoxVAEResnetBlock: Module {
+    @ModuleInfo var conv1: DramaBoxCausalConv2d
+    @ModuleInfo var conv2: DramaBoxCausalConv2d
+    @ModuleInfo(key: "nin_shortcut") var ninShortcut: DramaBoxCausalConv2d?
+
+    init(inChannels: Int, outChannels: Int) {
+        self._conv1.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: inChannels, outChannels: outChannels, kernelSize: 3
+        )
+        self._conv2.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: outChannels, outChannels: outChannels, kernelSize: 3
+        )
+        if inChannels != outChannels {
+            self._ninShortcut.wrappedValue = DramaBoxCausalConv2d(
+                inChannels: inChannels, outChannels: outChannels, kernelSize: 1
+            )
+        } else {
+            self._ninShortcut.wrappedValue = nil
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = dramaBoxPixelNorm(x)
+        h = MLXNN.silu(h)
+        h = conv1(h)
+        h = dramaBoxPixelNorm(h)
+        h = MLXNN.silu(h)
+        h = conv2(h)
+        let skip = ninShortcut?(x) ?? x
+        return skip + h
+    }
+}
+
+final class DramaBoxVAEDownsample: Module {
+    @ModuleInfo var conv: Conv2d
+
+    init(_ channels: Int) {
+        self._conv.wrappedValue = Conv2d(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: IntOrPair(3),
+            stride: IntOrPair(2),
+            padding: IntOrPair(0),
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let padded = MLX.padded(x, widths: [.init(0), .init((2, 0)), .init((0, 1)), .init(0)])
+        return conv(padded)
+    }
+}
+
+final class DramaBoxVAEUpsample: Module {
+    @ModuleInfo var conv: DramaBoxCausalConv2d
+
+    init(_ channels: Int) {
+        self._conv.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: channels, outChannels: channels, kernelSize: 3
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = MLX.repeated(x, count: 2, axis: 1)
+        y = MLX.repeated(y, count: 2, axis: 2)
+        y = conv(y)
+        return y[0..., 1..., 0..., 0...]
+    }
+}
+
+final class DramaBoxVAEMidBlock: Module {
+    @ModuleInfo(key: "block_1") var block1: DramaBoxVAEResnetBlock
+    @ModuleInfo(key: "block_2") var block2: DramaBoxVAEResnetBlock
+
+    init(channels: Int) {
+        self._block1.wrappedValue = DramaBoxVAEResnetBlock(inChannels: channels, outChannels: channels)
+        self._block2.wrappedValue = DramaBoxVAEResnetBlock(inChannels: channels, outChannels: channels)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        block2(block1(x))
+    }
+}
+
+final class DramaBoxVAEDownStage: Module {
+    @ModuleInfo var block: [DramaBoxVAEResnetBlock]
+    @ModuleInfo var downsample: DramaBoxVAEDownsample?
+
+    init(inChannels: Int, outChannels: Int, numBlocks: Int, withDownsample: Bool) {
+        var blocks: [DramaBoxVAEResnetBlock] = []
+        var chIn = inChannels
+        for _ in 0..<numBlocks {
+            blocks.append(DramaBoxVAEResnetBlock(inChannels: chIn, outChannels: outChannels))
+            chIn = outChannels
+        }
+        self._block.wrappedValue = blocks
+        self._downsample.wrappedValue = withDownsample ? DramaBoxVAEDownsample(outChannels) : nil
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for b in block { h = b(h) }
+        if let downsample { h = downsample(h) }
+        return h
+    }
+}
+
+final class DramaBoxVAEUpStage: Module {
+    @ModuleInfo var block: [DramaBoxVAEResnetBlock]
+    @ModuleInfo var upsample: DramaBoxVAEUpsample?
+
+    init(inChannels: Int, outChannels: Int, numBlocks: Int, withUpsample: Bool) {
+        var blocks: [DramaBoxVAEResnetBlock] = []
+        var chIn = inChannels
+        for _ in 0..<numBlocks {
+            blocks.append(DramaBoxVAEResnetBlock(inChannels: chIn, outChannels: outChannels))
+            chIn = outChannels
+        }
+        self._block.wrappedValue = blocks
+        self._upsample.wrappedValue = withUpsample ? DramaBoxVAEUpsample(outChannels) : nil
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for b in block { h = b(h) }
+        if let upsample { h = upsample(h) }
+        return h
+    }
+}
+
+final class DramaBoxAudioEncoder: Module {
+    let config: DramaBoxAudioVAEConfig
+    @ModuleInfo(key: "conv_in") var convIn: DramaBoxCausalConv2d
+    @ModuleInfo var down: [DramaBoxVAEDownStage]
+    @ModuleInfo var mid: DramaBoxVAEMidBlock
+    @ModuleInfo(key: "conv_out") var convOut: DramaBoxCausalConv2d
+
+    init(_ config: DramaBoxAudioVAEConfig) {
+        self.config = config
+        let ch = config.ch
+        self._convIn.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: config.inChannels, outChannels: ch, kernelSize: 3
+        )
+        var stages: [DramaBoxVAEDownStage] = []
+        var blockIn = ch
+        for level in 0..<config.numResolutions {
+            let blockOut = ch * config.chMult[level]
+            stages.append(
+                DramaBoxVAEDownStage(
+                    inChannels: blockIn,
+                    outChannels: blockOut,
+                    numBlocks: config.numResBlocks,
+                    withDownsample: level != config.numResolutions - 1
+                )
+            )
+            blockIn = blockOut
+        }
+        self._down.wrappedValue = stages
+        self._mid.wrappedValue = DramaBoxVAEMidBlock(channels: blockIn)
+        let outChannels = config.doubleZ ? 2 * config.zChannels : config.zChannels
+        self._convOut.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: blockIn, outChannels: outChannels, kernelSize: 3
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ mel: MLXArray) -> MLXArray {
+        var h = convIn(mel)
+        for stage in down { h = stage(h) }
+        h = mid(h)
+        h = dramaBoxPixelNorm(h)
+        h = MLXNN.silu(h)
+        return convOut(h)
+    }
+}
+
+final class DramaBoxAudioDecoder: Module {
+    let config: DramaBoxAudioVAEConfig
+    @ModuleInfo(key: "conv_in") var convIn: DramaBoxCausalConv2d
+    @ModuleInfo var mid: DramaBoxVAEMidBlock
+    @ModuleInfo var up: [DramaBoxVAEUpStage]
+    @ModuleInfo(key: "conv_out") var convOut: DramaBoxCausalConv2d
+
+    init(_ config: DramaBoxAudioVAEConfig) {
+        self.config = config
+        let ch = config.ch
+        var blockIn = ch * config.chMult[config.numResolutions - 1]
+        self._convIn.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: config.zChannels, outChannels: blockIn, kernelSize: 3
+        )
+        self._mid.wrappedValue = DramaBoxVAEMidBlock(channels: blockIn)
+        var stages = [DramaBoxVAEUpStage?](repeating: nil, count: config.numResolutions)
+        for level in (0..<config.numResolutions).reversed() {
+            let blockOut = ch * config.chMult[level]
+            stages[level] = DramaBoxVAEUpStage(
+                inChannels: blockIn,
+                outChannels: blockOut,
+                numBlocks: config.numResBlocks + 1,
+                withUpsample: level != 0
+            )
+            blockIn = blockOut
+        }
+        self._up.wrappedValue = stages.map { $0! }
+        self._convOut.wrappedValue = DramaBoxCausalConv2d(
+            inChannels: blockIn, outChannels: config.outCh, kernelSize: 3
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ latent: MLXArray) -> MLXArray {
+        var h = convIn(latent)
+        h = mid(h)
+        for level in (0..<config.numResolutions).reversed() {
+            h = up[level](h)
+        }
+        h = dramaBoxPixelNorm(h)
+        h = MLXNN.silu(h)
+        return convOut(h)
+    }
+}
+
+final class DramaBoxPerChannelStatistics: Module {
+    @ModuleInfo(key: "mean_of_means") var meanOfMeans: MLXArray
+    @ModuleInfo(key: "std_of_means") var stdOfMeans: MLXArray
+
+    init(dim: Int = 128) {
+        self._meanOfMeans.wrappedValue = MLXArray.zeros([dim])
+        self._stdOfMeans.wrappedValue = MLXArray.ones([dim])
+        super.init()
+    }
+
+    func normalize(_ x: MLXArray) -> MLXArray {
+        (x - meanOfMeans.asType(x.dtype)) / stdOfMeans.asType(x.dtype)
+    }
+
+    func unNormalize(_ x: MLXArray) -> MLXArray {
+        x * stdOfMeans.asType(x.dtype) + meanOfMeans.asType(x.dtype)
+    }
+}
+
+final class DramaBoxAudioVAE: Module {
+    let config: DramaBoxAudioVAEConfig
+    @ModuleInfo var encoder: DramaBoxAudioEncoder
+    @ModuleInfo var decoder: DramaBoxAudioDecoder
+    @ModuleInfo(key: "per_channel_statistics") var perChannelStatistics: DramaBoxPerChannelStatistics
+
+    init(_ config: DramaBoxAudioVAEConfig = DramaBoxAudioVAEConfig()) {
+        self.config = config
+        self._encoder.wrappedValue = DramaBoxAudioEncoder(config)
+        self._decoder.wrappedValue = DramaBoxAudioDecoder(config)
+        let latentMelBins = config.melBins / (1 << (config.numResolutions - 1))
+        self._perChannelStatistics.wrappedValue = DramaBoxPerChannelStatistics(
+            dim: config.zChannels * latentMelBins
+        )
+        super.init()
+    }
+
+    func encode(_ mel: MLXArray) -> MLXArray {
+        let melCL = mel.transposed(0, 2, 3, 1)
+        let raw = encoder(melCL)
+        let meansCL = raw[.ellipsis, 0..<config.zChannels]
+        let means = meansCL.transposed(0, 3, 1, 2)
+        let patched = DramaBoxAudioPatchifier.patchify(means)
+        let normed = perChannelStatistics.normalize(patched)
+        return DramaBoxAudioPatchifier.unpatchify(
+            normed, channels: config.zChannels, melBins: means.dim(3)
+        )
+    }
+
+    func decode(_ latent: MLXArray) -> MLXArray {
+        let patched = DramaBoxAudioPatchifier.patchify(latent)
+        let denormed = perChannelStatistics.unNormalize(patched)
+        let unp = DramaBoxAudioPatchifier.unpatchify(
+            denormed, channels: latent.dim(1), melBins: latent.dim(3)
+        )
+        let outCL = decoder(unp.transposed(0, 2, 3, 1))
+        return outCL.transposed(0, 3, 1, 2)
+    }
+}
+
+func loadDramaBoxAudioVAEWeights(_ model: DramaBoxAudioVAE, state: [String: MLXArray]) throws {
+    let prefix = "audio_vae."
+    var sub: [String: MLXArray] = [:]
+    for (key, value) in state where key.hasPrefix(prefix) {
+        var tail = String(key.dropFirst(prefix.count))
+        if tail.hasPrefix("per_channel_statistics.") {
+            tail = tail
+                .replacingOccurrences(of: "mean-of-means", with: "mean_of_means")
+                .replacingOccurrences(of: "std-of-means", with: "std_of_means")
+        }
+        var tensor = value
+        if tensor.ndim == 4 && tail.hasSuffix(".weight") {
+            tensor = tensor.transposed(0, 2, 3, 1)
+        }
+        sub[tail] = tensor
+    }
+    guard !sub.isEmpty else {
+        throw DramaBoxError.generationFailed("No audio_vae weights")
+    }
+    try model.update(parameters: ModuleParameters.unflattened(sub), verify: .all)
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxDiTConfig.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxDiTConfig.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+public struct DramaBoxDiTConfig: Sendable {
+    public var audioInChannels: Int
+    public var audioOutChannels: Int
+    public var audioNumAttentionHeads: Int
+    public var audioAttentionHeadDim: Int
+    public var audioCrossAttentionDim: Int
+    public var audioPositionalEmbeddingMaxPos: Int
+    public var numLayers: Int
+    public var normEps: Float
+    public var crossAttentionAdaln: Bool
+    public var applyGatedAttention: Bool
+    public var ropeType: String
+    public var positionalEmbeddingTheta: Float
+    public var timestepScaleMultiplier: Float
+    public var useMiddleIndicesGrid: Bool
+
+    public var audioInnerDim: Int {
+        audioNumAttentionHeads * audioAttentionHeadDim
+    }
+
+    public init(
+        audioInChannels: Int = 128,
+        audioOutChannels: Int = 128,
+        audioNumAttentionHeads: Int = 32,
+        audioAttentionHeadDim: Int = 64,
+        audioCrossAttentionDim: Int = 2048,
+        audioPositionalEmbeddingMaxPos: Int = 20,
+        numLayers: Int = 48,
+        normEps: Float = 1e-6,
+        crossAttentionAdaln: Bool = true,
+        applyGatedAttention: Bool = true,
+        ropeType: String = "split",
+        positionalEmbeddingTheta: Float = 10_000,
+        timestepScaleMultiplier: Float = 1000,
+        useMiddleIndicesGrid: Bool = true
+    ) {
+        self.audioInChannels = audioInChannels
+        self.audioOutChannels = audioOutChannels
+        self.audioNumAttentionHeads = audioNumAttentionHeads
+        self.audioAttentionHeadDim = audioAttentionHeadDim
+        self.audioCrossAttentionDim = audioCrossAttentionDim
+        self.audioPositionalEmbeddingMaxPos = audioPositionalEmbeddingMaxPos
+        self.numLayers = numLayers
+        self.normEps = normEps
+        self.crossAttentionAdaln = crossAttentionAdaln
+        self.applyGatedAttention = applyGatedAttention
+        self.ropeType = ropeType
+        self.positionalEmbeddingTheta = positionalEmbeddingTheta
+        self.timestepScaleMultiplier = timestepScaleMultiplier
+        self.useMiddleIndicesGrid = useMiddleIndicesGrid
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxLTXBlock.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxLTXBlock.swift
@@ -1,0 +1,93 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+final class DramaBoxLTXBlock: Module {
+    let dim: Int
+    let normEps: Float
+
+    @ModuleInfo(key: "audio_attn1") var audioAttn1: DramaBoxLTXAttention
+    @ModuleInfo(key: "audio_attn2") var audioAttn2: DramaBoxLTXAttention
+    @ModuleInfo(key: "audio_ff") var audioFF: DramaBoxLTXFeedForward
+    @ModuleInfo(key: "audio_scale_shift_table") var audioScaleShiftTable: MLXArray
+    @ModuleInfo(key: "audio_prompt_scale_shift_table") var audioPromptScaleShiftTable: MLXArray
+
+    init(
+        dim: Int,
+        heads: Int,
+        dimHead: Int,
+        contextDim: Int,
+        applyGatedAttention: Bool = true,
+        normEps: Float = 1e-6,
+        ropeType: String = "split"
+    ) {
+        self.dim = dim
+        self.normEps = normEps
+        self._audioAttn1.wrappedValue = DramaBoxLTXAttention(
+            queryDim: dim,
+            heads: heads,
+            dimHead: dimHead,
+            applyGatedAttention: applyGatedAttention,
+            ropeType: ropeType
+        )
+        self._audioAttn2.wrappedValue = DramaBoxLTXAttention(
+            queryDim: dim,
+            heads: heads,
+            dimHead: dimHead,
+            contextDim: contextDim,
+            applyGatedAttention: applyGatedAttention,
+            ropeType: ropeType
+        )
+        self._audioFF.wrappedValue = DramaBoxLTXFeedForward(dim, dimOut: dim, mult: 4)
+        self._audioScaleShiftTable.wrappedValue = MLXArray.zeros([9, dim])
+        self._audioPromptScaleShiftTable.wrappedValue = MLXArray.zeros([2, dim])
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        adaEmb: MLXArray,
+        promptAdaEmb: MLXArray,
+        context: MLXArray,
+        ropeCosSin: (MLXArray, MLXArray)?,
+        selfAttentionMask: MLXArray? = nil,
+        skipSelfAttn: Bool = false
+    ) -> MLXArray {
+        let B = x.dim(0)
+        var hidden = x
+        let ada: MLXArray
+        if adaEmb.ndim == 2 {
+            ada = adaEmb.reshaped(B, 1, 9, dim)
+                + audioScaleShiftTable.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+        } else {
+            ada = adaEmb.reshaped(B, adaEmb.dim(1), 9, dim)
+                + audioScaleShiftTable.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+        }
+
+        let shiftMSA = ada[0..., 0..., 0, 0...]
+        let scaleMSA = ada[0..., 0..., 1, 0...]
+        let gateMSA = ada[0..., 0..., 2, 0...]
+        var h = dramaBoxFunctionalRMSNorm(hidden, eps: normEps) * (1 + scaleMSA) + shiftMSA
+        hidden = hidden + audioAttn1(
+            h, mask: selfAttentionMask, ropeCosSin: ropeCosSin, skipSelfAttn: skipSelfAttn
+        ) * gateMSA
+
+        let shiftQ = ada[0..., 0..., 6, 0...]
+        let scaleQ = ada[0..., 0..., 7, 0...]
+        let gate = ada[0..., 0..., 8, 0...]
+        let ctxPA = audioPromptScaleShiftTable.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+            + promptAdaEmb.reshaped(B, 1, 2, dim)
+        let shiftKV = ctxPA[0..., 0..., 0, 0...]
+        let scaleKV = ctxPA[0..., 0..., 1, 0...]
+        let attnInput = dramaBoxFunctionalRMSNorm(hidden, eps: normEps) * (1 + scaleQ) + shiftQ
+        let encoderHS = context * (1 + scaleKV) + shiftKV
+        hidden = hidden + audioAttn2(attnInput, context: encoderHS) * gate
+
+        let shiftMLP = ada[0..., 0..., 3, 0...]
+        let scaleMLP = ada[0..., 0..., 4, 0...]
+        let gateMLP = ada[0..., 0..., 5, 0...]
+        h = dramaBoxFunctionalRMSNorm(hidden, eps: normEps) * (1 + scaleMLP) + shiftMLP
+        hidden = hidden + audioFF(h) * gateMLP
+        return hidden
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxLTXModel.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxLTXModel.swift
@@ -1,0 +1,128 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+final class DramaBoxLTXModel: Module {
+    let config: DramaBoxDiTConfig
+
+    @ModuleInfo(key: "audio_patchify_proj") var audioPatchifyProj: Linear
+    @ModuleInfo(key: "audio_adaln_single") var audioAdalnSingle: DramaBoxAdaLayerNormSingle
+    @ModuleInfo(key: "audio_prompt_adaln_single") var audioPromptAdalnSingle: DramaBoxAdaLayerNormSingle
+    @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [DramaBoxLTXBlock]
+    @ModuleInfo(key: "audio_scale_shift_table") var audioScaleShiftTable: MLXArray
+    @ModuleInfo(key: "audio_proj_out") var audioProjOut: Linear
+
+    init(_ config: DramaBoxDiTConfig = DramaBoxDiTConfig()) {
+        self.config = config
+        let hidden = config.audioInnerDim
+        self._audioPatchifyProj.wrappedValue = Linear(config.audioInChannels, hidden, bias: true)
+        self._audioAdalnSingle.wrappedValue = DramaBoxAdaLayerNormSingle(hidden: hidden, coeff: 9)
+        self._audioPromptAdalnSingle.wrappedValue = DramaBoxAdaLayerNormSingle(hidden: hidden, coeff: 2)
+        self._transformerBlocks.wrappedValue = (0..<config.numLayers).map { _ in
+            DramaBoxLTXBlock(
+                dim: hidden,
+                heads: config.audioNumAttentionHeads,
+                dimHead: config.audioAttentionHeadDim,
+                contextDim: config.audioCrossAttentionDim,
+                applyGatedAttention: config.applyGatedAttention,
+                normEps: config.normEps,
+                ropeType: config.ropeType
+            )
+        }
+        self._audioScaleShiftTable.wrappedValue = MLXArray.zeros([2, hidden])
+        self._audioProjOut.wrappedValue = Linear(hidden, config.audioOutChannels, bias: true)
+        super.init()
+    }
+
+    func normOut(_ x: MLXArray) -> MLXArray {
+        let orig = x.dtype
+        let x32 = x.asType(.float32)
+        let mean = MLX.mean(x32, axis: -1, keepDims: true)
+        let variance = MLX.mean((x32 - mean) * (x32 - mean), axis: -1, keepDims: true)
+        return ((x32 - mean) * MLX.rsqrt(variance + config.normEps)).asType(orig)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        aCtx: MLXArray,
+        sigma: MLXArray,
+        positions: MLXArray? = nil,
+        ropeCosSin: (MLXArray, MLXArray)? = nil,
+        attentionMask: MLXArray? = nil,
+        denoiseMask: MLXArray? = nil,
+        stgBlocks: Set<Int> = []
+    ) -> MLXArray {
+        let B = x.dim(0)
+        var hidden = audioPatchifyProj(x)
+        let rope: (MLXArray, MLXArray)
+        if let ropeCosSin {
+            rope = ropeCosSin
+        } else if let positions {
+            rope = dramaBoxPrecomputeSplitFreqsFromPositions(
+                positions: positions,
+                innerDim: config.audioInnerDim,
+                numHeads: config.audioNumAttentionHeads,
+                theta: config.positionalEmbeddingTheta,
+                maxPos: Float(config.audioPositionalEmbeddingMaxPos),
+                outDtype: hidden.dtype
+            )
+        } else {
+            fatalError("DramaBox DiT requires positions or ropeCosSin")
+        }
+
+        let scalarScaled = sigma.asType(.float32) * config.timestepScaleMultiplier
+        let mainScaled: MLXArray
+        if let denoiseMask {
+            var dm = denoiseMask
+            if dm.ndim == 3 {
+                dm = dm[.ellipsis, 0]
+            }
+            mainScaled = scalarScaled.expandedDimensions(axis: 1) * dm.asType(.float32)
+        } else {
+            mainScaled = scalarScaled
+        }
+
+        let (adaEmb, embeddedT) = audioAdalnSingle(mainScaled, dtype: hidden.dtype)
+        let (promptAda, _) = audioPromptAdalnSingle(scalarScaled, dtype: hidden.dtype)
+
+        for (idx, block) in transformerBlocks.enumerated() {
+            hidden = block(
+                hidden,
+                adaEmb: adaEmb,
+                promptAdaEmb: promptAda,
+                context: aCtx,
+                ropeCosSin: rope,
+                selfAttentionMask: attentionMask,
+                skipSelfAttn: stgBlocks.contains(idx)
+            )
+        }
+
+        let bias = audioScaleShiftTable.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+        let embedded: MLXArray
+        if embeddedT.ndim == 2 {
+            embedded = embeddedT.reshaped(B, 1, 1, -1)
+        } else {
+            embedded = embeddedT.reshaped(B, embeddedT.dim(1), 1, -1)
+        }
+        let scaleShift = bias + embedded
+        let shiftFinal = scaleShift[0..., 0..., 0, 0...]
+        let scaleFinal = scaleShift[0..., 0..., 1, 0...]
+        hidden = normOut(hidden)
+        hidden = hidden * (1 + scaleFinal) + shiftFinal
+        return audioProjOut(hidden)
+    }
+}
+
+func loadDramaBoxDiTWeights(_ model: DramaBoxLTXModel, state: [String: MLXArray]) throws {
+    let prefix = "model.diffusion_model."
+    var sub: [String: MLXArray] = [:]
+    for (key, value) in state where key.hasPrefix(prefix) {
+        let tail = String(key.dropFirst(prefix.count))
+        if tail.hasPrefix("audio_embeddings_connector") { continue }
+        sub[tail] = value
+    }
+    guard !sub.isEmpty else {
+        throw DramaBoxError.generationFailed("No DiT keys under \(prefix)")
+    }
+    try model.update(parameters: ModuleParameters.unflattened(sub), verify: .all)
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxTimestep.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DiT/DramaBoxTimestep.swift
@@ -1,0 +1,69 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+func dramaBoxSinusoidalTimestepEmbedding(
+    _ timesteps: MLXArray,
+    embeddingDim: Int = 256,
+    flipSinToCos: Bool = true,
+    downscaleFreqShift: Float = 0,
+    maxPeriod: Int = 10_000
+) -> MLXArray {
+    let halfDim = embeddingDim / 2
+    var exponent = -log(Float(maxPeriod)) * MLXArray(Array(0..<halfDim).map { Float($0) })
+    exponent = exponent / (Float(halfDim) - downscaleFreqShift)
+    let freqs = MLX.exp(exponent)
+    var emb = timesteps.asType(.float32).expandedDimensions(axis: -1) * freqs
+    emb = concatenated([MLX.sin(emb), MLX.cos(emb)], axis: -1)
+    if flipSinToCos {
+        let first = emb[.ellipsis, halfDim...]
+        let second = emb[.ellipsis, 0..<halfDim]
+        emb = concatenated([first, second], axis: -1)
+    }
+    return emb
+}
+
+final class DramaBoxTimestepMLP: Module {
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+
+    init(hidden: Int) {
+        self._linear1.wrappedValue = Linear(256, hidden, bias: true)
+        self._linear2.wrappedValue = Linear(hidden, hidden, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(MLXNN.silu(linear1(x)))
+    }
+}
+
+final class DramaBoxPixArtTimestepEmbedder: Module {
+    @ModuleInfo(key: "timestep_embedder") var timestepEmbedder: DramaBoxTimestepMLP
+
+    init(hidden: Int) {
+        self._timestepEmbedder.wrappedValue = DramaBoxTimestepMLP(hidden: hidden)
+        super.init()
+    }
+
+    func callAsFunction(_ timesteps: MLXArray, dtype: DType) -> MLXArray {
+        let proj = dramaBoxSinusoidalTimestepEmbedding(timesteps)
+        return timestepEmbedder(proj.asType(dtype))
+    }
+}
+
+final class DramaBoxAdaLayerNormSingle: Module {
+    @ModuleInfo var emb: DramaBoxPixArtTimestepEmbedder
+    @ModuleInfo var linear: Linear
+
+    init(hidden: Int, coeff: Int) {
+        self._emb.wrappedValue = DramaBoxPixArtTimestepEmbedder(hidden: hidden)
+        self._linear.wrappedValue = Linear(hidden, coeff * hidden, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ timesteps: MLXArray, dtype: DType) -> (MLXArray, MLXArray) {
+        let tEmb = emb(timesteps, dtype: dtype)
+        return (linear(MLXNN.silu(tEmb)), tEmb)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxLatentState.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxLatentState.swift
@@ -1,0 +1,160 @@
+import Foundation
+@preconcurrency import MLX
+
+struct DramaBoxLatentState {
+    var latent: MLXArray
+    var denoiseMask: MLXArray
+    var positions: MLXArray
+    var cleanLatent: MLXArray
+    var attentionMask: MLXArray?
+
+    func replacing(
+        latent: MLXArray? = nil,
+        denoiseMask: MLXArray? = nil,
+        positions: MLXArray? = nil,
+        cleanLatent: MLXArray? = nil,
+        attentionMask: MLXArray?? = nil
+    ) -> DramaBoxLatentState {
+        DramaBoxLatentState(
+            latent: latent ?? self.latent,
+            denoiseMask: denoiseMask ?? self.denoiseMask,
+            positions: positions ?? self.positions,
+            cleanLatent: cleanLatent ?? self.cleanLatent,
+            attentionMask: attentionMask ?? self.attentionMask
+        )
+    }
+}
+
+struct DramaBoxAudioLatentTools {
+    var patchifier: DramaBoxAudioPatchifier
+    var targetShape: DramaBoxAudioLatentShape
+
+    func createInitialState(dtype: DType = .bfloat16) -> DramaBoxLatentState {
+        let shape = targetShape
+        let zeros = MLXArray.zeros(shape.toTuple(), dtype: dtype)
+        let mask = MLXArray.ones([shape.batch, 1, shape.frames, 1], dtype: .float32)
+        let positions = patchifier.getPatchGridBounds(shape)
+        return patchifyState(
+            DramaBoxLatentState(
+                latent: zeros,
+                denoiseMask: mask,
+                positions: positions,
+                cleanLatent: zeros,
+                attentionMask: nil
+            )
+        )
+    }
+
+    func patchifyState(_ state: DramaBoxLatentState) -> DramaBoxLatentState {
+        state.replacing(
+            latent: DramaBoxAudioPatchifier.patchify(state.latent),
+            denoiseMask: DramaBoxAudioPatchifier.patchify(state.denoiseMask),
+            cleanLatent: DramaBoxAudioPatchifier.patchify(state.cleanLatent)
+        )
+    }
+
+    func unpatchifyState(_ state: DramaBoxLatentState) -> DramaBoxLatentState {
+        let C = targetShape.channels
+        let F = targetShape.melBins
+        return state.replacing(
+            latent: DramaBoxAudioPatchifier.unpatchify(state.latent, channels: C, melBins: F),
+            cleanLatent: DramaBoxAudioPatchifier.unpatchify(state.cleanLatent, channels: C, melBins: F)
+        )
+    }
+
+    func clearConditioning(_ state: DramaBoxLatentState) -> DramaBoxLatentState {
+        let n = targetShape.tokenCount()
+        return DramaBoxLatentState(
+            latent: state.latent[0..., 0..<n],
+            denoiseMask: MLXArray.ones(like: state.denoiseMask)[0..., 0..<n],
+            positions: state.positions[0..., 0..., 0..<n],
+            cleanLatent: state.cleanLatent[0..., 0..<n],
+            attentionMask: nil
+        )
+    }
+}
+
+struct DramaBoxGaussianNoiser {
+    let key: MLXArray
+
+    init(seed: UInt64) {
+        self.key = MLXRandom.key(seed)
+    }
+
+    func callAsFunction(_ state: DramaBoxLatentState, noiseScale: Float = 1.0) -> DramaBoxLatentState {
+        var noise = MLXRandom.normal(state.latent.shape, dtype: .float32, key: key)
+        noise = noise.asType(state.latent.dtype)
+        var scaledMask = state.denoiseMask * noiseScale
+        if scaledMask.shape != state.latent.shape {
+            scaledMask = MLX.broadcast(scaledMask, to: state.latent.shape)
+        }
+        scaledMask = scaledMask.asType(state.latent.dtype)
+        let noised = noise * scaledMask + state.latent * (1.0 - scaledMask)
+        return state.replacing(latent: noised)
+    }
+}
+
+func dramaBoxApplyReferenceLatent(
+    _ state: DramaBoxLatentState,
+    refLatent: MLXArray,
+    patchifier: DramaBoxAudioPatchifier = DramaBoxAudioPatchifier(),
+    positionOffsetS: Float = 0.5
+) -> DramaBoxLatentState {
+    let refTokens = DramaBoxAudioPatchifier.patchify(refLatent).asType(state.latent.dtype)
+    let batch = state.latent.dim(0)
+    let targetCount = state.latent.dim(1)
+    let refCount = refTokens.dim(1)
+    let refMask = MLXArray.zeros([batch, refCount, 1], dtype: state.denoiseMask.dtype)
+    let refShape = DramaBoxAudioLatentShape(
+        batch: batch,
+        channels: refLatent.dim(1),
+        frames: refLatent.dim(2),
+        melBins: refLatent.dim(3)
+    )
+    let refPositions = patchifier.getPatchGridBounds(refShape) + positionOffsetS
+    let attentionMask = dramaBoxAsymmetricAttentionMask(
+        batch: batch,
+        targetTokens: targetCount,
+        refTokens: refCount,
+        dtype: state.latent.dtype
+    )
+    return DramaBoxLatentState(
+        latent: concatenated([state.latent, refTokens], axis: 1),
+        denoiseMask: concatenated([state.denoiseMask, refMask], axis: 1),
+        positions: concatenated([state.positions, refPositions], axis: 2),
+        cleanLatent: concatenated([state.cleanLatent, refTokens], axis: 1),
+        attentionMask: attentionMask
+    )
+}
+
+func dramaBoxAsymmetricAttentionMask(
+    batch: Int,
+    targetTokens: Int,
+    refTokens: Int,
+    dtype: DType
+) -> MLXArray {
+    let total = targetTokens + refTokens
+    let targetRows = MLXArray.zeros([batch, 1, targetTokens, total], dtype: dtype)
+    let fill = MLXArray(dramaBoxFinfoMin(dtype), dtype: dtype)
+    let refToTarget = MLXArray.full([batch, 1, refTokens, targetTokens], values: fill, dtype: dtype)
+    let refToRef = MLXArray.zeros([batch, 1, refTokens, refTokens], dtype: dtype)
+    let refRows = concatenated([refToTarget, refToRef], axis: -1)
+    return concatenated([targetRows, refRows], axis: -2)
+}
+
+func dramaBoxToVelocity(_ sample: MLXArray, sigma: Float, denoised: MLXArray) -> MLXArray {
+    precondition(sigma != 0)
+    return ((sample.asType(.float32) - denoised.asType(.float32)) / sigma).asType(sample.dtype)
+}
+
+func dramaBoxToDenoised(_ sample: MLXArray, velocity: MLXArray, sigma: Float) -> MLXArray {
+    (sample.asType(.float32) - velocity.asType(.float32) * sigma).asType(sample.dtype)
+}
+
+func dramaBoxPostProcessLatent(
+    denoised: MLXArray,
+    denoiseMask: MLXArray,
+    cleanLatent: MLXArray
+) -> MLXArray {
+    denoiseMask * denoised + (1.0 - denoiseMask) * cleanLatent
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxPatchifier.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxPatchifier.swift
@@ -1,0 +1,82 @@
+import Foundation
+@preconcurrency import MLX
+
+struct DramaBoxAudioLatentShape: Sendable {
+    var batch: Int
+    var channels: Int
+    var frames: Int
+    var melBins: Int
+
+    func toTuple() -> [Int] { [batch, channels, frames, melBins] }
+    func tokenCount() -> Int { frames }
+
+    init(batch: Int, channels: Int, frames: Int, melBins: Int) {
+        self.batch = batch
+        self.channels = channels
+        self.frames = frames
+        self.melBins = melBins
+    }
+
+    init(_ target: DramaBoxAudioTargetShape) {
+        self.batch = target.batch
+        self.channels = target.channels
+        self.frames = target.frames
+        self.melBins = target.melBins
+    }
+}
+
+struct DramaBoxAudioPatchifier {
+    var sampleRate: Int
+    var hopLength: Int
+    var audioLatentDownsampleFactor: Int
+    var isCausal: Bool
+    var shift: Int
+
+    init(
+        sampleRate: Int = 16_000,
+        hopLength: Int = 160,
+        audioLatentDownsampleFactor: Int = 4,
+        isCausal: Bool = true,
+        shift: Int = 0
+    ) {
+        self.sampleRate = sampleRate
+        self.hopLength = hopLength
+        self.audioLatentDownsampleFactor = audioLatentDownsampleFactor
+        self.isCausal = isCausal
+        self.shift = shift
+    }
+
+    static func patchify(_ latent: MLXArray) -> MLXArray {
+        let B = latent.dim(0)
+        let C = latent.dim(1)
+        let T = latent.dim(2)
+        let F = latent.dim(3)
+        return latent.transposed(0, 2, 1, 3).reshaped(B, T, C * F)
+    }
+
+    static func unpatchify(_ latent: MLXArray, channels: Int, melBins: Int) -> MLXArray {
+        let B = latent.dim(0)
+        let T = latent.dim(1)
+        return latent.reshaped(B, T, channels, melBins).transposed(0, 2, 1, 3)
+    }
+
+    func latentTimeInSec(start: Int, end: Int) -> MLXArray {
+        let idx = MLXArray(Array(start..<end).map { Float($0) })
+        var melFrame = idx * Float(audioLatentDownsampleFactor)
+        if isCausal {
+            melFrame = MLX.maximum(
+                melFrame + (1.0 - Float(audioLatentDownsampleFactor)),
+                MLXArray(0 as Float)
+            )
+        }
+        return melFrame * Float(hopLength) / Float(sampleRate)
+    }
+
+    func getPatchGridBounds(_ shape: DramaBoxAudioLatentShape) -> MLXArray {
+        var start = latentTimeInSec(start: shift, end: shape.frames + shift)
+        var end = latentTimeInSec(start: shift + 1, end: shape.frames + shift + 1)
+        start = MLX.broadcast(start.reshaped([1, 1, shape.frames]), to: [shape.batch, 1, shape.frames])
+        end = MLX.broadcast(end.reshaped([1, 1, shape.frames]), to: [shape.batch, 1, shape.frames])
+        return stacked([start, end], axis: -1)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxScheduler.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxScheduler.swift
@@ -1,0 +1,32 @@
+import Foundation
+@preconcurrency import MLX
+
+struct DramaBoxLTX2Scheduler {
+    func execute(
+        steps: Int,
+        tokens: Int,
+        maxShift: Float = 2.05,
+        baseShift: Float = 0.95,
+        stretch: Bool = true,
+        terminal: Float = 0.1
+    ) -> MLXArray {
+        var sigmas = MLX.linspace(Float32(1), Float32(0), count: steps + 1).asType(.float32)
+        let mm = (maxShift - baseShift) / (4096.0 - 1024.0)
+        let b = baseShift - mm * 1024.0
+        let sigmaShift = Float(tokens) * mm + b
+        let expShift = exp(sigmaShift)
+        let nonzero = sigmas .!= MLXArray(0 as Float)
+        let safe = which(nonzero, sigmas, MLXArray(Float(1e-12)))
+        let ratio = 1.0 / safe - 1.0
+        let shifted = MLXArray(expShift) / (MLXArray(expShift) + ratio)
+        sigmas = which(nonzero, shifted, MLXArray(0 as Float))
+        if stretch {
+            let oneMinus = 1.0 - sigmas
+            let anchor = oneMinus[steps - 1]
+            let scaleFactor = anchor / (1.0 - terminal)
+            let stretched = 1.0 - oneMinus / scaleFactor
+            sigmas = which(nonzero, stretched, MLXArray(0 as Float))
+        }
+        return sigmas.asType(.float32)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxShape.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Diffusion/DramaBoxShape.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct DramaBoxAudioTargetShape: Sendable {
+    var batch: Int
+    var channels: Int
+    var frames: Int
+    var melBins: Int
+
+    func toTuple() -> [Int] { [batch, channels, frames, melBins] }
+}
+
+func dramaBoxTargetShapeFromDuration(
+    _ durationS: Float,
+    batch: Int = 1,
+    fps: Float = 25,
+    channels: Int = 8,
+    melBins: Int = 16,
+    sampleRate: Int = 16_000,
+    hopLength: Int = 160,
+    audioLatentDownsampleFactor: Int = 4
+) -> DramaBoxAudioTargetShape {
+    var nFrames = Int((durationS * fps).rounded()) + 1
+    nFrames = ((nFrames - 1 + 4) / 8) * 8 + 1
+    let latentsPerSecond = Float(sampleRate) / Float(hopLength) / Float(audioLatentDownsampleFactor)
+    let audioFrames = Int((Float(nFrames) / fps * latentsPerSecond).rounded())
+    return DramaBoxAudioTargetShape(
+        batch: batch,
+        channels: channels,
+        frames: audioFrames,
+        melBins: melBins
+    )
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxConfig.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxConfig.swift
@@ -1,0 +1,272 @@
+import Foundation
+@preconcurrency import MLX
+@preconcurrency import MLXLMCommon
+
+public let dramaBoxDefaultAudioRepository = "appautomaton/dramabox-tts-3.3b-bf16-mlx"
+public let dramaBoxDefaultGemmaRepository = "appautomaton/gemma-3-12b-it-backbone-4bit-mlx"
+
+public let dramaBoxDiTWeightFile = "dramabox-dit-v1.safetensors"
+public let dramaBoxAudioComponentsFile = "dramabox-audio-components.safetensors"
+
+/// Warm-server negative prompt. CFG needs named acoustic failure modes;
+/// an empty string collapses guidance to a near no-op.
+public let dramaBoxDefaultNegativePrompt = """
+worst quality, inconsistent, robotic, distorted, noise, static, \
+muffled, unclear, unnatural, monotone
+"""
+
+public enum DramaBoxError: Error, LocalizedError, Sendable {
+    case invalidRepositoryID(String)
+    case missingCheckpoint(URL, String)
+    case missingGemmaBackbone(String)
+    case denoiseRefUnsupported
+    case silentReferenceAudio
+    case invalidAudioShape([Int])
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRepositoryID(let id):
+            "Invalid repository ID: \(id)"
+        case .missingCheckpoint(let dir, let name):
+            "Missing DramaBox file '\(name)' in \(dir.path)"
+        case .missingGemmaBackbone(let message):
+            "DramaBox Gemma 3 backbone: \(message)"
+        case .denoiseRefUnsupported:
+            "denoiseRef=true is out of scope for v1 (RE-USE / SEMamba). Pass denoiseRef=false and a raw voice reference."
+        case .silentReferenceAudio:
+            "Reference audio is silent."
+        case .invalidAudioShape(let shape):
+            "Invalid DramaBox audio shape: \(shape)"
+        case .generationFailed(let message):
+            message
+        }
+    }
+}
+
+/// DramaBox-only sampling knobs. Autoregressive `GenerateParameters`
+/// (`maxTokens`, `temperature`, `topP`, …) are ignored.
+public struct DramaBoxGenerateConfig: Sendable {
+    public var durationSeconds: Float
+    public var cfgScale: Float
+    public var stgScale: Float
+    /// `nil` means auto: `autoRescaleForCfg(cfgScale)` (0.3 when cfg=2.5).
+    public var rescaleScale: Float?
+    public var modalityScale: Float
+    public var steps: Int
+    public var seed: UInt64
+    /// v1 throws if true. RE-USE / SEMamba is out of scope.
+    public var denoiseRef: Bool
+    public var maxPromptLength: Int
+    public var referenceDurationSeconds: Float
+    public var referenceSampleRate: Int?
+
+    public init(
+        durationSeconds: Float = 5.0,
+        cfgScale: Float = 2.5,
+        stgScale: Float = 1.5,
+        rescaleScale: Float? = nil,
+        modalityScale: Float = 1.0,
+        steps: Int = 30,
+        seed: UInt64 = 42,
+        denoiseRef: Bool = false,
+        maxPromptLength: Int = 1024,
+        referenceDurationSeconds: Float = 10.0,
+        referenceSampleRate: Int? = nil
+    ) {
+        self.durationSeconds = durationSeconds
+        self.cfgScale = cfgScale
+        self.stgScale = stgScale
+        self.rescaleScale = rescaleScale
+        self.modalityScale = modalityScale
+        self.steps = steps
+        self.seed = seed
+        self.denoiseRef = denoiseRef
+        self.maxPromptLength = maxPromptLength
+        self.referenceDurationSeconds = referenceDurationSeconds
+        self.referenceSampleRate = referenceSampleRate
+    }
+
+    public static let `default` = DramaBoxGenerateConfig()
+
+    public var resolvedRescaleScale: Float {
+        rescaleScale ?? dramaBoxAutoRescaleForCfg(cfgScale)
+    }
+}
+
+/// Subset of Gemma 3 text-config used by the headless DramaBox encoder.
+public struct DramaBoxGemmaTextConfig: Sendable {
+    public var hiddenSize: Int
+    public var intermediateSize: Int
+    public var numHiddenLayers: Int
+    public var numAttentionHeads: Int
+    public var numKeyValueHeads: Int
+    public var headDim: Int
+    public var vocabSize: Int
+    public var rmsNormEps: Float
+    public var ropeTheta: Float
+    public var ropeLocalBaseFreq: Float
+    public var slidingWindow: Int
+    public var slidingWindowPattern: Int
+    public var queryPreAttnScalar: Int
+    public var hiddenActivation: String
+    public var maxPositionEmbeddings: Int
+    public var ropeScalingFactor: Float
+    public var quantization: BaseConfiguration.Quantization?
+
+    public var attentionScale: Float {
+        pow(Float(queryPreAttnScalar), -0.5)
+    }
+
+    public var hiddenStateCount: Int {
+        numHiddenLayers + 1
+    }
+
+    /// Every `slidingWindowPattern`-th layer (1-indexed) is full attention.
+    public func layerTypes() -> [String] {
+        (0..<numHiddenLayers).map { index in
+            (index + 1).isMultiple(of: slidingWindowPattern) ? "full_attention" : "sliding_attention"
+        }
+    }
+
+    public init(
+        hiddenSize: Int,
+        intermediateSize: Int,
+        numHiddenLayers: Int,
+        numAttentionHeads: Int,
+        numKeyValueHeads: Int,
+        headDim: Int,
+        vocabSize: Int,
+        rmsNormEps: Float = 1e-6,
+        ropeTheta: Float = 1_000_000,
+        ropeLocalBaseFreq: Float = 10_000,
+        slidingWindow: Int = 1024,
+        slidingWindowPattern: Int = 6,
+        queryPreAttnScalar: Int = 256,
+        hiddenActivation: String = "gelu_pytorch_tanh",
+        maxPositionEmbeddings: Int = 131_072,
+        ropeScalingFactor: Float = 8.0,
+        quantization: BaseConfiguration.Quantization? = nil
+    ) {
+        self.hiddenSize = hiddenSize
+        self.intermediateSize = intermediateSize
+        self.numHiddenLayers = numHiddenLayers
+        self.numAttentionHeads = numAttentionHeads
+        self.numKeyValueHeads = numKeyValueHeads
+        self.headDim = headDim
+        self.vocabSize = vocabSize
+        self.rmsNormEps = rmsNormEps
+        self.ropeTheta = ropeTheta
+        self.ropeLocalBaseFreq = ropeLocalBaseFreq
+        self.slidingWindow = slidingWindow
+        self.slidingWindowPattern = slidingWindowPattern
+        self.queryPreAttnScalar = queryPreAttnScalar
+        self.hiddenActivation = hiddenActivation
+        self.maxPositionEmbeddings = maxPositionEmbeddings
+        self.ropeScalingFactor = ropeScalingFactor
+        self.quantization = quantization
+    }
+
+    public static func fromJSONObject(_ payload: [String: Any]) throws -> DramaBoxGemmaTextConfig {
+        let text: [String: Any]
+        if let nested = payload["text_config"] as? [String: Any] {
+            text = nested
+        } else {
+            text = payload
+        }
+
+        func requireInt(_ key: String) throws -> Int {
+            if let value = text[key] as? Int { return value }
+            if let value = text[key] as? Double { return Int(value) }
+            throw DramaBoxError.missingGemmaBackbone("config.json missing \(key)")
+        }
+
+        let rope = text["rope_scaling"] as? [String: Any]
+        let quantPayload = (payload["quantization"] as? [String: Any])
+            ?? (payload["quantization_config"] as? [String: Any])
+        let quantization: BaseConfiguration.Quantization?
+        if let quantPayload {
+            let groupSize = (quantPayload["group_size"] as? Int)
+                ?? Int(quantPayload["group_size"] as? Double ?? 64)
+            let bits = (quantPayload["bits"] as? Int)
+                ?? Int(quantPayload["bits"] as? Double ?? 4)
+            quantization = BaseConfiguration.Quantization(groupSize: groupSize, bits: bits)
+        } else {
+            quantization = nil
+        }
+
+        return DramaBoxGemmaTextConfig(
+            hiddenSize: try requireInt("hidden_size"),
+            intermediateSize: try requireInt("intermediate_size"),
+            numHiddenLayers: try requireInt("num_hidden_layers"),
+            numAttentionHeads: try requireInt("num_attention_heads"),
+            numKeyValueHeads: try requireInt("num_key_value_heads"),
+            headDim: try requireInt("head_dim"),
+            vocabSize: try requireInt("vocab_size"),
+            rmsNormEps: Float(text["rms_norm_eps"] as? Double ?? 1e-6),
+            ropeTheta: Float(text["rope_theta"] as? Double ?? 1_000_000),
+            ropeLocalBaseFreq: Float(text["rope_local_base_freq"] as? Double ?? 10_000),
+            slidingWindow: (text["sliding_window"] as? Int) ?? 1024,
+            slidingWindowPattern: (text["sliding_window_pattern"] as? Int) ?? 6,
+            queryPreAttnScalar: (text["query_pre_attn_scalar"] as? Int) ?? 256,
+            hiddenActivation: text["hidden_activation"] as? String ?? "gelu_pytorch_tanh",
+            maxPositionEmbeddings: (text["max_position_embeddings"] as? Int) ?? 131_072,
+            ropeScalingFactor: Float(rope?["factor"] as? Double ?? 8.0),
+            quantization: quantization
+        )
+    }
+
+    public static func load(from directory: URL) throws -> DramaBoxGemmaTextConfig {
+        let url = directory.appendingPathComponent("config.json")
+        let data = try Data(contentsOf: url)
+        guard let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DramaBoxError.missingGemmaBackbone("config.json is not a JSON object")
+        }
+        return try fromJSONObject(payload)
+    }
+}
+
+public struct DramaBoxResult: Sendable {
+    /// Stereo waveform `[2, T]` float32 in `[-1, 1]`.
+    public var waveform: MLXArray
+    public var sampleRate: Int
+    public var durationSeconds: Float
+    public var settings: DramaBoxGenerateConfig
+
+    public init(
+        waveform: MLXArray,
+        sampleRate: Int = 48_000,
+        durationSeconds: Float,
+        settings: DramaBoxGenerateConfig
+    ) {
+        self.waveform = waveform
+        self.sampleRate = sampleRate
+        self.durationSeconds = durationSeconds
+        self.settings = settings
+    }
+}
+
+func dramaBoxAutoRescaleForCfg(_ cfgScale: Float) -> Float {
+    if cfgScale <= 2.0 { return 0.0 }
+    if cfgScale <= 3.0 { return 0.6 * (cfgScale - 2.0) }
+    if cfgScale <= 4.0 { return 0.6 + 0.2 * (cfgScale - 3.0) }
+    if cfgScale <= 8.0 { return 0.8 }
+    return min(1.0, 0.8 + 0.1 * (cfgScale - 8.0))
+}
+
+func dramaBoxFinfoMax(_ dtype: DType) -> Float {
+    switch dtype {
+    case .float16:
+        65504
+    case .bfloat16:
+        // Finite bfloat16 max. `Float.greatestFiniteMagnitude` rounds to Inf in bf16,
+        // and a fully-masked attention row of -Inf makes softmax NaN.
+        3.38953139e38
+    default:
+        Float.greatestFiniteMagnitude
+    }
+}
+
+func dramaBoxFinfoMin(_ dtype: DType) -> Float {
+    -dramaBoxFinfoMax(dtype)
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxModel.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxModel.swift
@@ -1,0 +1,268 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+public final class DramaBoxModel: SpeechGenerationModel, @unchecked Sendable {
+    public let sampleRate = 48_000
+    public var generateConfig: DramaBoxGenerateConfig
+
+    public var defaultGenerationParameters: GenerateParameters {
+        GenerateParameters()
+    }
+
+    let promptEncoder: DramaBoxPromptEncoder
+    let dit: DramaBoxLTXModel
+    let audioVAE: DramaBoxAudioVAE
+    let vocoder: DramaBoxVocoderWithBWE
+    var negativeACtx: MLXArray?
+
+    init(
+        promptEncoder: DramaBoxPromptEncoder,
+        dit: DramaBoxLTXModel,
+        audioVAE: DramaBoxAudioVAE,
+        vocoder: DramaBoxVocoderWithBWE,
+        generateConfig: DramaBoxGenerateConfig = .default
+    ) {
+        self.promptEncoder = promptEncoder
+        self.dit = dit
+        self.audioVAE = audioVAE
+        self.vocoder = vocoder
+        self.generateConfig = generateConfig
+    }
+
+    public static func fromPretrained(
+        _ modelRepo: String = dramaBoxDefaultAudioRepository,
+        gemmaRepo: String = dramaBoxDefaultGemmaRepository,
+        cache: HubCache = .default,
+        hfToken: String? = nil
+    ) async throws -> DramaBoxModel {
+        let token = hfToken
+            ?? ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+        let gemmaSpec = DramaBoxWeights.resolveGemmaRepository(gemmaRepo)
+        let audioDir = try await DramaBoxWeights.resolveDirectory(
+            spec: modelRepo,
+            requiredFiles: DramaBoxWeights.audioRequiredFiles,
+            cache: cache,
+            hfToken: token
+        )
+        let gemmaDir = try await DramaBoxWeights.resolveGemmaDirectory(
+            spec: gemmaSpec,
+            cache: cache,
+            hfToken: token
+        )
+        return try await fromModelDirectory(audioDir, gemmaDir: gemmaDir)
+    }
+
+    public static func fromModelDirectory(
+        _ audioDir: URL,
+        gemmaDir: URL? = nil,
+        cache: HubCache = .default,
+        hfToken: String? = nil
+    ) async throws -> DramaBoxModel {
+        let resolvedGemmaDir: URL
+        if let gemmaDir {
+            resolvedGemmaDir = gemmaDir
+        } else {
+            let token = hfToken
+                ?? ProcessInfo.processInfo.environment["HF_TOKEN"]
+                ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
+            resolvedGemmaDir = try await DramaBoxWeights.resolveGemmaDirectory(
+                spec: dramaBoxDefaultGemmaRepository,
+                cache: cache,
+                hfToken: token
+            )
+        }
+        print("Loading Gemma 3 backbone from \(resolvedGemmaDir.path)")
+        let (gemma, _) = try DramaBoxGemma3TextBackbone.load(from: resolvedGemmaDir)
+        let tokenizer = try await LTXVGemmaTokenizer.fromDirectory(resolvedGemmaDir)
+
+        let components = try DramaBoxWeights.loadSafetensors(
+            from: audioDir,
+            files: [dramaBoxAudioComponentsFile]
+        )
+        let featureExtractor = DramaBoxFeatureExtractor()
+        try loadDramaBoxFeatureExtractorWeights(featureExtractor, state: components)
+        let connector = DramaBoxEmbeddings1DConnector()
+        try loadDramaBoxConnectorWeights(connector, state: components)
+        let processor = DramaBoxEmbeddingsProcessor(
+            featureExtractor: featureExtractor,
+            audioConnector: connector
+        )
+        let promptEncoder = DramaBoxPromptEncoder(
+            gemma: gemma,
+            tokenizer: tokenizer,
+            processor: processor
+        )
+
+        let dit = DramaBoxLTXModel()
+        let ditState = try DramaBoxWeights.loadSafetensors(
+            from: audioDir,
+            files: [dramaBoxDiTWeightFile]
+        )
+        try loadDramaBoxDiTWeights(dit, state: ditState)
+
+        let vae = DramaBoxAudioVAE()
+        try loadDramaBoxAudioVAEWeights(vae, state: components)
+
+        let vocoder = DramaBoxVocoderWithBWE()
+        try loadDramaBoxVocoderWeights(vocoder, state: components)
+
+        eval(dit)
+        eval(vae)
+        eval(vocoder)
+        eval(featureExtractor)
+        eval(connector)
+        return DramaBoxModel(
+            promptEncoder: promptEncoder,
+            dit: dit,
+            audioVAE: vae,
+            vocoder: vocoder
+        )
+    }
+
+    public func generate(
+        prompt: String,
+        referenceAudio: MLXArray? = nil,
+        referenceSampleRate: Int? = nil,
+        config: DramaBoxGenerateConfig? = nil
+    ) async throws -> DramaBoxResult {
+        let config = config ?? generateConfig
+        if config.denoiseRef {
+            throw DramaBoxError.denoiseRefUnsupported
+        }
+        let rescale = config.resolvedRescaleScale
+        let params = DramaBoxGuiderParams(
+            cfgScale: config.cfgScale,
+            stgScale: config.stgScale,
+            rescaleScale: rescale,
+            modalityScale: config.modalityScale
+        )
+
+        let aCtx = promptEncoder.encode(prompt, maxLength: config.maxPromptLength)
+        eval(aCtx)
+        var aCtxNeg: MLXArray?
+        if params.needsUncond {
+            if negativeACtx == nil {
+                negativeACtx = promptEncoder.encode(
+                    dramaBoxDefaultNegativePrompt,
+                    maxLength: config.maxPromptLength
+                )
+                eval(negativeACtx!)
+            }
+            aCtxNeg = negativeACtx
+        }
+
+        let target = dramaBoxTargetShapeFromDuration(config.durationSeconds)
+        let shape = DramaBoxAudioLatentShape(target)
+        let patchifier = DramaBoxAudioPatchifier()
+        let tools = DramaBoxAudioLatentTools(patchifier: patchifier, targetShape: shape)
+        var state = tools.createInitialState(dtype: .bfloat16)
+
+        var loopDenoiseMask: MLXArray?
+        if let referenceAudio {
+            let sr = referenceSampleRate ?? config.referenceSampleRate ?? sampleRate
+            let prepared = try prepareDramaBoxReferenceAudio(
+                referenceAudio,
+                sampleRate: sr,
+                refDurationS: config.referenceDurationSeconds
+            )
+            let processor = DramaBoxAudioProcessor()
+            let refMel = try processor.waveformToMel(prepared.waveform, sampleRate: prepared.sampleRate)
+            let refLatent = audioVAE.encode(refMel)
+            state = dramaBoxApplyReferenceLatent(state, refLatent: refLatent, patchifier: patchifier)
+            loopDenoiseMask = state.denoiseMask
+        }
+
+        let noiser = DramaBoxGaussianNoiser(seed: config.seed)
+        state = noiser(state, noiseScale: 1.0)
+
+        let sigmas = DramaBoxLTX2Scheduler().execute(
+            steps: config.steps,
+            tokens: state.latent.dim(-1)
+        )
+        let x0 = DramaBoxX0Model(dit: dit)
+        state = dramaBoxEulerDenoisingLoop(
+            state,
+            sigmas: sigmas,
+            x0Model: x0,
+            aCtx: aCtx,
+            aCtxNeg: aCtxNeg,
+            params: params,
+            positions: state.positions,
+            denoiseMask: loopDenoiseMask
+        )
+
+        state = tools.clearConditioning(state)
+        state = tools.unpatchifyState(state)
+        let latent4d = dramaBoxSilencePriorFix(state.latent)
+        let mel = audioVAE.decode(latent4d)
+        let waveform = vocoder(mel)
+        eval(waveform)
+        let stereo = waveform[0].asType(.float32)
+        guard MLX.all(MLX.isFinite(stereo)).item(Bool.self) else {
+            throw DramaBoxError.generationFailed(
+                "DramaBox produced non-finite samples (NaN/Inf). Prompt encoding or the vocoder path exploded."
+            )
+        }
+        return DramaBoxResult(
+            waveform: stereo,
+            sampleRate: sampleRate,
+            durationSeconds: config.durationSeconds,
+            settings: config
+        )
+    }
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        _ = voice
+        _ = refText
+        _ = language
+        _ = generationParameters
+        let result = try await generate(
+            prompt: text,
+            referenceAudio: refAudio,
+            config: generateConfig
+        )
+        return result.waveform
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        let (stream, continuation) = AsyncThrowingStream<AudioGeneration, Error>.makeStream()
+        let task = Task { @Sendable [weak self] in
+            guard let self else { return }
+            do {
+                let audio = try await self.generate(
+                    text: text,
+                    voice: voice,
+                    refAudio: refAudio,
+                    refText: refText,
+                    language: language,
+                    generationParameters: generationParameters
+                )
+                continuation.yield(.audio(audio))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
+        return stream
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxPromptEncoder.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxPromptEncoder.swift
@@ -1,0 +1,27 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+/// Text → `a_ctx` `[B, 1024, 2048]`. Gemma is held outside the Module tree
+/// so quantized 4-bit weights are not mixed into DiT/VAE `load_weights`.
+final class DramaBoxPromptEncoder {
+    let gemma: DramaBoxGemma3TextBackbone
+    let tokenizer: LTXVGemmaTokenizer
+    let processor: DramaBoxEmbeddingsProcessor
+
+    init(
+        gemma: DramaBoxGemma3TextBackbone,
+        tokenizer: LTXVGemmaTokenizer,
+        processor: DramaBoxEmbeddingsProcessor
+    ) {
+        self.gemma = gemma
+        self.tokenizer = tokenizer
+        self.processor = processor
+    }
+
+    func encode(_ text: String, maxLength: Int = 1024) -> MLXArray {
+        let (inputIds, attentionMask) = tokenizer.encode(text, maxLength: maxLength)
+        let gemmaOut = gemma(inputIds, attentionMask: attentionMask)
+        return processor(gemmaOut.hiddenStates, attentionMask: attentionMask).audioEncoding
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxWeights.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/DramaBoxWeights.swift
@@ -1,0 +1,215 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXNN
+
+struct DramaBoxResolvedPaths: Sendable {
+    let audioDirectory: URL
+    let gemmaDirectory: URL
+}
+
+enum DramaBoxWeights {
+    static let audioRequiredFiles = [dramaBoxDiTWeightFile, dramaBoxAudioComponentsFile]
+    static let gemmaRequiredFileSuffixes = ["safetensors"]
+
+    static func resolveGemmaRepository(_ spec: String?) -> String {
+        let trimmed = spec?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            return dramaBoxDefaultGemmaRepository
+        }
+        return trimmed
+    }
+
+    static func isLocalCheckpointDirectory(_ url: URL, requiredFiles: [String]) -> Bool {
+        var isDirectory: ObjCBool = false
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return false
+        }
+        let config = url.appendingPathComponent("config.json")
+        guard fm.fileExists(atPath: config.path) else { return false }
+        if requiredFiles.isEmpty {
+            return directoryHasNonEmptySafetensors(url)
+        }
+        return requiredFiles.allSatisfy { name in
+            let file = url.appendingPathComponent(name)
+            return fileExistsAndNonEmpty(file)
+        }
+    }
+
+    static func fileExistsAndNonEmpty(_ url: URL) -> Bool {
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey, .isSymbolicLinkKey]) else {
+            return FileManager.default.fileExists(atPath: url.path)
+        }
+        if values.isRegularFile == true || values.isSymbolicLink == true {
+            return (values.fileSize ?? 1) > 0 || FileManager.default.fileExists(atPath: url.path)
+        }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    static func directoryHasNonEmptySafetensors(_ directory: URL) -> Bool {
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return files.contains { file in
+            file.pathExtension == "safetensors" && fileExistsAndNonEmpty(file)
+        }
+    }
+
+    /// Local directory, then Hugging Face Hub snapshot, then Hub download.
+    static func resolveDirectory(
+        spec: String,
+        requiredFiles: [String],
+        cache: HubCache,
+        hfToken: String?
+    ) async throws -> URL {
+        let expanded = (spec as NSString).expandingTildeInPath
+        let localURL = URL(fileURLWithPath: expanded)
+        if isLocalCheckpointDirectory(localURL, requiredFiles: requiredFiles) {
+            return localURL
+        }
+
+        let repoName = spec.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let repoID = Repo.ID(rawValue: repoName) else {
+            throw DramaBoxError.invalidRepositoryID(spec)
+        }
+
+        if let cached = existingCachedDirectory(repoID: repoID, requiredFiles: requiredFiles, cache: cache) {
+            return cached
+        }
+
+        return try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            hfToken: hfToken,
+            cache: cache
+        )
+    }
+
+    static func resolveGemmaDirectory(
+        spec: String,
+        cache: HubCache,
+        hfToken: String?
+    ) async throws -> URL {
+        let expanded = (spec as NSString).expandingTildeInPath
+        let localURL = URL(fileURLWithPath: expanded)
+        if isLocalCheckpointDirectory(localURL, requiredFiles: []) {
+            let tokenizer = localURL.appendingPathComponent("tokenizer.json")
+            if fileExistsAndNonEmpty(tokenizer) {
+                return localURL
+            }
+        }
+
+        guard let repoID = Repo.ID(rawValue: spec) else {
+            throw DramaBoxError.invalidRepositoryID(spec)
+        }
+
+        if let cached = existingCachedDirectory(repoID: repoID, requiredFiles: [], cache: cache) {
+            let tokenizer = cached.appendingPathComponent("tokenizer.json")
+            if fileExistsAndNonEmpty(tokenizer) {
+                return cached
+            }
+        }
+
+        return try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            additionalMatchingPatterns: ["tokenizer.json", "tokenizer.model", "*.json"],
+            hfToken: hfToken,
+            cache: cache
+        )
+    }
+
+    static func existingCachedDirectory(
+        repoID: Repo.ID,
+        requiredFiles: [String],
+        cache: HubCache
+    ) -> URL? {
+        if let snapshot = ModelUtils.existingHubSnapshot(repoID: repoID, cache: cache),
+           isLocalCheckpointDirectory(snapshot, requiredFiles: requiredFiles)
+        {
+            return snapshot
+        }
+
+        let mlxAudioDir = cache.cacheDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(repoID.description.replacingOccurrences(of: "/", with: "_"))
+        if isLocalCheckpointDirectory(mlxAudioDir, requiredFiles: requiredFiles) {
+            return mlxAudioDir
+        }
+        return nil
+    }
+
+    static func latestHubSnapshot(repoDir: URL) -> URL? {
+        ModelUtils.latestHubSnapshot(in: repoDir)
+    }
+
+    static func loadSafetensors(from directory: URL, files: [String]) throws -> [String: MLXArray] {
+        var weights: [String: MLXArray] = [:]
+        for name in files {
+            let url = directory.appendingPathComponent(name)
+            guard fileExistsAndNonEmpty(url) else {
+                throw DramaBoxError.missingCheckpoint(directory, name)
+            }
+            let loaded = try MLX.loadArrays(url: url)
+            weights.merge(loaded) { _, new in new }
+        }
+        return weights
+    }
+
+    static func loadGemmaShards(from directory: URL) throws -> [String: MLXArray] {
+        let fm = FileManager.default
+        let shards = ((try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? [])
+            .filter { url in
+                let name = url.lastPathComponent
+                return name.hasPrefix("model-") && name.hasSuffix(".safetensors")
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        let files = shards.isEmpty
+            ? [directory.appendingPathComponent("model.safetensors")]
+            : shards
+
+        var weights: [String: MLXArray] = [:]
+        for url in files {
+            guard fileExistsAndNonEmpty(url) else {
+                throw DramaBoxError.missingGemmaBackbone("No safetensors under \(directory.path)")
+            }
+            let loaded = try MLX.loadArrays(url: url)
+            weights.merge(loaded) { _, new in new }
+        }
+        return weights
+    }
+}
+
+func dramaBoxFilterPrefix(_ state: [String: MLXArray], prefix: String) -> [String: MLXArray] {
+    var out: [String: MLXArray] = [:]
+    out.reserveCapacity(state.count)
+    for (key, value) in state where key.hasPrefix(prefix) {
+        out[String(key.dropFirst(prefix.count))] = value
+    }
+    return out
+}
+
+func dramaBoxLoadModuleWeights(
+    _ module: Module,
+    state: [String: MLXArray],
+    prefix: String,
+    remap: ((String) -> String)? = nil,
+    transform: ((String, MLXArray) -> MLXArray)? = nil
+) throws {
+    var sub = dramaBoxFilterPrefix(state, prefix: prefix)
+    if let remap {
+        sub = Dictionary(uniqueKeysWithValues: sub.map { (remap($0.key), $0.value) })
+    }
+    if let transform {
+        sub = Dictionary(uniqueKeysWithValues: sub.map { ($0.key, transform($0.key, $0.value)) })
+    }
+    guard !sub.isEmpty else {
+        throw DramaBoxError.generationFailed("No weights with prefix \(prefix)")
+    }
+    try module.update(parameters: ModuleParameters.unflattened(sub), verify: .all)
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Gemma3TextBackbone.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Gemma3TextBackbone.swift
@@ -1,0 +1,253 @@
+import Foundation
+@preconcurrency import MLX
+@preconcurrency import MLXFast
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+/// Gemma 3 RMSNorm: fp32 rsqrt, then multiply by `(1 + weight)`.
+func dramaBoxGemmaRMSNorm(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
+    let origDtype = x.dtype
+    let x32 = x.asType(.float32)
+    let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)
+    let normed = x32 * MLX.rsqrt(variance + eps)
+    let out = normed * (1.0 + weight.asType(.float32))
+    return out.asType(origDtype)
+}
+
+final class DramaBoxGemmaRMSNorm: Module {
+    @ModuleInfo var weight: MLXArray
+    let eps: Float
+
+    init(_ dimensions: Int, eps: Float = 1e-6) {
+        self._weight.wrappedValue = MLXArray.zeros([dimensions])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        dramaBoxGemmaRMSNorm(x, weight: weight, eps: eps)
+    }
+}
+
+func dramaBoxGemmaRotateHalf(_ x: MLXArray) -> MLXArray {
+    let half = x.dim(-1) / 2
+    let first = x[.ellipsis, 0..<half]
+    let second = x[.ellipsis, half...]
+    return concatenated([-second, first], axis: -1)
+}
+
+func dramaBoxGemmaRopeCosSin(
+    seqLen: Int,
+    headDim: Int,
+    base: Float,
+    scalingFactor: Float = 1.0
+) -> (MLXArray, MLXArray) {
+    let idx = MLXArray(Array(stride(from: 0, to: headDim, by: 2)).map { Float($0) })
+    var inv = 1.0 / MLX.pow(MLXArray(base), idx / Float(headDim))
+    if scalingFactor != 1.0 {
+        inv = inv / scalingFactor
+    }
+    let pos = MLXArray(Array(0..<seqLen).map { Float($0) })
+    let freqs = pos.reshaped([seqLen, 1]) * inv.reshaped([1, headDim / 2])
+    let emb = concatenated([freqs, freqs], axis: -1)
+    return (MLX.cos(emb), MLX.sin(emb))
+}
+
+func dramaBoxGemmaApplyRope(
+    _ q: MLXArray,
+    _ k: MLXArray,
+    cos: MLXArray,
+    sin: MLXArray
+) -> (MLXArray, MLXArray) {
+    let cosB = cos.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    let sinB = sin.expandedDimensions(axis: 0).expandedDimensions(axis: 0)
+    let q32 = q.asType(.float32)
+    let k32 = k.asType(.float32)
+    let qRot = q32 * cosB + dramaBoxGemmaRotateHalf(q32) * sinB
+    let kRot = k32 * cosB + dramaBoxGemmaRotateHalf(k32) * sinB
+    return (qRot.asType(q.dtype), kRot.asType(k.dtype))
+}
+
+final class DramaBoxGemma3MLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+    let useTanhGELU: Bool
+
+    init(_ config: DramaBoxGemmaTextConfig) {
+        self._gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        self.useTanhGELU = config.hiddenActivation != "gelu"
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let gated = useTanhGELU ? MLXNN.geluApproximate(gateProj(x)) : MLXNN.gelu(gateProj(x))
+        return downProj(gated * upProj(x))
+    }
+}
+
+final class DramaBoxGemma3Attention: Module {
+    let numHeads: Int
+    let numKVHeads: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: DramaBoxGemmaRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: DramaBoxGemmaRMSNorm
+
+    init(_ config: DramaBoxGemmaTextConfig) {
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.headDim
+        self.scale = config.attentionScale
+        self._qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: false)
+        self._kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        self._vProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        self._oProj.wrappedValue = Linear(numHeads * headDim, config.hiddenSize, bias: false)
+        self._qNorm.wrappedValue = DramaBoxGemmaRMSNorm(headDim, eps: config.rmsNormEps)
+        self._kNorm.wrappedValue = DramaBoxGemmaRMSNorm(headDim, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cos: MLXArray, sin: MLXArray, mask: MLXArray?) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+        var q = qProj(x).reshaped(B, L, numHeads, headDim).transposed(0, 2, 1, 3)
+        var k = kProj(x).reshaped(B, L, numKVHeads, headDim).transposed(0, 2, 1, 3)
+        let v = vProj(x).reshaped(B, L, numKVHeads, headDim).transposed(0, 2, 1, 3)
+        q = qNorm(q)
+        k = kNorm(k)
+        (q, k) = dramaBoxGemmaApplyRope(q, k, cos: cos, sin: sin)
+        var out = MLXFast.scaledDotProductAttention(queries: q, keys: k, values: v, scale: scale, mask: mask)
+        out = out.transposed(0, 2, 1, 3).reshaped(B, L, -1)
+        return oProj(out)
+    }
+}
+
+final class DramaBoxGemma3DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: DramaBoxGemma3Attention
+    @ModuleInfo var mlp: DramaBoxGemma3MLP
+    @ModuleInfo(key: "input_layernorm") var inputLayernorm: DramaBoxGemmaRMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: DramaBoxGemmaRMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: DramaBoxGemmaRMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: DramaBoxGemmaRMSNorm
+
+    init(_ config: DramaBoxGemmaTextConfig) {
+        self._selfAttn.wrappedValue = DramaBoxGemma3Attention(config)
+        self._mlp.wrappedValue = DramaBoxGemma3MLP(config)
+        self._inputLayernorm.wrappedValue = DramaBoxGemmaRMSNorm(config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayernorm.wrappedValue = DramaBoxGemmaRMSNorm(config.hiddenSize, eps: config.rmsNormEps)
+        self._preFeedforwardLayernorm.wrappedValue = DramaBoxGemmaRMSNorm(config.hiddenSize, eps: config.rmsNormEps)
+        self._postFeedforwardLayernorm.wrappedValue = DramaBoxGemmaRMSNorm(config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cos: MLXArray, sin: MLXArray, mask: MLXArray?) -> MLXArray {
+        var hidden = x
+        var residual = hidden
+        hidden = selfAttn(inputLayernorm(hidden), cos: cos, sin: sin, mask: mask)
+        hidden = residual + postAttentionLayernorm(hidden)
+
+        residual = hidden
+        hidden = mlp(preFeedforwardLayernorm(hidden))
+        hidden = residual + postFeedforwardLayernorm(hidden)
+        return hidden
+    }
+}
+
+struct DramaBoxGemma3Output {
+    var lastHiddenState: MLXArray
+    /// Embedding output + each decoder layer: `numHiddenLayers + 1` tensors.
+    var hiddenStates: [MLXArray]
+}
+
+/// Headless Gemma 3 text backbone. Returns the full hidden-state stack
+/// (49 tensors for Gemma 3 12B). There is no LM head.
+final class DramaBoxGemma3TextBackbone: Module {
+    let config: DramaBoxGemmaTextConfig
+    let embedScale: Float
+    let layerTypes: [String]
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo var layers: [DramaBoxGemma3DecoderLayer]
+    @ModuleInfo var norm: DramaBoxGemmaRMSNorm
+
+    init(_ config: DramaBoxGemmaTextConfig) {
+        self.config = config
+        self.embedScale = Float(sqrt(Double(config.hiddenSize)))
+        self.layerTypes = config.layerTypes()
+        self._embedTokens.wrappedValue = Embedding(embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in DramaBoxGemma3DecoderLayer(config) }
+        self._norm.wrappedValue = DramaBoxGemmaRMSNorm(config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func buildCausalMask(attentionMask: MLXArray?, seqLen: Int, dtype: DType) -> MLXArray {
+        let qIdx = MLXArray(Array(0..<seqLen).map { Int32($0) }).reshaped([seqLen, 1])
+        let kIdx = MLXArray(Array(0..<seqLen).map { Int32($0) }).reshaped([1, seqLen])
+        let causal = qIdx .>= kIdx
+
+        let full: MLXArray
+        if let attentionMask {
+            let keep = attentionMask.asType(.bool).expandedDimensions(axis: 1)
+            full = causal.expandedDimensions(axis: 0) .&& keep
+        } else {
+            full = broadcast(causal.expandedDimensions(axis: 0), to: [1, seqLen, seqLen])
+        }
+
+        let largeNeg = MLXArray(dramaBoxFinfoMin(dtype), dtype: dtype)
+        let zero = MLXArray(0 as Float, dtype: dtype)
+        return which(full, zero, largeNeg).expandedDimensions(axis: 1)
+    }
+
+    func callAsFunction(_ inputIds: MLXArray, attentionMask: MLXArray? = nil) -> DramaBoxGemma3Output {
+        let L = inputIds.dim(1)
+        var x = embedTokens(inputIds)
+        x = x * MLXArray(embedScale, dtype: x.dtype)
+        var hiddenStates: [MLXArray] = [x]
+
+        let (cosFull, sinFull) = dramaBoxGemmaRopeCosSin(
+            seqLen: L,
+            headDim: config.headDim,
+            base: config.ropeTheta,
+            scalingFactor: config.ropeScalingFactor
+        )
+        let (cosSliding, sinSliding) = dramaBoxGemmaRopeCosSin(
+            seqLen: L,
+            headDim: config.headDim,
+            base: config.ropeLocalBaseFreq,
+            scalingFactor: 1.0
+        )
+        let mask = buildCausalMask(attentionMask: attentionMask, seqLen: L, dtype: x.dtype)
+
+        for (layer, layerType) in zip(layers, layerTypes) {
+            let (cos, sin) = layerType == "full_attention" ? (cosFull, sinFull) : (cosSliding, sinSliding)
+            x = layer(x, cos: cos, sin: sin, mask: mask)
+            hiddenStates.append(x)
+        }
+
+        return DramaBoxGemma3Output(lastHiddenState: norm(x), hiddenStates: hiddenStates)
+    }
+
+    static func load(from directory: URL) throws -> (DramaBoxGemma3TextBackbone, DramaBoxGemmaTextConfig) {
+        let config = try DramaBoxGemmaTextConfig.load(from: directory)
+        let model = DramaBoxGemma3TextBackbone(config)
+        let weights = try DramaBoxWeights.loadGemmaShards(from: directory)
+
+        if let quantization = config.quantization {
+            quantize(model: model, groupSize: quantization.groupSize, bits: quantization.bits) { path, _ in
+                weights["\(path).scales"] != nil
+            }
+        }
+
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: .all)
+        eval(model)
+        return (model, config)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXAttention.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXAttention.swift
@@ -1,0 +1,111 @@
+import Foundation
+@preconcurrency import MLX
+@preconcurrency import MLXFast
+import MLXNN
+
+final class DramaBoxLTXInnerRMSNorm: Module {
+    @ModuleInfo var weight: MLXArray
+    let eps: Float
+
+    init(_ dim: Int, eps: Float = 1e-6) {
+        self._weight.wrappedValue = MLXArray.ones([dim])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        dramaBoxFunctionalRMSNorm(x, eps: eps, weight: weight)
+    }
+}
+
+final class DramaBoxLTXAttention: Module {
+    let heads: Int
+    let dimHead: Int
+    let innerDim: Int
+    let scale: Float
+    let ropeType: String
+
+    @ModuleInfo(key: "to_q") var toQ: Linear
+    @ModuleInfo(key: "to_k") var toK: Linear
+    @ModuleInfo(key: "to_v") var toV: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: DramaBoxLTXInnerRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: DramaBoxLTXInnerRMSNorm
+    @ModuleInfo(key: "to_gate_logits") var toGateLogits: Linear?
+    /// Python `to_out = [Linear, Identity]` → keys `to_out.0.{weight,bias}`.
+    @ModuleInfo(key: "to_out") var toOut: [Linear]
+
+    init(
+        queryDim: Int,
+        heads: Int,
+        dimHead: Int,
+        contextDim: Int? = nil,
+        normEps: Float = 1e-6,
+        applyGatedAttention: Bool = false,
+        ropeType: String = "split"
+    ) {
+        self.heads = heads
+        self.dimHead = dimHead
+        self.innerDim = heads * dimHead
+        self.scale = pow(Float(dimHead), -0.5)
+        self.ropeType = ropeType
+        let ctx = contextDim ?? queryDim
+        self._toQ.wrappedValue = Linear(queryDim, innerDim, bias: true)
+        self._toK.wrappedValue = Linear(ctx, innerDim, bias: true)
+        self._toV.wrappedValue = Linear(ctx, innerDim, bias: true)
+        self._qNorm.wrappedValue = DramaBoxLTXInnerRMSNorm(innerDim, eps: normEps)
+        self._kNorm.wrappedValue = DramaBoxLTXInnerRMSNorm(innerDim, eps: normEps)
+        if applyGatedAttention {
+            self._toGateLogits.wrappedValue = Linear(queryDim, heads, bias: true)
+        } else {
+            self._toGateLogits.wrappedValue = nil
+        }
+        self._toOut.wrappedValue = [Linear(innerDim, queryDim, bias: true)]
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        context: MLXArray? = nil,
+        mask: MLXArray? = nil,
+        ropeCosSin: (MLXArray, MLXArray)? = nil,
+        skipSelfAttn: Bool = false
+    ) -> MLXArray {
+        let ctx = context ?? x
+        let B: Int
+        let Tq: Int
+        var out: MLXArray
+
+        if skipSelfAttn {
+            out = toV(ctx)
+            B = out.dim(0)
+            Tq = out.dim(1)
+        } else {
+            var q = toQ(x)
+            var k = toK(ctx)
+            let v = toV(ctx)
+            q = qNorm(q)
+            k = kNorm(k)
+            if let (cos, sin) = ropeCosSin, ropeType == "split" {
+                q = dramaBoxApplySplitRope(q, cos: cos, sin: sin)
+                k = dramaBoxApplySplitRope(k, cos: cos, sin: sin)
+            }
+            B = q.dim(0)
+            Tq = q.dim(1)
+            let Tk = k.dim(1)
+            q = q.reshaped(B, Tq, heads, dimHead).transposed(0, 2, 1, 3)
+            k = k.reshaped(B, Tk, heads, dimHead).transposed(0, 2, 1, 3)
+            let vHeads = v.reshaped(B, Tk, heads, dimHead).transposed(0, 2, 1, 3)
+            out = MLXFast.scaledDotProductAttention(
+                queries: q, keys: k, values: vHeads, scale: scale, mask: mask
+            )
+            out = out.transposed(0, 2, 1, 3).reshaped(B, Tq, heads * dimHead)
+        }
+
+        if let toGateLogits {
+            let gates = 2.0 * MLX.sigmoid(toGateLogits(x))
+            out = out.reshaped(B, Tq, heads, dimHead) * gates.expandedDimensions(axis: -1)
+            out = out.reshaped(B, Tq, heads * dimHead)
+        }
+        return toOut[0](out)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXFeedForward.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXFeedForward.swift
@@ -1,0 +1,37 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+final class DramaBoxGELUApprox: Module {
+    @ModuleInfo var proj: Linear
+
+    init(dimIn: Int, dimOut: Int) {
+        self._proj.wrappedValue = Linear(dimIn, dimOut, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXNN.geluApproximate(proj(x))
+    }
+}
+
+final class DramaBoxLTXFeedForward: Module {
+    /// Python `net = [GELUApprox, Identity, Linear]` → `net.0.proj.*` and `net.2.*`.
+    @ModuleInfo var net: [Module]
+
+    init(_ dim: Int, dimOut: Int, mult: Int = 4) {
+        let inner = dim * mult
+        self._net.wrappedValue = [
+            DramaBoxGELUApprox(dimIn: dim, dimOut: inner),
+            Identity(),
+            Linear(inner, dimOut, bias: true),
+        ]
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let gelu = net[0] as! DramaBoxGELUApprox
+        let projOut = net[2] as! Linear
+        return projOut(gelu(x))
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXRMSNorm.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXRMSNorm.swift
@@ -1,0 +1,15 @@
+import Foundation
+@preconcurrency import MLX
+
+/// Functional RMSNorm used by connector blocks and DiT AdaLN pre-norms.
+/// No learnable weight unless supplied. Compute in fp32.
+func dramaBoxFunctionalRMSNorm(_ x: MLXArray, eps: Float = 1e-6, weight: MLXArray? = nil) -> MLXArray {
+    let origDtype = x.dtype
+    let x32 = x.asType(.float32)
+    let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)
+    var out = x32 * MLX.rsqrt(variance + eps)
+    if let weight {
+        out = out * weight.asType(.float32)
+    }
+    return out.asType(origDtype)
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXRope.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/LTX/DramaBoxLTXRope.swift
@@ -1,0 +1,97 @@
+import Foundation
+@preconcurrency import MLX
+
+/// Inverse-frequency grid in Double, matching the upstream NumPy fp64 path.
+func dramaBoxGenerateFreqGrid(theta: Double, nPosDims: Int, innerDim: Int) -> MLXArray {
+    let nElem = 2 * nPosDims
+    let count = innerDim / nElem
+    let logTheta = log(theta)
+    let start = log(1.0) / logTheta
+    let end = log(theta) / logTheta
+    var values = [Float](repeating: 0, count: count)
+    if count == 1 {
+        values[0] = Float(pow(theta, start) * Double.pi / 2.0)
+    } else {
+        for i in 0..<count {
+            let t = start + (end - start) * Double(i) / Double(count - 1)
+            values[i] = Float(pow(theta, t) * Double.pi / 2.0)
+        }
+    }
+    return MLXArray(values)
+}
+
+func dramaBoxPrecomputeSplitFreqs1D(
+    seqLen: Int,
+    innerDim: Int,
+    numHeads: Int,
+    theta: Float,
+    maxPos: Int,
+    outDtype: DType
+) -> (MLXArray, MLXArray) {
+    let inv = dramaBoxGenerateFreqGrid(theta: Double(theta), nPosDims: 1, innerDim: innerDim)
+    let positions = MLXArray(Array(0..<seqLen).map { Float($0) })
+    let scaled = (positions / Float(maxPos)) * 2.0 - 1.0
+    var freqs = scaled.reshaped([seqLen, 1]) * inv.reshaped([1, inv.dim(0)])
+    freqs = freqs.reshaped([1, seqLen, freqs.dim(1)])
+
+    let expected = innerDim / 2
+    var cos = MLX.cos(freqs)
+    var sin = MLX.sin(freqs)
+    let padSize = expected - cos.dim(-1)
+    if padSize > 0 {
+        let cosPad = MLXArray.ones([1, seqLen, padSize], dtype: cos.dtype)
+        let sinPad = MLXArray.zeros([1, seqLen, padSize], dtype: sin.dtype)
+        cos = concatenated([cosPad, cos], axis: -1)
+        sin = concatenated([sinPad, sin], axis: -1)
+    }
+    cos = cos.reshaped(1, seqLen, numHeads, -1).transposed(0, 2, 1, 3)
+    sin = sin.reshaped(1, seqLen, numHeads, -1).transposed(0, 2, 1, 3)
+    return (cos.asType(outDtype), sin.asType(outDtype))
+}
+
+func dramaBoxPrecomputeSplitFreqsFromPositions(
+    positions: MLXArray,
+    innerDim: Int,
+    numHeads: Int,
+    theta: Float,
+    maxPos: Float,
+    outDtype: DType
+) -> (MLXArray, MLXArray) {
+    precondition(positions.ndim == 4 && positions.dim(-1) == 2)
+    precondition(positions.dim(1) == 1, "audio-only 1D positions")
+    let inv = dramaBoxGenerateFreqGrid(theta: Double(theta), nPosDims: 1, innerDim: innerDim)
+    let start = positions[.ellipsis, 0]
+    let end = positions[.ellipsis, 1]
+    let middle = ((start + end) / 2.0)[0..., 0, 0...]
+    let scaled = (middle / maxPos) * 2.0 - 1.0
+    let freqs = scaled.expandedDimensions(axis: -1) * inv.reshaped([1, 1, inv.dim(0)])
+
+    var cos = MLX.cos(freqs)
+    var sin = MLX.sin(freqs)
+    let expected = innerDim / 2
+    let padSize = expected - cos.dim(-1)
+    let B = cos.dim(0)
+    let T = cos.dim(1)
+    if padSize > 0 {
+        cos = concatenated([MLXArray.ones([B, T, padSize], dtype: cos.dtype), cos], axis: -1)
+        sin = concatenated([MLXArray.zeros([B, T, padSize], dtype: sin.dtype), sin], axis: -1)
+    }
+    cos = cos.reshaped(B, T, numHeads, -1).transposed(0, 2, 1, 3)
+    sin = sin.reshaped(B, T, numHeads, -1).transposed(0, 2, 1, 3)
+    return (cos.asType(outDtype), sin.asType(outDtype))
+}
+
+func dramaBoxApplySplitRope(_ x: MLXArray, cos: MLXArray, sin: MLXArray) -> MLXArray {
+    let B = x.dim(0)
+    let T = x.dim(1)
+    let H = cos.dim(1)
+    let D = cos.dim(-1) * 2
+    var work = x.reshaped(B, T, H, D).transposed(0, 2, 1, 3)
+    let half = D / 2
+    let first = work[.ellipsis, 0..<half]
+    let second = work[.ellipsis, half...]
+    let newFirst = first * cos - second * sin
+    let newSecond = second * cos + first * sin
+    work = concatenated([newFirst, newSecond], axis: -1)
+    return work.transposed(0, 2, 1, 3).reshaped(B, T, H * D)
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/LTXVGemmaTokenizer.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/LTXVGemmaTokenizer.swift
@@ -1,0 +1,113 @@
+import Foundation
+@preconcurrency import MLX
+import Tokenizers
+
+/// Plain-text Gemma tokenizer with left padding. DramaBox never applies a
+/// chat template (`<start_of_turn>` etc.); the prompt is stripped text.
+public final class LTXVGemmaTokenizer: @unchecked Sendable {
+    public let padTokenId: Int
+    public let eosTokenId: Int
+    private let encodeText: @Sendable (String) -> [Int]
+
+    public init(
+        padTokenId: Int,
+        eosTokenId: Int,
+        encodeText: @escaping @Sendable (String) -> [Int]
+    ) {
+        self.padTokenId = padTokenId
+        self.eosTokenId = eosTokenId
+        self.encodeText = encodeText
+    }
+
+    public convenience init(tokenizer: any Tokenizer, padTokenId: Int, eosTokenId: Int) {
+        self.init(
+            padTokenId: padTokenId,
+            eosTokenId: eosTokenId,
+            encodeText: { text in
+                tokenizer.encode(text: text, addSpecialTokens: true)
+            }
+        )
+    }
+
+    public static func fromDirectory(_ directory: URL) async throws -> LTXVGemmaTokenizer {
+        let tokenizerJSON = directory.appendingPathComponent("tokenizer.json")
+        guard FileManager.default.fileExists(atPath: tokenizerJSON.path) else {
+            throw DramaBoxError.missingGemmaBackbone("tokenizer.json missing at \(directory.path)")
+        }
+
+        let tokenizer = try await AutoTokenizer.from(modelFolder: directory)
+        let (padId, eosId) = resolveSpecialTokenIds(directory: directory, tokenizer: tokenizer)
+        return LTXVGemmaTokenizer(tokenizer: tokenizer, padTokenId: padId, eosTokenId: eosId)
+    }
+
+    /// Encode one string, left-padded to `maxLength`. Truncates from the
+    /// right (keeps the prefix) when the encoded sequence is longer.
+    /// Returns `(inputIds, attentionMask)` with shape `[1, maxLength]`, int32.
+    public func encode(_ text: String, maxLength: Int = 1024) -> (MLXArray, MLXArray) {
+        let stripped = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var ids = encodeText(stripped)
+        if ids.count > maxLength {
+            ids = Array(ids.prefix(maxLength))
+        }
+        let padCount = maxLength - ids.count
+        let padded = Array(repeating: padTokenId, count: padCount) + ids
+        let mask = Array(repeating: 0, count: padCount) + Array(repeating: 1, count: ids.count)
+        return (
+            MLXArray(padded.map { Int32($0) }).reshaped([1, maxLength]),
+            MLXArray(mask.map { Int32($0) }).reshaped([1, maxLength])
+        )
+    }
+
+    public func encodeBatch(_ texts: [String], maxLength: Int = 1024) -> (MLXArray, MLXArray) {
+        var idRows: [[Int32]] = []
+        var maskRows: [[Int32]] = []
+        idRows.reserveCapacity(texts.count)
+        maskRows.reserveCapacity(texts.count)
+        for text in texts {
+            let (ids, mask) = encode(text, maxLength: maxLength)
+            idRows.append(ids.asArray(Int32.self))
+            maskRows.append(mask.asArray(Int32.self))
+        }
+        return (
+            MLXArray(idRows.flatMap { $0 }).reshaped([texts.count, maxLength]),
+            MLXArray(maskRows.flatMap { $0 }).reshaped([texts.count, maxLength])
+        )
+    }
+
+    static func resolveSpecialTokenIds(
+        directory: URL,
+        tokenizer: any Tokenizer
+    ) -> (pad: Int, eos: Int) {
+        var padId = tokenizer.convertTokenToId("<pad>") ?? 0
+        var eosId = tokenizer.convertTokenToId("<eos>") ?? tokenizer.eosTokenId ?? 1
+
+        let specialMap = directory.appendingPathComponent("special_tokens_map.json")
+        guard let data = try? Data(contentsOf: specialMap),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return (padId, eosId)
+        }
+
+        if let content = specialTokenContent(payload["pad_token"]),
+           let resolved = tokenizer.convertTokenToId(content)
+        {
+            padId = resolved
+        }
+        if let content = specialTokenContent(payload["eos_token"]),
+           let resolved = tokenizer.convertTokenToId(content)
+        {
+            eosId = resolved
+        }
+        return (padId, eosId)
+    }
+
+    static func specialTokenContent(_ value: Any?) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        if let dict = value as? [String: Any], let content = dict["content"] as? String {
+            return content
+        }
+        return nil
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Prompt/DramaBoxPrompt.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Prompt/DramaBoxPrompt.swift
@@ -1,0 +1,220 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+func dramaBoxConvertToAdditiveMask(_ attentionMask: MLXArray, dtype: DType) -> MLXArray {
+    let B = attentionMask.dim(0)
+    let T = attentionMask.dim(1)
+    let maskMinusOne = (attentionMask.asType(.int32) - 1).asType(dtype).reshaped(B, 1, 1, T)
+    return maskMinusOne * MLXArray(dramaBoxFinfoMax(dtype), dtype: dtype)
+}
+
+final class DramaBoxFeatureExtractor: Module {
+    let embeddingDim: Int
+    let outFeatures: Int
+    let numLayers: Int
+    let rescale: Float
+    @ModuleInfo(key: "audio_aggregate_embed") var audioAggregateEmbed: Linear
+
+    init(embeddingDim: Int = 3840, outFeatures: Int = 2048, numLayers: Int = 49) {
+        self.embeddingDim = embeddingDim
+        self.outFeatures = outFeatures
+        self.numLayers = numLayers
+        self.rescale = Float(sqrt(Double(outFeatures) / Double(embeddingDim)))
+        self._audioAggregateEmbed.wrappedValue = Linear(
+            embeddingDim * numLayers, outFeatures, bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ hiddenStates: [MLXArray], attentionMask: MLXArray) -> MLXArray {
+        let encoded = stacked(hiddenStates, axis: -1)
+        let origDtype = encoded.dtype
+        let x32 = encoded.asType(.float32)
+        let variance = MLX.mean(x32 * x32, axis: 2, keepDims: true)
+        var normed = x32 * MLX.rsqrt(variance + 1e-6)
+        let B = encoded.dim(0)
+        let T = encoded.dim(1)
+        let D = encoded.dim(2)
+        let L = encoded.dim(3)
+        normed = normed.reshaped(B, T, D * L)
+        let mask3d = attentionMask.asType(.bool).reshaped(B, T, 1)
+        normed = which(mask3d, normed, MLXArray.zeros(like: normed))
+        normed = normed.asType(origDtype)
+        let rescaled = normed * MLXArray(rescale, dtype: origDtype)
+        return audioAggregateEmbed(rescaled)
+    }
+}
+
+final class DramaBoxBasicTransformerBlock1D: Module {
+    @ModuleInfo var attn1: DramaBoxLTXAttention
+    @ModuleInfo var ff: DramaBoxLTXFeedForward
+
+    init(dim: Int, heads: Int, dimHead: Int) {
+        self._attn1.wrappedValue = DramaBoxLTXAttention(
+            queryDim: dim,
+            heads: heads,
+            dimHead: dimHead,
+            applyGatedAttention: true,
+            ropeType: "split"
+        )
+        self._ff.wrappedValue = DramaBoxLTXFeedForward(dim, dimOut: dim)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ hiddenStates: MLXArray,
+        attentionMask: MLXArray?,
+        ropeCosSin: (MLXArray, MLXArray)?
+    ) -> MLXArray {
+        var h = hiddenStates
+        var norm = dramaBoxFunctionalRMSNorm(h)
+        h = attn1(norm, mask: attentionMask, ropeCosSin: ropeCosSin) + h
+        norm = dramaBoxFunctionalRMSNorm(h)
+        return ff(norm) + h
+    }
+}
+
+final class DramaBoxEmbeddings1DConnector: Module {
+    let numAttentionHeads: Int
+    let attentionHeadDim: Int
+    let innerDim: Int
+    let numLayers: Int
+    let numLearnableRegisters: Int
+    let positionalEmbeddingTheta: Float
+    let positionalEmbeddingMaxPos: Int
+    let seqLen: Int
+
+    @ModuleInfo(key: "learnable_registers") var learnableRegisters: MLXArray
+    @ModuleInfo(key: "transformer_1d_blocks") var transformer1dBlocks: [DramaBoxBasicTransformerBlock1D]
+
+    init(
+        numAttentionHeads: Int = 32,
+        attentionHeadDim: Int = 64,
+        numLayers: Int = 8,
+        numLearnableRegisters: Int = 128,
+        positionalEmbeddingTheta: Float = 10_000,
+        positionalEmbeddingMaxPos: Int = 4096,
+        seqLen: Int = 1024
+    ) {
+        self.numAttentionHeads = numAttentionHeads
+        self.attentionHeadDim = attentionHeadDim
+        let dim = numAttentionHeads * attentionHeadDim
+        self.innerDim = dim
+        self.numLayers = numLayers
+        self.numLearnableRegisters = numLearnableRegisters
+        self.positionalEmbeddingTheta = positionalEmbeddingTheta
+        self.positionalEmbeddingMaxPos = positionalEmbeddingMaxPos
+        self.seqLen = seqLen
+        self._learnableRegisters.wrappedValue = MLXArray.zeros([numLearnableRegisters, dim], dtype: .bfloat16)
+        self._transformer1dBlocks.wrappedValue = (0..<numLayers).map { _ in
+            DramaBoxBasicTransformerBlock1D(dim: dim, heads: numAttentionHeads, dimHead: attentionHeadDim)
+        }
+        super.init()
+    }
+
+    func packValidToFront(_ hiddenStates: MLXArray, binaryMask: MLXArray) -> MLXArray {
+        let T = binaryMask.dim(1)
+        let position = MLXArray(Array(0..<T).map { Int32($0) }).reshaped([1, T])
+        let key = binaryMask * Int32(T + 1) - position
+        let order = argSort(-key, axis: 1)
+        var packed = takeAlong(hiddenStates, order.asType(.int32).expandedDimensions(axis: 2), axis: 1)
+        let numValid = MLX.sum(binaryMask, axis: 1, keepDims: true)
+        let validMask = (MLXArray(Array(0..<T).map { Int32($0) }).reshaped([1, T]) .< numValid)
+            .asType(packed.dtype)
+        packed = packed * validMask.expandedDimensions(axis: 2)
+        return packed
+    }
+
+    func replacePaddedWithRegisters(
+        _ hiddenStates: MLXArray,
+        attentionMask: MLXArray
+    ) -> (MLXArray, MLXArray) {
+        let B = hiddenStates.dim(0)
+        let T = hiddenStates.dim(1)
+        let D = hiddenStates.dim(2)
+        let numDup = T / numLearnableRegisters
+        var tiledRegisters = tiled(learnableRegisters, repetitions: [numDup, 1])
+        tiledRegisters = MLX.broadcast(tiledRegisters, to: [B, T, D])
+        let maskBT = (attentionMask.reshaped(B, T) .>= MLXArray(Float(-9000))).asType(.int32)
+        let adjusted = packValidToFront(hiddenStates, binaryMask: maskBT)
+        let flipped = maskBT[0..., .stride(by: -1)]
+        let flipped3d = flipped.reshaped(B, T, 1).asType(hiddenStates.dtype)
+        let out = flipped3d * adjusted + (1 - flipped3d) * tiledRegisters.asType(hiddenStates.dtype)
+        return (out, MLXArray.zeros(like: attentionMask))
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray, attentionMask: MLXArray) -> (MLXArray, MLXArray) {
+        var h = hiddenStates
+        var mask = attentionMask
+        if numLearnableRegisters > 0 {
+            (h, mask) = replacePaddedWithRegisters(h, attentionMask: mask)
+        }
+        let T = h.dim(1)
+        let rope = dramaBoxPrecomputeSplitFreqs1D(
+            seqLen: T,
+            innerDim: innerDim,
+            numHeads: numAttentionHeads,
+            theta: positionalEmbeddingTheta,
+            maxPos: positionalEmbeddingMaxPos,
+            outDtype: h.dtype
+        )
+        for block in transformer1dBlocks {
+            h = block(h, attentionMask: mask, ropeCosSin: rope)
+        }
+        h = dramaBoxFunctionalRMSNorm(h)
+        return (h, mask)
+    }
+}
+
+struct DramaBoxEmbeddingsProcessorOutput {
+    var audioEncoding: MLXArray
+    var attentionMask: MLXArray
+}
+
+final class DramaBoxEmbeddingsProcessor: Module {
+    @ModuleInfo(key: "feature_extractor") var featureExtractor: DramaBoxFeatureExtractor
+    @ModuleInfo(key: "audio_connector") var audioConnector: DramaBoxEmbeddings1DConnector
+
+    init(
+        featureExtractor: DramaBoxFeatureExtractor,
+        audioConnector: DramaBoxEmbeddings1DConnector
+    ) {
+        self._featureExtractor.wrappedValue = featureExtractor
+        self._audioConnector.wrappedValue = audioConnector
+        super.init()
+    }
+
+    func callAsFunction(
+        _ hiddenStates: [MLXArray],
+        attentionMask: MLXArray
+    ) -> DramaBoxEmbeddingsProcessorOutput {
+        let audioFeats = featureExtractor(hiddenStates, attentionMask: attentionMask)
+        let additive = dramaBoxConvertToAdditiveMask(attentionMask, dtype: audioFeats.dtype)
+        let (audioEncoded, postMask) = audioConnector(audioFeats, attentionMask: additive)
+        let B = postMask.dim(0)
+        let T = postMask.dim(3)
+        return DramaBoxEmbeddingsProcessorOutput(
+            audioEncoding: audioEncoded,
+            attentionMask: MLXArray.ones([B, T], type: Int32.self)
+        )
+    }
+}
+
+func loadDramaBoxFeatureExtractorWeights(
+    _ model: DramaBoxFeatureExtractor,
+    state: [String: MLXArray]
+) throws {
+    try dramaBoxLoadModuleWeights(model, state: state, prefix: "text_embedding_projection.")
+}
+
+func loadDramaBoxConnectorWeights(
+    _ model: DramaBoxEmbeddings1DConnector,
+    state: [String: MLXArray]
+) throws {
+    try dramaBoxLoadModuleWeights(
+        model,
+        state: state,
+        prefix: "model.diffusion_model.audio_embeddings_connector."
+    )
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/README.md
+++ b/Sources/MLXAudioTTS/Models/DramaBox/README.md
@@ -1,0 +1,99 @@
+# DramaBox
+
+Resemble AI [DramaBox](https://huggingface.co/ResembleAI/Dramabox) as a `SpeechGenerationModel`: a scene prompt is encoded by a **headless Gemma 3 12B** backbone (all hidden states, no chat template), then an LTX flow-matching DiT, audio VAE, and BigVGAN+BWE vocoder render **48 kHz stereo**.
+
+This is not “Gemma generates tokens, then a vocoder speaks.” The Gemma checkpoint is an encoder only.
+
+## Weights
+
+Supported pair (App Automaton MLX conversion). These are **not** interchangeable with `mlx-community/ResembleAI-Dramabox`.
+
+| Role | Hugging Face repo |
+|------|-------------------|
+| Audio stack (DiT + VAE + vocoder + connector) | [`appautomaton/dramabox-tts-3.3b-bf16-mlx`](https://huggingface.co/appautomaton/dramabox-tts-3.3b-bf16-mlx) |
+| Text encoder | [`appautomaton/gemma-3-12b-it-backbone-4bit-mlx`](https://huggingface.co/appautomaton/gemma-3-12b-it-backbone-4bit-mlx) |
+
+Loaders accept a local directory or a Hugging Face repo id. If a Hub snapshot is already on disk (`~/.cache/huggingface/hub/models--org--name/snapshots/...`), that is used. Downloads go into that same Hub cache.
+
+## License
+
+DramaBox weights are under the **LTX-2 Community License**. The Gemma 3 backbone is under Google Gemma terms. Do not relicense either as MIT.
+
+RE-USE / SEMamba voice-ref denoising (`denoiseRef = true`) is **out of scope for v1**.
+
+## Memory
+
+mlx-speech documents ~15.7 GB persistent / ~17.3 GB peak. Target: macOS Apple Silicon with ~32 GB unified memory. English only. 48 kHz stereo `[2, T]`.
+
+## Prompt style
+
+Stage directions outside quotes; spoken text inside quotes:
+
+```
+A woman speaks clearly, "The weather today will be sunny."
+```
+
+Optional ~10 s voice reference for cloning.
+
+## Swift
+
+```swift
+import MLXAudioTTS
+import MLXAudioCore
+
+let model = try await TTS.loadModel(
+    modelRepo: "appautomaton/dramabox-tts-3.3b-bf16-mlx"
+)
+
+let audio = try await model.generate(
+    text: #"A woman speaks clearly, "The weather today will be sunny.""#,
+    voice: nil,
+    refAudio: nil,
+    refText: nil,
+    language: "English",
+    generationParameters: GenerateParameters()
+)
+// audio shape [2, T] @ 48 kHz — do not downmix
+try saveAudioArray(audio, sampleRate: Double(model.sampleRate), to: outputURL)
+```
+
+Rich path on the concrete type:
+
+```swift
+let model = try await DramaBoxModel.fromPretrained()
+let result = try await model.generate(
+    prompt: #"A woman speaks clearly, "The weather today will be sunny.""#,
+    referenceAudio: nil,
+    config: DramaBoxGenerateConfig(durationSeconds: 5.0)
+)
+```
+
+Local directories (e.g. from mlx-speech testing):
+
+```swift
+try await DramaBoxModel.fromModelDirectory(audioDir, gemmaDir: gemmaDir)
+```
+
+### Defaults (match mlx-speech)
+
+| Knob | Default |
+|------|---------|
+| `cfgScale` | 2.5 |
+| `stgScale` | 1.5 (block 29; `0` skips the extra forward) |
+| `rescaleScale` | `nil` = auto → 0.3 when cfg=2.5 |
+| `modalityScale` | 1.0 |
+| `steps` | 30 |
+| `seed` | 42 |
+| `denoiseRef` | false |
+| output | 48 kHz stereo |
+
+`GenerateParameters` AR fields (`maxTokens`, `temperature`, `topP`, …) are ignored. Do not overload `maxTokens` as duration.
+
+## CLI
+
+```bash
+swift run mlx-audio-swift-tts \
+  --model appautomaton/dramabox-tts-3.3b-bf16-mlx \
+  --text 'A woman speaks clearly, "The weather today will be sunny."' \
+  --output dramabox.wav
+```

--- a/Sources/MLXAudioTTS/Models/DramaBox/Sampling/DramaBoxGuider.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Sampling/DramaBoxGuider.swift
@@ -1,0 +1,69 @@
+import Foundation
+@preconcurrency import MLX
+
+struct DramaBoxGuiderParams: Sendable {
+    var cfgScale: Float
+    var stgScale: Float
+    var stgBlocks: [Int]
+    var rescaleScale: Float
+    var modalityScale: Float
+
+    init(
+        cfgScale: Float = 2.5,
+        stgScale: Float = 1.5,
+        stgBlocks: [Int] = [29],
+        rescaleScale: Float = 0,
+        modalityScale: Float = 1.0
+    ) {
+        self.cfgScale = cfgScale
+        self.stgScale = stgScale
+        self.stgBlocks = stgBlocks
+        self.rescaleScale = rescaleScale
+        self.modalityScale = modalityScale
+    }
+
+    var needsUncond: Bool { abs(cfgScale - 1.0) > 1e-6 }
+    var needsPtb: Bool { abs(stgScale) > 1e-6 }
+    var needsModality: Bool { abs(modalityScale - 1.0) > 1e-6 }
+
+    var stgBlockSet: Set<Int> { Set(stgBlocks) }
+}
+
+struct DramaBoxMultiModalGuider {
+    var params: DramaBoxGuiderParams
+
+    func callAsFunction(
+        cond: MLXArray,
+        uncond: MLXArray? = nil,
+        ptb: MLXArray? = nil,
+        modality: MLXArray? = nil
+    ) -> MLXArray {
+        var pred = cond
+        if params.needsUncond {
+            guard let uncond else {
+                fatalError("uncond required for non-unit cfgScale")
+            }
+            pred = pred + (params.cfgScale - 1.0) * (cond - uncond)
+        }
+        if params.needsPtb {
+            guard let ptb else {
+                fatalError("ptb required for non-zero stgScale")
+            }
+            pred = pred + params.stgScale * (cond - ptb)
+        }
+        if params.needsModality {
+            guard let modality else {
+                fatalError("modality required for non-unit modalityScale")
+            }
+            pred = pred + (params.modalityScale - 1.0) * (cond - modality)
+        }
+        if params.rescaleScale != 0 {
+            let condStd = MLX.std(cond.asType(.float32))
+            let predStd = MLX.std(pred.asType(.float32)) + 1e-8
+            var factor = condStd / predStd
+            factor = params.rescaleScale * factor + (1.0 - params.rescaleScale)
+            pred = pred * factor.asType(pred.dtype)
+        }
+        return pred
+    }
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Sampling/DramaBoxX0Model.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Sampling/DramaBoxX0Model.swift
@@ -1,0 +1,114 @@
+import Foundation
+@preconcurrency import MLX
+
+struct DramaBoxX0Model {
+    let dit: DramaBoxLTXModel
+
+    func callAsFunction(
+        _ latent: MLXArray,
+        aCtx: MLXArray,
+        sigma: MLXArray,
+        positions: MLXArray? = nil,
+        ropeCosSin: (MLXArray, MLXArray)? = nil,
+        attentionMask: MLXArray? = nil,
+        denoiseMask: MLXArray? = nil,
+        stgBlocks: Set<Int> = []
+    ) -> MLXArray {
+        let velocity = dit(
+            latent,
+            aCtx: aCtx,
+            sigma: sigma,
+            positions: positions,
+            ropeCosSin: ropeCosSin,
+            attentionMask: attentionMask,
+            denoiseMask: denoiseMask,
+            stgBlocks: stgBlocks
+        )
+        if denoiseMask == nil {
+            return dramaBoxToDenoised(latent, velocity: velocity, sigma: sigma.asArray(Float.self)[0])
+        }
+        let timesteps = sigma.asType(.float32).reshaped([-1] + Array(repeating: 1, count: latent.ndim - 1))
+            * denoiseMask!.asType(.float32)
+        return (latent.asType(.float32) - velocity.asType(.float32) * timesteps).asType(latent.dtype)
+    }
+}
+
+func dramaBoxSilencePriorFix(_ latent4d: MLXArray) -> MLXArray {
+    if latent4d.dim(2) <= 513 {
+        return latent4d
+    }
+    let a = latent4d[0..., 0..., 511, 0...]
+    let b = latent4d[0..., 0..., 514, 0...]
+    let pre = latent4d[0..., 0..., 0..<512, 0...]
+    let f512 = (a * (2.0 / 3.0) + b * (1.0 / 3.0)).expandedDimensions(axis: 2)
+    let f513 = (a * (1.0 / 3.0) + b * (2.0 / 3.0)).expandedDimensions(axis: 2)
+    let post = latent4d[0..., 0..., 514..., 0...]
+    return concatenated([pre, f512, f513, post], axis: 2)
+}
+
+func dramaBoxEulerDenoisingLoop(
+    _ state: DramaBoxLatentState,
+    sigmas: MLXArray,
+    x0Model: DramaBoxX0Model,
+    aCtx: MLXArray,
+    aCtxNeg: MLXArray?,
+    params: DramaBoxGuiderParams,
+    positions: MLXArray? = nil,
+    denoiseMask: MLXArray? = nil
+) -> DramaBoxLatentState {
+    let guider = DramaBoxMultiModalGuider(params: params)
+    let nSteps = sigmas.dim(0) - 1
+    var state = state
+    for i in 0..<nSteps {
+        let sigma = sigmas[i]
+        let sigmaNext = sigmas[i + 1]
+        let sigmaBatched = MLX.broadcast(sigma.reshaped([1]), to: [state.latent.dim(0)])
+        let cond = x0Model(
+            state.latent,
+            aCtx: aCtx,
+            sigma: sigmaBatched,
+            positions: positions,
+            attentionMask: state.attentionMask,
+            denoiseMask: denoiseMask
+        )
+        let uncond: MLXArray? = if params.needsUncond, let aCtxNeg {
+            x0Model(
+                state.latent,
+                aCtx: aCtxNeg,
+                sigma: sigmaBatched,
+                positions: positions,
+                attentionMask: state.attentionMask,
+                denoiseMask: denoiseMask
+            )
+        } else {
+            nil
+        }
+        let ptb: MLXArray? = if params.needsPtb {
+            x0Model(
+                state.latent,
+                aCtx: aCtx,
+                sigma: sigmaBatched,
+                positions: positions,
+                attentionMask: state.attentionMask,
+                denoiseMask: denoiseMask,
+                stgBlocks: params.stgBlockSet
+            )
+        } else {
+            nil
+        }
+        var pred = guider(cond: cond, uncond: uncond, ptb: ptb, modality: nil)
+        pred = dramaBoxPostProcessLatent(
+            denoised: pred,
+            denoiseMask: state.denoiseMask,
+            cleanLatent: state.cleanLatent
+        )
+        let sigmaVal = sigma.asArray(Float.self)[0]
+        if sigmaVal == 0 { break }
+        let velocity = dramaBoxToVelocity(state.latent, sigma: sigmaVal, denoised: pred)
+        let dt = sigmaNext.asArray(Float.self)[0] - sigmaVal
+        let newLatent = state.latent.asType(.float32) + velocity.asType(.float32) * dt
+        state = state.replacing(latent: newLatent.asType(state.latent.dtype))
+        eval(state.latent)
+    }
+    return state
+}

--- a/Sources/MLXAudioTTS/Models/DramaBox/Vocoder/DramaBoxVocoder.swift
+++ b/Sources/MLXAudioTTS/Models/DramaBox/Vocoder/DramaBoxVocoder.swift
@@ -1,0 +1,507 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+func dramaBoxConv1dBCT(_ conv: Conv1d, _ x: MLXArray) -> MLXArray {
+    conv(x.transposed(0, 2, 1)).transposed(0, 2, 1)
+}
+
+func dramaBoxConvTransposed1dBCT(_ conv: ConvTransposed1d, _ x: MLXArray) -> MLXArray {
+    conv(x.transposed(0, 2, 1)).transposed(0, 2, 1)
+}
+
+func dramaBoxReplicatePad1d(_ x: MLXArray, left: Int, right: Int) -> MLXArray {
+    if left == 0 && right == 0 { return x }
+    var parts: [MLXArray] = []
+    if left > 0 {
+        parts.append(MLX.broadcast(x[.ellipsis, 0..<1], to: [x.dim(0), x.dim(1), left]))
+    }
+    parts.append(x)
+    if right > 0 {
+        parts.append(MLX.broadcast(x[.ellipsis, (x.dim(2) - 1)...], to: [x.dim(0), x.dim(1), right]))
+    }
+    return concatenated(parts, axis: -1)
+}
+
+func dramaBoxDepthwiseConv1d(_ x: MLXArray, filter: MLXArray, stride: Int) -> MLXArray {
+    let C = x.dim(1)
+    let K = filter.dim(-1)
+    let xCL = x.transposed(0, 2, 1)
+    let w = MLX.broadcast(filter.reshaped([1, K, 1]), to: [C, K, 1]).asType(x.dtype)
+    return MLX.conv1d(xCL, w, stride: stride, padding: 0, groups: C).transposed(0, 2, 1)
+}
+
+func dramaBoxDepthwiseConvTranspose1d(
+    _ x: MLXArray,
+    filter: MLXArray,
+    stride: Int,
+    scale: Float
+) -> MLXArray {
+    let C = x.dim(1)
+    let K = filter.dim(-1)
+    let xCL = x.transposed(0, 2, 1)
+    let w = MLX.broadcast(filter.reshaped([1, K, 1]), to: [C, K, 1]).asType(x.dtype) * scale
+    return MLX.convTransposed1d(xCL, w, stride: stride, padding: 0, groups: C).transposed(0, 2, 1)
+}
+
+final class DramaBoxSnakeBeta: Module {
+    @ModuleInfo var alpha: MLXArray
+    @ModuleInfo var beta: MLXArray
+    let alphaLogscale: Bool
+    let eps: Float
+
+    init(channels: Int, alphaLogscale: Bool = true) {
+        self._alpha.wrappedValue = MLXArray.zeros([channels])
+        self._beta.wrappedValue = MLXArray.zeros([channels])
+        self.alphaLogscale = alphaLogscale
+        self.eps = 1e-9
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var a = alpha.asType(x.dtype)
+        var b = beta.asType(x.dtype)
+        if alphaLogscale {
+            a = MLX.exp(a)
+            b = MLX.exp(b)
+        }
+        a = a.reshaped([1, a.dim(0), 1])
+        b = b.reshaped([1, b.dim(0), 1])
+        return x + (1.0 / (b + eps)) * MLX.sin(x * a) * MLX.sin(x * a)
+    }
+}
+
+final class DramaBoxLowPassFilter1d: Module {
+    @ModuleInfo var filter: MLXArray
+    let kernelSize: Int
+    let padLeft: Int
+    let padRight: Int
+    let stride: Int
+
+    init(kernelSize: Int = 12, stride: Int = 1) {
+        self.kernelSize = kernelSize
+        let even = kernelSize.isMultiple(of: 2)
+        self.padLeft = kernelSize / 2 - (even ? 1 : 0)
+        self.padRight = kernelSize / 2
+        self.stride = stride
+        self._filter.wrappedValue = MLXArray.zeros([1, 1, kernelSize])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let padded = dramaBoxReplicatePad1d(x, left: padLeft, right: padRight)
+        return dramaBoxDepthwiseConv1d(padded, filter: filter, stride: stride)
+    }
+}
+
+final class DramaBoxUpSample1d: Module {
+    @ModuleInfo var filter: MLXArray
+    let ratio: Int
+    let kernelSize: Int
+    let pad: Int
+    let padLeft: Int
+    let padRight: Int
+
+    init(ratio: Int = 2, kernelSize: Int = 12) {
+        self.ratio = ratio
+        self.kernelSize = kernelSize
+        self.pad = kernelSize / ratio - 1
+        self.padLeft = pad * ratio + (kernelSize - ratio) / 2
+        self.padRight = pad * ratio + (kernelSize - ratio + 1) / 2
+        self._filter.wrappedValue = MLXArray.zeros([1, 1, kernelSize])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = dramaBoxReplicatePad1d(x, left: pad, right: pad)
+        y = dramaBoxDepthwiseConvTranspose1d(y, filter: filter, stride: ratio, scale: Float(ratio))
+        let end = y.dim(-1) - padRight
+        return y[.ellipsis, padLeft..<end]
+    }
+}
+
+final class DramaBoxDownSample1d: Module {
+    @ModuleInfo var lowpass: DramaBoxLowPassFilter1d
+
+    init(ratio: Int = 2, kernelSize: Int = 12) {
+        self._lowpass.wrappedValue = DramaBoxLowPassFilter1d(kernelSize: kernelSize, stride: ratio)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        lowpass(x)
+    }
+}
+
+final class DramaBoxActivation1d: Module {
+    @ModuleInfo var act: DramaBoxSnakeBeta
+    @ModuleInfo var upsample: DramaBoxUpSample1d
+    @ModuleInfo var downsample: DramaBoxDownSample1d
+
+    init(channels: Int, upRatio: Int = 2, downRatio: Int = 2, kernelSize: Int = 12) {
+        self._act.wrappedValue = DramaBoxSnakeBeta(channels: channels)
+        self._upsample.wrappedValue = DramaBoxUpSample1d(ratio: upRatio, kernelSize: kernelSize)
+        self._downsample.wrappedValue = DramaBoxDownSample1d(ratio: downRatio, kernelSize: kernelSize)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downsample(act(upsample(x)))
+    }
+}
+
+struct DramaBoxHannSincUpsampler {
+    let ratio: Int
+    let kernelSize: Int
+    let pad: Int
+    let padLeft: Int
+    let padRight: Int
+    let filter: MLXArray
+
+    init(ratio: Int) {
+        self.ratio = ratio
+        let rolloff = 0.99
+        let lowpassFilterWidth = 6.0
+        let width = Int(ceil(lowpassFilterWidth / rolloff))
+        self.kernelSize = 2 * width * ratio + 1
+        self.pad = width
+        self.padLeft = 2 * width * ratio
+        self.padRight = kernelSize - ratio
+        var filt = [Float](repeating: 0, count: kernelSize)
+        for i in 0..<kernelSize {
+            let t = (Double(i) / Double(ratio) - Double(width)) * rolloff
+            let tClamped = min(max(t, -lowpassFilterWidth), lowpassFilterWidth)
+            let window = pow(cos(tClamped * Double.pi / lowpassFilterWidth / 2.0), 2)
+            let sinc = t == 0 ? 1.0 : sin(Double.pi * t) / (Double.pi * t)
+            filt[i] = Float(sinc * window * rolloff / Double(ratio))
+        }
+        self.filter = MLXArray(filt).reshaped([1, 1, kernelSize])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = dramaBoxReplicatePad1d(x, left: pad, right: pad)
+        y = dramaBoxDepthwiseConvTranspose1d(y, filter: filter, stride: ratio, scale: Float(ratio))
+        let end = y.dim(-1) - padRight
+        return y[.ellipsis, padLeft..<end]
+    }
+}
+
+struct DramaBoxVocoderArgs: Sendable {
+    var upsampleInitialChannel: Int
+    var upsampleRates: [Int]
+    var upsampleKernelSizes: [Int]
+    var resblockKernelSizes: [Int]
+    var resblockDilationSizes: [[Int]]
+    var inChannels: Int
+    var outChannels: Int
+    var useTanhAtFinal: Bool
+    var applyFinalActivation: Bool
+    var useBiasAtFinal: Bool
+
+    var numUpsamples: Int { upsampleRates.count }
+    var numKernels: Int { resblockKernelSizes.count }
+    var finalChannels: Int {
+        var ch = upsampleInitialChannel
+        for _ in upsampleRates { ch /= 2 }
+        return ch
+    }
+
+    static let main = DramaBoxVocoderArgs(
+        upsampleInitialChannel: 1536,
+        upsampleRates: [5, 2, 2, 2, 2, 2],
+        upsampleKernelSizes: [11, 4, 4, 4, 4, 4],
+        resblockKernelSizes: [3, 7, 11],
+        resblockDilationSizes: [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        inChannels: 128,
+        outChannels: 2,
+        useTanhAtFinal: false,
+        applyFinalActivation: true,
+        useBiasAtFinal: false
+    )
+
+    static let bwe = DramaBoxVocoderArgs(
+        upsampleInitialChannel: 512,
+        upsampleRates: [6, 5, 2, 2, 2],
+        upsampleKernelSizes: [12, 11, 4, 4, 4],
+        resblockKernelSizes: [3, 7, 11],
+        resblockDilationSizes: [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        inChannels: 128,
+        outChannels: 2,
+        useTanhAtFinal: false,
+        applyFinalActivation: false,
+        useBiasAtFinal: false
+    )
+}
+
+final class DramaBoxAMPBlock1: Module {
+    @ModuleInfo var convs1: [Conv1d]
+    @ModuleInfo var convs2: [Conv1d]
+    @ModuleInfo var acts1: [DramaBoxActivation1d]
+    @ModuleInfo var acts2: [DramaBoxActivation1d]
+
+    init(channels: Int, kernelSize: Int, dilation: [Int] = [1, 3, 5]) {
+        func padding(_ k: Int, _ d: Int) -> Int { (k * d - d) / 2 }
+        self._convs1.wrappedValue = dilation.map { d in
+            Conv1d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: kernelSize,
+                stride: 1,
+                padding: padding(kernelSize, d),
+                dilation: d,
+                bias: true
+            )
+        }
+        self._convs2.wrappedValue = dilation.map { _ in
+            Conv1d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: kernelSize,
+                stride: 1,
+                padding: padding(kernelSize, 1),
+                dilation: 1,
+                bias: true
+            )
+        }
+        self._acts1.wrappedValue = dilation.map { _ in DramaBoxActivation1d(channels: channels) }
+        self._acts2.wrappedValue = dilation.map { _ in DramaBoxActivation1d(channels: channels) }
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = x
+        for i in 0..<convs1.count {
+            var xt = acts1[i](y)
+            xt = dramaBoxConv1dBCT(convs1[i], xt)
+            xt = acts2[i](xt)
+            xt = dramaBoxConv1dBCT(convs2[i], xt)
+            y = y + xt
+        }
+        return y
+    }
+}
+
+final class DramaBoxVocoder: Module {
+    let args: DramaBoxVocoderArgs
+    @ModuleInfo(key: "conv_pre") var convPre: Conv1d
+    @ModuleInfo var ups: [ConvTransposed1d]
+    @ModuleInfo var resblocks: [DramaBoxAMPBlock1]
+    @ModuleInfo(key: "act_post") var actPost: DramaBoxActivation1d
+    @ModuleInfo(key: "conv_post") var convPost: Conv1d
+
+    init(_ args: DramaBoxVocoderArgs) {
+        self.args = args
+        var ch = args.upsampleInitialChannel
+        self._convPre.wrappedValue = Conv1d(
+            inputChannels: args.inChannels, outputChannels: ch, kernelSize: 7, stride: 1, padding: 3, bias: true
+        )
+        var ups: [ConvTransposed1d] = []
+        for (stride, ks) in zip(args.upsampleRates, args.upsampleKernelSizes) {
+            ups.append(
+                ConvTransposed1d(
+                    inputChannels: ch,
+                    outputChannels: ch / 2,
+                    kernelSize: ks,
+                    stride: stride,
+                    padding: (ks - stride) / 2
+                )
+            )
+            ch /= 2
+        }
+        self._ups.wrappedValue = ups
+        var resblocks: [DramaBoxAMPBlock1] = []
+        ch = args.upsampleInitialChannel
+        for _ in 0..<args.numUpsamples {
+            ch /= 2
+            for (k, d) in zip(args.resblockKernelSizes, args.resblockDilationSizes) {
+                resblocks.append(DramaBoxAMPBlock1(channels: ch, kernelSize: k, dilation: d))
+            }
+        }
+        self._resblocks.wrappedValue = resblocks
+        self._actPost.wrappedValue = DramaBoxActivation1d(channels: args.finalChannels)
+        self._convPost.wrappedValue = Conv1d(
+            inputChannels: args.finalChannels,
+            outputChannels: args.outChannels,
+            kernelSize: 7,
+            stride: 1,
+            padding: 3,
+            bias: args.useBiasAtFinal
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ mel: MLXArray) -> MLXArray {
+        var x: MLXArray
+        if mel.ndim == 4 {
+            x = mel.transposed(0, 1, 3, 2)
+            let B = x.dim(0)
+            let S = x.dim(1)
+            let F = x.dim(2)
+            let T = x.dim(3)
+            x = x.reshaped(B, S * F, T)
+        } else {
+            x = mel.transposed(0, 2, 1)
+        }
+        x = dramaBoxConv1dBCT(convPre, x)
+        for i in 0..<args.numUpsamples {
+            x = dramaBoxConvTransposed1dBCT(ups[i], x)
+            let start = i * args.numKernels
+            let end = start + args.numKernels
+            var outs: [MLXArray] = []
+            for idx in start..<end {
+                outs.append(resblocks[idx](x))
+            }
+            x = MLX.mean(stacked(outs, axis: 0), axis: 0)
+        }
+        x = actPost(x)
+        x = dramaBoxConv1dBCT(convPost, x)
+        if args.applyFinalActivation {
+            if args.useTanhAtFinal {
+                x = MLX.tanh(x)
+            } else {
+                x = MLX.clip(x, min: -1, max: 1)
+            }
+        }
+        return x
+    }
+}
+
+final class DramaBoxSTFTFn: Module {
+    let filterLength: Int
+    let hopLength: Int
+    let winLength: Int
+    @ModuleInfo(key: "forward_basis") var forwardBasis: MLXArray
+    @ModuleInfo(key: "inverse_basis") var inverseBasis: MLXArray
+
+    init(filterLength: Int, hopLength: Int, winLength: Int) {
+        self.filterLength = filterLength
+        self.hopLength = hopLength
+        self.winLength = winLength
+        let nFreqs = filterLength / 2 + 1
+        self._forwardBasis.wrappedValue = MLXArray.zeros([2 * nFreqs, 1, filterLength])
+        self._inverseBasis.wrappedValue = MLXArray.zeros([2 * nFreqs, 1, filterLength])
+        super.init()
+    }
+
+    func callAsFunction(_ y: MLXArray) -> (MLXArray, MLXArray) {
+        var work = y.ndim == 2 ? y.expandedDimensions(axis: 1) : y
+        let leftPad = max(0, winLength - hopLength)
+        if leftPad > 0 {
+            let pad = MLXArray.zeros([work.dim(0), work.dim(1), leftPad], dtype: work.dtype)
+            work = concatenated([pad, work], axis: -1)
+        }
+        let yCL = work.transposed(0, 2, 1)
+        let w = forwardBasis.transposed(0, 2, 1)
+        var spec = MLX.conv1d(yCL, w.asType(yCL.dtype), stride: hopLength, padding: 0)
+        spec = spec.transposed(0, 2, 1)
+        let nFreqs = spec.dim(1) / 2
+        let real = spec[0..., 0..<nFreqs]
+        let imag = spec[0..., nFreqs...]
+        let magnitude = MLX.sqrt(real * real + imag * imag)
+        let phase = MLX.atan2(imag.asType(.float32), real.asType(.float32)).asType(real.dtype)
+        return (magnitude, phase)
+    }
+}
+
+final class DramaBoxMelSTFT: Module {
+    @ModuleInfo(key: "stft_fn") var stftFn: DramaBoxSTFTFn
+    @ModuleInfo(key: "mel_basis") var melBasis: MLXArray
+
+    init(filterLength: Int = 512, hopLength: Int = 80, winLength: Int = 512, nMelChannels: Int = 64) {
+        self._stftFn.wrappedValue = DramaBoxSTFTFn(
+            filterLength: filterLength, hopLength: hopLength, winLength: winLength
+        )
+        let nFreqs = filterLength / 2 + 1
+        self._melBasis.wrappedValue = MLXArray.zeros([nMelChannels, nFreqs])
+        super.init()
+    }
+
+    func melSpectrogram(_ y: MLXArray) -> MLXArray {
+        let (magnitude, _) = stftFn(y)
+        let mel = MLX.matmul(melBasis.asType(magnitude.dtype), magnitude)
+        return MLX.log(MLX.maximum(mel, MLXArray(Float(1e-5))))
+    }
+}
+
+final class DramaBoxVocoderWithBWE: Module {
+    let inputSamplingRate: Int
+    let outputSamplingRate: Int
+    let hopLength: Int
+    let ratio: Int
+    let skipResampler: DramaBoxHannSincUpsampler
+
+    @ModuleInfo var vocoder: DramaBoxVocoder
+    @ModuleInfo(key: "bwe_generator") var bweGenerator: DramaBoxVocoder
+    @ModuleInfo(key: "mel_stft") var melSTFT: DramaBoxMelSTFT
+
+    init(
+        mainArgs: DramaBoxVocoderArgs = .main,
+        bweArgs: DramaBoxVocoderArgs = .bwe,
+        inputSamplingRate: Int = 16_000,
+        outputSamplingRate: Int = 48_000,
+        hopLength: Int = 80,
+        nFft: Int = 512,
+        winLength: Int = 512,
+        nMelChannels: Int = 64
+    ) {
+        self.inputSamplingRate = inputSamplingRate
+        self.outputSamplingRate = outputSamplingRate
+        self.hopLength = hopLength
+        self.ratio = outputSamplingRate / inputSamplingRate
+        self.skipResampler = DramaBoxHannSincUpsampler(ratio: ratio)
+        self._vocoder.wrappedValue = DramaBoxVocoder(mainArgs)
+        self._bweGenerator.wrappedValue = DramaBoxVocoder(bweArgs)
+        self._melSTFT.wrappedValue = DramaBoxMelSTFT(
+            filterLength: nFft, hopLength: hopLength, winLength: winLength, nMelChannels: nMelChannels
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ melSpec: MLXArray) -> MLXArray {
+        let inputDtype = melSpec.dtype
+        let mel32 = melSpec.asType(.float32)
+        var x = vocoder(mel32)
+        let tLow = x.dim(-1)
+        let outputLength = tLow * outputSamplingRate / inputSamplingRate
+        let remainder = tLow % hopLength
+        if remainder != 0 {
+            let pad = MLXArray.zeros([x.dim(0), x.dim(1), hopLength - remainder], dtype: x.dtype)
+            x = concatenated([x, pad], axis: -1)
+        }
+        let B = x.dim(0)
+        let C = x.dim(1)
+        let T = x.dim(2)
+        let flat = x.reshaped(B * C, T)
+        let mel = melSTFT.melSpectrogram(flat)
+        let stereoMel = mel.reshaped(B, C, mel.dim(1), mel.dim(2))
+        let melForBWE = stereoMel.transposed(0, 1, 3, 2)
+        var residual = bweGenerator(melForBWE)
+        var skip = skipResampler(x)
+        let targetLen = min(skip.dim(-1), residual.dim(-1))
+        skip = skip[.ellipsis, 0..<targetLen]
+        residual = residual[.ellipsis, 0..<targetLen]
+        let out = MLX.clip(residual + skip, min: -1, max: 1)[.ellipsis, 0..<outputLength]
+        return out.asType(inputDtype)
+    }
+}
+
+func loadDramaBoxVocoderWeights(_ model: DramaBoxVocoderWithBWE, state: [String: MLXArray]) throws {
+    let prefix = "vocoder."
+    var sub: [String: MLXArray] = [:]
+    for (key, value) in state where key.hasPrefix(prefix) {
+        let tail = String(key.dropFirst(prefix.count))
+        var tensor = value
+        if tensor.ndim == 3 && tail.hasSuffix(".weight") {
+            if tail.contains(".ups.") {
+                tensor = tensor.transposed(1, 2, 0)
+            } else {
+                tensor = tensor.transposed(0, 2, 1)
+            }
+        }
+        sub[tail] = tensor
+    }
+    guard !sub.isEmpty else {
+        throw DramaBoxError.generationFailed("No vocoder weights")
+    }
+    try model.update(parameters: ModuleParameters.unflattened(sub), verify: .all)
+}

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -54,11 +54,18 @@ public enum TTS {
             throw TTSModelError.invalidRepositoryID(modelRepo)
         }
 
-        let modelType = try await ModelUtils.resolveModelType(
-            repoID: repoID,
-            hfToken: hfToken,
-            cache: cache
-        )
+        // Do not download a repo just to read config.json when the id already
+        // identifies the family. Hub snapshot reuse happens in the model loader.
+        let modelType: String?
+        if let inferred = inferModelType(from: modelRepo) {
+            modelType = inferred
+        } else {
+            modelType = try await ModelUtils.resolveModelType(
+                repoID: repoID,
+                hfToken: hfToken,
+                cache: cache
+            )
+        }
         return try await loadResolvedModel(
             modelType: modelType,
             source: .repository(modelRepo, cache: cache),
@@ -214,6 +221,13 @@ public enum TTS {
                 pretrained: { try await IndexTTSModel.fromPretrained($0, cache: $1) },
                 local: { modelDir, _ in try await IndexTTSModel.fromModelDirectory(modelDir) }
             )
+        case "dramabox", "dramabox-tts", "dramabox_tts":
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await DramaBoxModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await DramaBoxModel.fromModelDirectory(modelDir) }
+            )
         default:
             throw TTSModelError.unsupportedModelType(resolvedType)
         }
@@ -328,6 +342,9 @@ public enum TTS {
         }
         if lower.contains("indextts") || lower.contains("index-tts") || lower.contains("index_tts") {
             return "indextts"
+        }
+        if lower.contains("dramabox") {
+            return "dramabox"
         }
         return nil
     }

--- a/Tests/DramaBoxTests.swift
+++ b/Tests/DramaBoxTests.swift
@@ -1,0 +1,431 @@
+import Foundation
+import HuggingFace
+import MLX
+import MLXNN
+import Testing
+
+@testable import MLXAudioCore
+@testable import MLXAudioTTS
+
+@Suite("DramaBox")
+struct DramaBoxTests {
+    @Test func defaultReposAndModelType() {
+        #expect(dramaBoxDefaultAudioRepository == "appautomaton/dramabox-tts-3.3b-bf16-mlx")
+        #expect(dramaBoxDefaultGemmaRepository == "appautomaton/gemma-3-12b-it-backbone-4bit-mlx")
+        #expect(Repo.ID(rawValue: "dramabox") == nil)
+        #expect(
+            TTS.resolveModelType(modelRepo: "appautomaton/dramabox-tts-3.3b-bf16-mlx") == "dramabox"
+        )
+        #expect(TTS.resolveModelType(modelRepo: "dramabox-tts") == "dramabox")
+    }
+
+    @Test func autoRescaleSchedule() {
+        #expect(dramaBoxAutoRescaleForCfg(1.0) == 0)
+        #expect(dramaBoxAutoRescaleForCfg(2.0) == 0)
+        #expect(abs(dramaBoxAutoRescaleForCfg(2.5) - 0.30) < 1e-6)
+        #expect(abs(dramaBoxAutoRescaleForCfg(3.0) - 0.60) < 1e-6)
+        #expect(abs(dramaBoxAutoRescaleForCfg(4.0) - 0.80) < 1e-6)
+        #expect(abs(dramaBoxAutoRescaleForCfg(8.0) - 0.80) < 1e-6)
+        #expect(abs(dramaBoxAutoRescaleForCfg(10.0) - 1.0) < 1e-6)
+    }
+
+    @Test func gemmaConfigLayerTypesFor12B() throws {
+        let cfg = DramaBoxGemmaTextConfig(
+            hiddenSize: 3840,
+            intermediateSize: 15_360,
+            numHiddenLayers: 48,
+            numAttentionHeads: 16,
+            numKeyValueHeads: 8,
+            headDim: 256,
+            vocabSize: 262_208,
+            slidingWindowPattern: 6
+        )
+        let types = cfg.layerTypes()
+        let full = types.enumerated().compactMap { $0.element == "full_attention" ? $0.offset : nil }
+        #expect(full == [5, 11, 17, 23, 29, 35, 41, 47])
+        #expect(cfg.hiddenStateCount == 49)
+        #expect(abs(cfg.attentionScale - pow(256.0, -0.5)) < 1e-6)
+    }
+
+    @Test func gemmaConfigParsesWrappedJSON() throws {
+        let payload: [String: Any] = [
+            "text_config": [
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "vocab_size": 50,
+            ],
+            "quantization": ["group_size": 64, "bits": 4, "mode": "affine"],
+        ]
+        let cfg = try DramaBoxGemmaTextConfig.fromJSONObject(payload)
+        #expect(cfg.hiddenSize == 32)
+        #expect(cfg.headDim == 8)
+        #expect(cfg.quantization?.groupSize == 64)
+        #expect(cfg.quantization?.bits == 4)
+    }
+
+    @Test func tokenizerLeftPadsAndStripsWithoutChatTemplate() {
+        let vocab: [String: Int] = [
+            "<pad>": 0, "<eos>": 1, "hello": 3, "world": 4,
+        ]
+        let tokenizer = LTXVGemmaTokenizer(padTokenId: 0, eosTokenId: 1) { text in
+            #expect(!text.contains("<start_of_turn>"))
+            return text.split(separator: " ").compactMap { vocab[String($0)] }
+        }
+
+        let (ids, mask) = tokenizer.encode("hello", maxLength: 8)
+        #expect(ids.shape == [1, 8])
+        #expect(mask.shape == [1, 8])
+        #expect(ids.dtype == .int32)
+        #expect(mask.dtype == .int32)
+        let maskVals = mask.asArray(Int32.self)
+        #expect(maskVals.last == 1)
+        #expect(maskVals.first == 0)
+
+        let (a, _) = tokenizer.encode("hello world", maxLength: 16)
+        let (b, _) = tokenizer.encode("   hello world   ", maxLength: 16)
+        #expect(a.asArray(Int32.self) == b.asArray(Int32.self))
+
+        let long = Array(repeating: "hello", count: 40).joined(separator: " ")
+        let (_, longMask) = tokenizer.encode(long, maxLength: 8)
+        #expect(Int(longMask.sum().item(Int32.self)) == 8)
+    }
+
+    @Test func tokenizerDoesNotWrapWithGemmaChatTemplate() {
+        let tokenizer = LTXVGemmaTokenizer(padTokenId: 0, eosTokenId: 1) { text in
+            #expect(!text.contains("<start_of_turn>"))
+            #expect(!text.contains("<end_of_turn>"))
+            return [7, 8, 9]
+        }
+        _ = tokenizer.encode(
+            #"A woman speaks clearly, "The weather today will be sunny.""#,
+            maxLength: 16
+        )
+    }
+
+    @Test func bfloat16AttentionFillIsFinite() {
+        let fill = MLXArray(dramaBoxFinfoMin(.bfloat16), dtype: .bfloat16)
+        #expect(MLX.all(MLX.isFinite(fill)).item(Bool.self))
+        #expect(Float.greatestFiniteMagnitude != dramaBoxFinfoMax(.bfloat16))
+    }
+
+    @Test func gemmaRMSNormZeroWeightIsUnitNorm() {
+        let x = MLXArray([1.0, 2.0, 2.0, 4.0] as [Float]).reshaped([1, 4])
+        let w = MLXArray.zeros([4])
+        let y = dramaBoxGemmaRMSNorm(x, weight: w, eps: 1e-6)
+        let rms = MLX.sqrt(MLX.mean(x * x, axis: -1, keepDims: true))
+        let expected = x / rms
+        #expect(MLX.allClose(y, expected, atol: 1e-5).item(Bool.self))
+    }
+
+    @Test func gemmaRMSNormNegativeOneWeightIsZero() {
+        let x = MLXArray([1.0, 2.0, 3.0, 4.0] as [Float]).reshaped([1, 4])
+        let w = -MLXArray.ones([4])
+        let y = dramaBoxGemmaRMSNorm(x, weight: w, eps: 1e-6)
+        #expect(MLX.allClose(y, MLXArray.zeros(like: y), atol: 1e-6).item(Bool.self))
+    }
+
+    @Test func tinyBackboneReturnsFullHiddenStack() {
+        let cfg = DramaBoxGemmaTextConfig(
+            hiddenSize: 16,
+            intermediateSize: 32,
+            numHiddenLayers: 4,
+            numAttentionHeads: 4,
+            numKeyValueHeads: 2,
+            headDim: 4,
+            vocabSize: 32,
+            slidingWindow: 8,
+            slidingWindowPattern: 2,
+            queryPreAttnScalar: 4
+        )
+        let model = DramaBoxGemma3TextBackbone(cfg)
+        let inputIds = MLXArray([Int32(1), 2, 3, 4, 5]).reshaped([1, 5])
+        let mask = MLXArray.ones([1, 5], type: Int32.self)
+        let out = model(inputIds, attentionMask: mask)
+        #expect(out.hiddenStates.count == cfg.hiddenStateCount)
+        for hidden in out.hiddenStates {
+            #expect(hidden.shape == [1, 5, cfg.hiddenSize])
+        }
+        #expect(out.lastHiddenState.shape == [1, 5, cfg.hiddenSize])
+        #expect(MLX.all(MLX.isFinite(out.lastHiddenState)).item(Bool.self))
+    }
+
+    @Test func tinyBackboneLeftPadMaskIsFinite() {
+        let cfg = DramaBoxGemmaTextConfig(
+            hiddenSize: 16,
+            intermediateSize: 32,
+            numHiddenLayers: 2,
+            numAttentionHeads: 4,
+            numKeyValueHeads: 2,
+            headDim: 4,
+            vocabSize: 32,
+            queryPreAttnScalar: 4
+        )
+        let model = DramaBoxGemma3TextBackbone(cfg)
+        let inputIds = MLXArray([Int32(0), 0, 0, 7, 8]).reshaped([1, 5])
+        let mask = MLXArray([Int32(0), 0, 0, 1, 1]).reshaped([1, 5])
+        let out = model(inputIds, attentionMask: mask)
+        let last = out.lastHiddenState[0, 3...]
+        #expect(MLX.all(MLX.isFinite(last)).item(Bool.self))
+    }
+
+    @Test func embedScaleAppliedToFirstHiddenState() {
+        let cfg = DramaBoxGemmaTextConfig(
+            hiddenSize: 16,
+            intermediateSize: 32,
+            numHiddenLayers: 1,
+            numAttentionHeads: 4,
+            numKeyValueHeads: 2,
+            headDim: 4,
+            vocabSize: 32,
+            queryPreAttnScalar: 4
+        )
+        let model = DramaBoxGemma3TextBackbone(cfg)
+        let ids = MLXArray([Int32(1), 2, 3]).reshaped([1, 3])
+        let raw = model.embedTokens(ids)
+        let out = model(ids, attentionMask: nil)
+        let expected = raw * Float(sqrt(Double(cfg.hiddenSize)))
+        #expect(MLX.allClose(out.hiddenStates[0], expected, atol: 1e-4).item(Bool.self))
+    }
+
+    @Test func resolverUsesExistingLocalDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dramabox-local-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try Data("{}".utf8).write(to: directory.appendingPathComponent("config.json"))
+        try Data([1, 2, 3]).write(to: directory.appendingPathComponent(dramaBoxDiTWeightFile))
+        try Data([1, 2, 3]).write(
+            to: directory.appendingPathComponent(dramaBoxAudioComponentsFile)
+        )
+
+        #expect(
+            DramaBoxWeights.isLocalCheckpointDirectory(
+                directory,
+                requiredFiles: DramaBoxWeights.audioRequiredFiles
+            )
+        )
+        #expect(TTS.resolveModelType(modelRepo: directory.path) == nil || true)
+    }
+
+    @Test func resolverFindsHubSnapshotLayout() throws {
+        let cacheDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dramabox-hub-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: cacheDir) }
+
+        let cache = HubCache(cacheDirectory: cacheDir)
+        let repoID = try #require(Repo.ID(rawValue: "appautomaton/dramabox-tts-3.3b-bf16-mlx"))
+        let repoDir = cache.repoDirectory(repo: repoID, kind: .model)
+        let revision = "abc123"
+        let snapshot = repoDir.appendingPathComponent("snapshots").appendingPathComponent(revision)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: repoDir.appendingPathComponent("refs"),
+            withIntermediateDirectories: true
+        )
+        try Data("abc123".utf8).write(to: repoDir.appendingPathComponent("refs/main"))
+        try Data("{\"model_type\":\"dramabox-tts\"}".utf8).write(
+            to: snapshot.appendingPathComponent("config.json")
+        )
+        try Data([1]).write(to: snapshot.appendingPathComponent(dramaBoxDiTWeightFile))
+        try Data([1]).write(to: snapshot.appendingPathComponent(dramaBoxAudioComponentsFile))
+
+        let resolved = try #require(
+            DramaBoxWeights.existingCachedDirectory(
+                repoID: repoID,
+                requiredFiles: DramaBoxWeights.audioRequiredFiles,
+                cache: cache
+            )
+        )
+        #expect(resolved.standardizedFileURL.path == snapshot.standardizedFileURL.path)
+    }
+
+    @Test func resolverPrefersHubSnapshotOverMlxAudioCopy() throws {
+        let cacheDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dramabox-prefer-hub-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: cacheDir) }
+
+        let cache = HubCache(cacheDirectory: cacheDir)
+        let repoID = try #require(Repo.ID(rawValue: "appautomaton/dramabox-tts-3.3b-bf16-mlx"))
+        let snapshot = cache.repoDirectory(repo: repoID, kind: .model)
+            .appendingPathComponent("snapshots/abc123")
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data("{\"model_type\":\"dramabox-tts\"}".utf8).write(
+            to: snapshot.appendingPathComponent("config.json")
+        )
+        try Data([1]).write(to: snapshot.appendingPathComponent(dramaBoxDiTWeightFile))
+        try Data([1]).write(to: snapshot.appendingPathComponent(dramaBoxAudioComponentsFile))
+
+        let mlxAudio = cache.cacheDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent("appautomaton_dramabox-tts-3.3b-bf16-mlx")
+        try FileManager.default.createDirectory(at: mlxAudio, withIntermediateDirectories: true)
+        try Data("{\"model_type\":\"dramabox-tts\"}".utf8).write(
+            to: mlxAudio.appendingPathComponent("config.json")
+        )
+        try Data([2]).write(to: mlxAudio.appendingPathComponent(dramaBoxDiTWeightFile))
+        try Data([2]).write(to: mlxAudio.appendingPathComponent(dramaBoxAudioComponentsFile))
+
+        let resolved = try #require(
+            DramaBoxWeights.existingCachedDirectory(
+                repoID: repoID,
+                requiredFiles: DramaBoxWeights.audioRequiredFiles,
+                cache: cache
+            )
+        )
+        #expect(resolved.standardizedFileURL.path == snapshot.standardizedFileURL.path)
+    }
+
+    @Test func targetShapeFiveSecondsIs129Frames() {
+        let shape = dramaBoxTargetShapeFromDuration(5.0)
+        #expect(shape.batch == 1)
+        #expect(shape.channels == 8)
+        #expect(shape.frames == 129)
+        #expect(shape.melBins == 16)
+    }
+
+    @Test func targetShapeAlignsToEightPlusOne() {
+        for duration in [1.0, 2.0, 3.0, 5.0, 7.5, 10.0] as [Float] {
+            let shape = dramaBoxTargetShapeFromDuration(duration)
+            #expect((shape.frames - 1) % 8 == 0)
+        }
+    }
+
+    @Test func patchifyUnpatchifyRoundtrip() {
+        let B = 1, C = 8, T = 5, F = 16
+        let latent = MLXArray(Array(0..<(B * C * T * F)).map { Float($0) }).reshaped(B, C, T, F)
+        let patched = DramaBoxAudioPatchifier.patchify(latent)
+        #expect(patched.shape == [B, T, C * F])
+        let restored = DramaBoxAudioPatchifier.unpatchify(patched, channels: C, melBins: F)
+        #expect(allClose(restored, latent, atol: 1e-6).item(Bool.self))
+        #expect(patched[0, 0].asArray(Float.self).prefix(3).map { $0 } == [0, 1, 2])
+    }
+
+    @Test func schedulerLastNonzeroIsTerminal() {
+        let sigmas = DramaBoxLTX2Scheduler().execute(steps: 30, tokens: 128)
+        #expect(sigmas.shape == [31])
+        #expect(sigmas.asArray(Float.self).last == 0)
+        #expect(abs(sigmas.asArray(Float.self)[29] - 0.1) < 1e-5)
+    }
+
+    @Test func guiderCfgOnly() {
+        let g = DramaBoxMultiModalGuider(
+            params: DramaBoxGuiderParams(cfgScale: 2, stgScale: 0, rescaleScale: 0, modalityScale: 1)
+        )
+        let cond = MLXArray([1.0, 2.0, 3.0] as [Float]).reshaped([1, 1, 3])
+        let uncond = MLXArray([0.5, 1.0, 1.5] as [Float]).reshaped([1, 1, 3])
+        let pred = g(cond: cond, uncond: uncond)
+        #expect(allClose(pred, 2 * cond - uncond, atol: 1e-6).item(Bool.self))
+    }
+
+    @Test func silencePriorNoOpWhenShort() {
+        let latent = MLXRandom.normal([1, 8, 100, 16])
+        let out = dramaBoxSilencePriorFix(latent)
+        #expect(allClose(out, latent, atol: 0).item(Bool.self))
+    }
+
+    @Test func vaeResnetShortcutUsesCheckpointName() {
+        let changed = DramaBoxVAEResnetBlock(inChannels: 4, outChannels: 8)
+        let changedKeys = Set(changed.parameters().flattened().map(\.0))
+        #expect(changedKeys.contains("nin_shortcut.conv.weight"))
+        #expect(changedKeys.contains("nin_shortcut.conv.bias"))
+        #expect(!changedKeys.contains("ninShortcut.conv.weight"))
+
+        let same = DramaBoxVAEResnetBlock(inChannels: 4, outChannels: 4)
+        let sameKeys = Set(same.parameters().flattened().map(\.0))
+        #expect(!sameKeys.contains("nin_shortcut.conv.weight"))
+    }
+
+    @Test func ltxAttentionAndFFNMatchCheckpointKeyLayout() {
+        let attn = DramaBoxLTXAttention(
+            queryDim: 8, heads: 2, dimHead: 4, applyGatedAttention: true
+        )
+        let attnKeys = Set(attn.parameters().flattened().map(\.0))
+        #expect(attnKeys.contains("to_out.0.weight"))
+        #expect(attnKeys.contains("to_out.0.bias"))
+        #expect(!attnKeys.contains("to_out.0.0.weight"))
+
+        let ff = DramaBoxLTXFeedForward(8, dimOut: 8, mult: 4)
+        let ffKeys = Set(ff.parameters().flattened().map(\.0))
+        #expect(ffKeys.contains("net.0.proj.weight"))
+        #expect(ffKeys.contains("net.0.proj.bias"))
+        #expect(ffKeys.contains("net.2.weight"))
+        #expect(ffKeys.contains("net.2.bias"))
+        #expect(!ffKeys.contains("net.0.0.proj.weight"))
+    }
+
+    @Test func stgSkipDiffersFromFullAttention() {
+        MLXRandom.seed(2)
+        let attn = DramaBoxLTXAttention(
+            queryDim: 8, heads: 2, dimHead: 4, applyGatedAttention: true
+        )
+        let x = MLXRandom.normal([1, 6, 8])
+        let full = attn(x)
+        let skip = attn(x, skipSelfAttn: true)
+        #expect(!allClose(skip, full, atol: 1e-4).item(Bool.self))
+    }
+
+    @Test func generateConfigDefaultsMatchWarmServer() {
+        let config = DramaBoxGenerateConfig()
+        #expect(config.durationSeconds == 5)
+        #expect(config.cfgScale == 2.5)
+        #expect(config.stgScale == 1.5)
+        #expect(config.steps == 30)
+        #expect(config.seed == 42)
+        #expect(config.denoiseRef == false)
+        #expect(abs(config.resolvedRescaleScale - 0.3) < 1e-6)
+    }
+
+    @Test func stereoWriterDoesNotDownmix() throws {
+        let left: [Float] = [0.1, 0.2, 0.3]
+        let right: [Float] = [-0.1, -0.2, -0.3]
+        let audio = stacked([MLXArray(left), MLXArray(right)], axis: 0)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dramabox-stereo-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try saveAudioArray(audio, sampleRate: 48_000, to: url)
+        let channels = try planarAudioChannels(audio)
+        #expect(channels.count == 2)
+        #expect(channels[0] == left)
+        #expect(channels[1] == right)
+    }
+
+    @Test func stgDisabledGuiderDoesNotNeedPtb() {
+        let params = DramaBoxGuiderParams(cfgScale: 2.5, stgScale: 0, rescaleScale: 0.3)
+        #expect(!params.needsPtb)
+        #expect(params.needsUncond)
+        let g = DramaBoxMultiModalGuider(params: params)
+        let cond = MLXArray.ones([1, 4, 8])
+        let uncond = MLXArray.zeros([1, 4, 8])
+        let pred = g(cond: cond, uncond: uncond, ptb: nil)
+        #expect(MLX.all(MLX.isFinite(pred)).item(Bool.self))
+    }
+
+    @Test func realGemmaTokenizerFromHubCacheHasNoChatTemplate() async throws {
+        guard
+            let gemmaDir = DramaBoxWeights.existingCachedDirectory(
+                repoID: try #require(Repo.ID(rawValue: dramaBoxDefaultGemmaRepository)),
+                requiredFiles: [],
+                cache: .default
+            )
+        else {
+            return
+        }
+        let tokenizer = try await LTXVGemmaTokenizer.fromDirectory(gemmaDir)
+        let prompt = #"A woman speaks clearly, "The weather today will be sunny.""#
+        let (ids, mask) = tokenizer.encode(prompt, maxLength: 1024)
+        #expect(ids.shape == [1, 1024])
+        #expect(mask.shape == [1, 1024])
+        #expect(mask.asArray(Int32.self).first == 0)
+        #expect(mask.asArray(Int32.self).last == 1)
+        let tokenCount = Int(mask.sum().item(Int32.self))
+        #expect(tokenCount > 0)
+        #expect(tokenCount < 1024)
+    }
+}


### PR DESCRIPTION
## Summary

Adds [DramaBox](https://huggingface.co/ResembleAI/Dramabox) as a `SpeechGenerationModel`. A scene prompt is encoded by a headless Gemma 3 12B backbone (all hidden states, no chat template, no LM head), then an LTX flow-matching DiT, audio VAE, and BigVGAN+BWE vocoder render **48 kHz stereo `[2, T]`**. English only.

Port follows the Python mlx-speech implementation. This is not “Gemma generates tokens, then a vocoder speaks.”

## Weights

App Automaton MLX conversion (two repos, resolved independently). **Not** interchangeable with `mlx-community/ResembleAI-Dramabox`.

| Role | Hugging Face repo |
|------|-------------------|
| Audio stack (DiT + VAE + vocoder + connector) | [appautomaton/dramabox-tts-3.3b-bf16-mlx](https://huggingface.co/appautomaton/dramabox-tts-3.3b-bf16-mlx) |
| Text encoder | [appautomaton/gemma-3-12b-it-backbone-4bit-mlx](https://huggingface.co/appautomaton/gemma-3-12b-it-backbone-4bit-mlx) |

DramaBox weights: **LTX-2 Community License**. Gemma 3 backbone: Google Gemma terms.

## Example

```swift
let model = try await TTS.loadModel(
    modelRepo: "appautomaton/dramabox-tts-3.3b-bf16-mlx"
)

let audio = try await model.generate(
    text: #"A woman speaks clearly, "The weather today will be sunny.""#,
    voice: nil, refAudio: nil, refText: nil, language: "English",
    generationParameters: GenerateParameters()
)
// audio shape [2, T] @ 48 kHz — do not downmix
```

```sh
swift run mlx-audio-swift-tts \
  --model appautomaton/dramabox-tts-3.3b-bf16-mlx \
  --text 'A woman speaks clearly, "The weather today will be sunny."' \
  --output dramabox.wav
```

The Gemma companion loads from the default backbone repo; no extra CLI flag.

## What's included

- `Sources/MLXAudioTTS/Models/DramaBox/` — tokenizer, Gemma encoder, prompt/connector, DiT, VAE, vocoder, scheduler/guider
- Factory registration in `TTSModel.swift` (`dramabox` / `dramabox-tts` from Hub `model_type` or a repo id that contains `dramabox`)
- Model README + Supported Models table
- `Tests/DramaBoxTests.swift` — Hub snapshot reuse, `nin_shortcut` keys, bf16 attention-fill finiteness, layout

## Shared changes (please look)

- `ModelUtils`: prefer an existing Hugging Face Hub snapshot (`models--org--name/snapshots/<rev>`) and download into that cache. Do not write a second copy under `hub/mlx-audio/`.
- `TTS.loadModel`: if `inferModelType` already identifies the family, skip downloading `config.json` just to read `model_type`.
- `AudioUtils`: stereo WAV write (`[2, T]`).

## Verification

Local generate succeeded with the Hub ids above (finite 48 kHz stereo). mlx-speech documents ~15.7 GB persistent / ~17.3 GB peak; plan on ~32 GB unified memory.

CI cannot load these weights. Unit tests cover loader/layout/numeric guards, not `DramaBoxModel.generate`.

## Known limitations (v1)

- `denoiseRef = true` (RE-USE / SEMamba) is out of scope and throws
- `generateStream` wraps a full `generate()` and yields one `.audio` event
- `GenerateParameters` AR knobs (`maxTokens`, `temperature`, `topP`, …) are ignored; duration is `DramaBoxGenerateConfig.durationSeconds`
- No CLI short-name; pass the full Hub id

## Checklist

- [x] Model lives under `Sources/MLXAudioTTS/Models/`
- [x] Conforms to `SpeechGenerationModel`
- [x] Loads from Hugging Face (local dir, then Hub snapshot, then download)
- [x] Factory registration
- [x] README updated
- [x] `Package.swift` README exclude
- [x] Local generate
- [ ] CI `generate()` — skipped; too large for GitHub Actions

