### PR TITLE
feat: add Breeze TTS 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MLXAudio follows a modular design allowing you to import only what you need:
 
 - **MLXAudioCore**: Base types, protocols, and utilities
 - **MLXAudioCodecs**: Audio codec implementations (SNAC, Encodec, Vocos, Mimi, DACVAE, Descript DAC, Fish S1 DAC, S3TokenizerV2, MOSS Audio Tokenizer, Higgs Audio Tokenizer, Step-Audio-2 token-to-wav)
-- **MLXAudioTTS**: Text-to-Speech models (Qwen3-TTS, OmniVoice, Fish Audio S2 Pro, IndexTTS, Soprano, VyvoTTS, Orpheus, MOSS-TTS, Marvis TTS, Pocket TTS, Irodori TTS)
+- **MLXAudioTTS**: Text-to-Speech models (Breeze TTS 2, Qwen3-TTS, OmniVoice, Fish Audio S2 Pro, IndexTTS, Soprano, VyvoTTS, Orpheus, MOSS-TTS, Marvis TTS, Pocket TTS, Irodori TTS)
 - **MLXAudioSTT**: Speech-to-Text models (Qwen3-ASR, Qwen3-ForcedAligner, Voxtral Realtime, Cohere Transcribe, Parakeet, Nemotron ASR, GLMASR, FireRedASR2, SenseVoice, Granite Speech, Whisper, Canary, Moonshine, Wav2Vec2, MMS)
 - **MLXAudioVAD**: Voice Activity Detection & Speaker Diarization (Sortformer, SmartTurn, FSMN VAD, Silero VAD)
 - **MLXAudioSTS**: Speech-to-Speech models (LFM2.5-Audio, SAM-Audio, MossFormer2-SE, DeepFilterNet)
@@ -118,6 +118,7 @@ for try await event in model.generateStream(text: text, parameters: parameters) 
 
 | Model | Model README | HuggingFace Repo |
 |-------|--------------|------------------|
+| Breeze TTS 2 | [Breeze TTS 2 README](Sources/MLXAudioTTS/Models/BreezeTTS/README.md) | [mlx-community/Breeze-TTS-2-mlx-4bit](https://huggingface.co/mlx-community/Breeze-TTS-2-mlx-4bit) |
 | Qwen3-TTS | [Qwen3-TTS README](Sources/MLXAudioTTS/Models/Qwen3TTS/README.md) | [mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit) |
 | OmniVoice | [OmniVoice README](Sources/MLXAudioTTS/Models/OmniVoice/README.md) | [mlx-community/OmniVoice](https://huggingface.co/mlx-community/OmniVoice) |
 | Fish Audio S2 Pro | [Fish Audio S2 Pro README](Sources/MLXAudioTTS/Models/FishSpeech/README.md) | [mlx-community/fish-audio-s2-pro-8bit](https://huggingface.co/mlx-community/fish-audio-s2-pro-8bit) |

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSConfig.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSConfig.swift
@@ -99,7 +99,7 @@ public struct BreezeDepthDecoderConfig: Codable, Sendable {
     }
 }
 
-public struct BreezeTextEncoderConfig: Codable, Sendable {
+public struct BreezeTextEncoderConfig: Decodable, Sendable {
     var vocabSize: Int
     var hiddenSize: Int
     var intermediateSize: Int
@@ -150,12 +150,19 @@ public struct BreezeTextEncoderConfig: Codable, Sendable {
             ?? c.decodeIfPresent(Int.self, forKey: .privateSlidingWindowPattern)
             ?? 6
         eoiTokenIndex = try c.decodeIfPresent(Int.self, forKey: .eoiTokenIndex) ?? 256_000
-        layerTypes = try c.decodeIfPresent([String].self, forKey: .layerTypes)
-            ?? (0..<numHiddenLayers).map { ($0 + 1).isMultiple(of: slidingWindowPattern) ? "full_attention" : "sliding_attention" }
+        if let decodedLayerTypes = try c.decodeIfPresent([String].self, forKey: .layerTypes) {
+            layerTypes = decodedLayerTypes
+        } else {
+            let layerCount = numHiddenLayers
+            let pattern = slidingWindowPattern
+            layerTypes = (0..<layerCount).map {
+                ($0 + 1).isMultiple(of: pattern) ? "full_attention" : "sliding_attention"
+            }
+        }
     }
 }
 
-public struct BreezeCodecConfig: Codable, Sendable {
+public struct BreezeCodecConfig: Decodable, Sendable {
     var samplingRate: Int
     var codebookSize: Int
 

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSConfig.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSConfig.swift
@@ -1,0 +1,246 @@
+import Foundation
+import MLXLMCommon
+
+public struct BreezeBackboneConfig: Codable, Sendable {
+    var modelType: String
+    var vocabSize: Int
+    var hiddenSize: Int
+    var intermediateSize: Int
+    var numHiddenLayers: Int
+    var numAttentionHeads: Int
+    var numKeyValueHeads: Int
+    var headDim: Int
+    var rmsNormEps: Float
+    var maxPositionEmbeddings: Int
+    var ropeTheta: Float
+    var ropeScaling: [String: StringOrNumber]?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case ropeTheta = "rope_theta"
+        case ropeScaling = "rope_scaling"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "qwen3"
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 151_936
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 2_048
+        intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 6_144
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 28
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 16
+        numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 8
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 128
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-5
+        maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 40_960
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 500_000
+        ropeScaling = try c.decodeIfPresent([String: StringOrNumber].self, forKey: .ropeScaling)
+    }
+}
+
+public struct BreezeDepthDecoderConfig: Codable, Sendable {
+    var vocabSize: Int
+    var numCodebooks: Int
+    var audioEmbedSize: Int
+    var backboneHiddenSize: Int
+    var hiddenSize: Int
+    var numHiddenLayers: Int
+    var intermediateSize: Int
+    var numAttentionHeads: Int
+    var numKeyValueHeads: Int
+    var headDim: Int
+    var rmsNormEps: Float
+    var maxPositionEmbeddings: Int
+    var ropeTheta: Float
+    var ropeScaling: [String: StringOrNumber]?
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case numCodebooks = "num_codebooks"
+        case audioEmbedSize = "audio_embed_size"
+        case backboneHiddenSize = "backbone_hidden_size"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case ropeTheta = "rope_theta"
+        case ropeScaling = "rope_scaling"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 2_051
+        numCodebooks = try c.decodeIfPresent(Int.self, forKey: .numCodebooks) ?? 16
+        audioEmbedSize = try c.decodeIfPresent(Int.self, forKey: .audioEmbedSize) ?? 2_048
+        backboneHiddenSize = try c.decodeIfPresent(Int.self, forKey: .backboneHiddenSize) ?? 2_048
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1_024
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 12
+        intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 8_192
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 8
+        numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 2
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 128
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-5
+        maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 33
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 500_000
+        ropeScaling = try c.decodeIfPresent([String: StringOrNumber].self, forKey: .ropeScaling)
+    }
+}
+
+public struct BreezeTextEncoderConfig: Codable, Sendable {
+    var vocabSize: Int
+    var hiddenSize: Int
+    var intermediateSize: Int
+    var numHiddenLayers: Int
+    var numAttentionHeads: Int
+    var numKeyValueHeads: Int
+    var headDim: Int
+    var rmsNormEps: Float
+    var queryPreAttentionScalar: Float
+    var maxPositionEmbeddings: Int
+    var slidingWindow: Int
+    var slidingWindowPattern: Int
+    var eoiTokenIndex: Int
+    var layerTypes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case queryPreAttentionScalar = "query_pre_attn_scalar"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case slidingWindow = "sliding_window"
+        case slidingWindowPattern = "sliding_window_pattern"
+        case privateSlidingWindowPattern = "_sliding_window_pattern"
+        case eoiTokenIndex = "eoi_token_index"
+        case layerTypes = "layer_types"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 262_208
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 2_304
+        intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 9_216
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 26
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 8
+        numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 4
+        headDim = try c.decodeIfPresent(Int.self, forKey: .headDim) ?? 256
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        queryPreAttentionScalar = try c.decodeIfPresent(Float.self, forKey: .queryPreAttentionScalar) ?? 256
+        maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 131_072
+        slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 4_096
+        slidingWindowPattern = try c.decodeIfPresent(Int.self, forKey: .slidingWindowPattern)
+            ?? c.decodeIfPresent(Int.self, forKey: .privateSlidingWindowPattern)
+            ?? 6
+        eoiTokenIndex = try c.decodeIfPresent(Int.self, forKey: .eoiTokenIndex) ?? 256_000
+        layerTypes = try c.decodeIfPresent([String].self, forKey: .layerTypes)
+            ?? (0..<numHiddenLayers).map { ($0 + 1).isMultiple(of: slidingWindowPattern) ? "full_attention" : "sliding_attention" }
+    }
+}
+
+public struct BreezeCodecConfig: Codable, Sendable {
+    var samplingRate: Int
+    var codebookSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case samplingRate = "sampling_rate"
+        case outputSamplingRate = "output_sample_rate"
+        case codebookSize = "codebook_size"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        samplingRate = try c.decodeIfPresent(Int.self, forKey: .samplingRate)
+            ?? c.decodeIfPresent(Int.self, forKey: .outputSamplingRate)
+            ?? 24_000
+        codebookSize = try c.decodeIfPresent(Int.self, forKey: .codebookSize) ?? 2_048
+    }
+}
+
+public struct BreezeTTSConfig: Decodable, Sendable {
+    var modelType: String
+    var audioNumCodebooks: Int
+    var audioVocabSize: Int
+    var audioEmbedSize: Int
+    var textVocabSize: Int
+    var audioTokenID: Int
+    var audioEOSTokenID: Int
+    var codebookPadTokenID: Int
+    var codebookEOSTokenID: Int
+    var tieCodebooksEmbeddings: Bool
+    var backboneConfig: BreezeBackboneConfig
+    var codecConfig: BreezeCodecConfig
+    var depthDecoderConfig: BreezeDepthDecoderConfig
+    var textEncoderConfig: BreezeTextEncoderConfig
+    var quantization: BaseConfiguration.Quantization?
+    var perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+
+    var numCodebooks: Int { audioNumCodebooks }
+    var codecVocabSize: Int { codecConfig.codebookSize }
+    var sampleRate: Int { codecConfig.samplingRate }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case audioNumCodebooks = "audio_num_codebooks"
+        case numCodebooks = "num_codebooks"
+        case audioVocabSize = "audio_vocab_size"
+        case vocabSize = "vocab_size"
+        case audioEmbedSize = "audio_embed_size"
+        case textVocabSize = "text_vocab_size"
+        case audioTokenID = "audio_token_id"
+        case audioEOSTokenID = "audio_eos_token_id"
+        case codebookPadTokenID = "codebook_pad_token_id"
+        case codebookEOSTokenID = "codebook_eos_token_id"
+        case tieCodebooksEmbeddings = "tie_codebooks_embeddings"
+        case backboneConfig = "backbone_config"
+        case codecConfig = "codec_config"
+        case depthDecoderConfig = "depth_decoder_config"
+        case textEncoderConfig = "text_encoder_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "breeze"
+        audioNumCodebooks = try c.decodeIfPresent(Int.self, forKey: .audioNumCodebooks)
+            ?? c.decodeIfPresent(Int.self, forKey: .numCodebooks)
+            ?? 16
+        audioVocabSize = try c.decodeIfPresent(Int.self, forKey: .audioVocabSize)
+            ?? c.decodeIfPresent(Int.self, forKey: .vocabSize)
+            ?? 2_051
+        backboneConfig = try c.decode(BreezeBackboneConfig.self, forKey: .backboneConfig)
+        codecConfig = try c.decodeIfPresent(BreezeCodecConfig.self, forKey: .codecConfig)
+            ?? JSONDecoder().decode(BreezeCodecConfig.self, from: Data("{}".utf8))
+        depthDecoderConfig = try c.decodeIfPresent(BreezeDepthDecoderConfig.self, forKey: .depthDecoderConfig)
+            ?? JSONDecoder().decode(BreezeDepthDecoderConfig.self, from: Data("{}".utf8))
+        textEncoderConfig = try c.decodeIfPresent(BreezeTextEncoderConfig.self, forKey: .textEncoderConfig)
+            ?? JSONDecoder().decode(BreezeTextEncoderConfig.self, from: Data("{}".utf8))
+        audioEmbedSize = try c.decodeIfPresent(Int.self, forKey: .audioEmbedSize) ?? backboneConfig.hiddenSize
+        textVocabSize = try c.decodeIfPresent(Int.self, forKey: .textVocabSize) ?? 262_158
+        audioTokenID = try c.decodeIfPresent(Int.self, forKey: .audioTokenID) ?? 262_144
+        audioEOSTokenID = try c.decodeIfPresent(Int.self, forKey: .audioEOSTokenID) ?? 262_145
+        codebookPadTokenID = try c.decodeIfPresent(Int.self, forKey: .codebookPadTokenID) ?? 2_050
+        codebookEOSTokenID = try c.decodeIfPresent(Int.self, forKey: .codebookEOSTokenID) ?? 0
+        tieCodebooksEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieCodebooksEmbeddings) ?? true
+
+        let base = try? BaseConfiguration(from: decoder)
+        quantization = base?.quantization
+        perLayerQuantization = base?.perLayerQuantization
+    }
+}

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSModel.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSModel.swift
@@ -1,0 +1,428 @@
+import Foundation
+import HuggingFace
+@preconcurrency import MLX
+import MLXAudioCore
+@preconcurrency import MLXLMCommon
+import MLXNN
+import Tokenizers
+
+public final class BreezeTTSModel: Module, SpeechGenerationModel, @unchecked Sendable {
+    let config: BreezeTTSConfig
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+    @ModuleInfo(key: "embed_text_tokens") var embedTextTokens: Embedding
+    @ModuleInfo(key: "backbone_model") var backboneModel: BreezeBackbone
+    @ModuleInfo(key: "depth_decoder") var depthDecoder: BreezeDepthDecoder
+    @ModuleInfo(key: "text_encoder") var textEncoder: BreezeTTSTextEncoder
+    @ModuleInfo(key: "text_encoder_proj") var textEncoderProjection: Linear
+
+    var tokenizer: Tokenizers.Tokenizer?
+    var audioTokenizer: Qwen3TTSSpeechTokenizer?
+
+    public var sampleRate: Int { config.sampleRate }
+
+    public var defaultGenerationParameters: GenerateParameters {
+        GenerateParameters(
+            maxTokens: 750,
+            temperature: 0.9,
+            topP: 1,
+            topK: 50,
+            repetitionPenalty: 1
+        )
+    }
+
+    init(config: BreezeTTSConfig) {
+        self.config = config
+        _lmHead.wrappedValue = Linear(
+            config.backboneConfig.hiddenSize,
+            config.audioVocabSize + 1,
+            bias: false
+        )
+        _embedTextTokens.wrappedValue = Embedding(
+            embeddingCount: config.textVocabSize,
+            dimensions: config.backboneConfig.hiddenSize
+        )
+        _backboneModel.wrappedValue = BreezeBackbone(config: config)
+        _depthDecoder.wrappedValue = BreezeDepthDecoder(config: config.depthDecoderConfig)
+        _textEncoder.wrappedValue = BreezeTTSTextEncoder(config: config.textEncoderConfig)
+        _textEncoderProjection.wrappedValue = Linear(
+            config.textEncoderConfig.hiddenSize,
+            config.backboneConfig.hiddenSize,
+            bias: false
+        )
+    }
+
+    static func promptText(text: String, instruction: String?) -> String {
+        guard let instruction, !instruction.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return "[S0]\(text)"
+        }
+        return "[S0]<ins_bos>\(instruction)<ins_eos>\(text)"
+    }
+
+    static func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result = weights.filter { key, _ in
+            !key.hasPrefix("codec_model.")
+                && !key.hasSuffix(".initialized")
+                && !key.contains("rotary_emb.inv_freq")
+        }
+        let depthKey = "depth_decoder.model.embed_tokens.weight"
+        let backboneKey = "backbone_model.embed_tokens.embed_audio_tokens.weight"
+        if let tied = result[depthKey] {
+            result[backboneKey] = tied
+        }
+        return result
+    }
+
+    public func generate(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) async throws -> MLXArray {
+        _ = language
+        return try generateAudio(
+            text: text,
+            instruction: voice,
+            refAudio: refAudio,
+            refText: refText,
+            parameters: generationParameters
+        ).audio
+    }
+
+    public func generateStream(
+        text: String,
+        voice: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        language: String?,
+        generationParameters: GenerateParameters
+    ) -> AsyncThrowingStream<AudioGeneration, Error> {
+        _ = language
+        return AsyncThrowingStream { continuation in
+            let task = Task { @Sendable [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+                do {
+                    let result = try generateAudio(
+                        text: text,
+                        instruction: voice,
+                        refAudio: refAudio,
+                        refText: refText,
+                        parameters: generationParameters,
+                        onToken: { continuation.yield(.token($0)) }
+                    )
+                    continuation.yield(.info(result.info))
+                    continuation.yield(.audio(result.audio))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
+
+    private struct GenerationResult {
+        let audio: MLXArray
+        let info: AudioGenerationInfo
+    }
+
+    private func generateAudio(
+        text: String,
+        instruction: String?,
+        refAudio: MLXArray?,
+        refText: String?,
+        parameters: GenerateParameters,
+        onToken: ((Int) -> Void)? = nil
+    ) throws -> GenerationResult {
+        guard tokenizer != nil else {
+            throw AudioGenerationError.modelNotInitialized("Breeze text tokenizer is not loaded")
+        }
+        guard let audioTokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Breeze audio tokenizer is not loaded")
+        }
+        if refAudio != nil && (refText?.isEmpty != false) {
+            throw AudioGenerationError.invalidInput("Breeze voice cloning needs a reference transcript")
+        }
+        let maxTokens = parameters.maxTokens ?? 750
+        guard maxTokens > 0 else {
+            throw AudioGenerationError.invalidInput("maxTokens must be positive")
+        }
+
+        let started = Date()
+        let conditionalPrompt = try promptEmbeddings(
+            text: text,
+            instruction: instruction,
+            refAudio: refAudio,
+            refText: refText
+        )
+        let usesGuidance = instruction?.isEmpty == false
+        let unconditionalPrompt = usesGuidance
+            ? try promptEmbeddings(text: text, instruction: nil, refAudio: refAudio, refText: refText)
+            : nil
+
+        let conditionalCache = backboneModel.makeCache()
+        var conditionalHidden = backboneModel(
+            inputEmbeddings: conditionalPrompt,
+            cache: conditionalCache
+        )[0..., -1, 0...]
+        let unconditionalCache = unconditionalPrompt.map { _ in backboneModel.makeCache() }
+        var unconditionalHidden = zipOptional(unconditionalPrompt, unconditionalCache).map {
+            backboneModel(inputEmbeddings: $0.0, cache: $0.1)[0..., -1, 0...]
+        }
+        eval(conditionalHidden)
+        if let unconditionalHidden { eval(unconditionalHidden) }
+        let prefillTime = Date().timeIntervalSince(started)
+
+        let sampler = parameters.temperature > 0
+            ? TopPSampler(
+                temperature: parameters.temperature,
+                topP: parameters.topP,
+                topK: min(parameters.topK, config.codecVocabSize),
+                minP: parameters.minP,
+                seed: parameters.seed
+            )
+            : nil
+        var frames = [[Int32]]()
+
+        for _ in 0..<maxTokens {
+            if Task.isCancelled { throw CancellationError() }
+            var logits = lmHead(conditionalHidden)
+            if let unconditionalHidden {
+                let unconditioned = lmHead(unconditionalHidden)
+                logits = unconditioned + 4 * (logits - unconditioned)
+            }
+            logits = applyRepetitionPenalty(
+                logits,
+                generatedTokens: frames.map { Int($0[0]) },
+                penalty: parameters.repetitionPenalty ?? 1
+            )
+            logits = maskReservedTokens(logits, allowsEOS: true)
+            let first = sample(logits, sampler: sampler)
+            if first == config.audioVocabSize { break }
+            onToken?(first)
+
+            var frame = [Int32(first)]
+            var depthInputs = [Int32(0), Int32(first)]
+            while frame.count < config.numCodebooks {
+                let ids = MLXArray(depthInputs).reshaped([1, depthInputs.count])
+                var depthLogits = depthDecoder.nextLogits(
+                    tokenIDs: ids,
+                    backboneHiddenState: conditionalHidden
+                )
+                if let unconditionalHidden {
+                    let unconditioned = depthDecoder.nextLogits(
+                        tokenIDs: ids,
+                        backboneHiddenState: unconditionalHidden
+                    )
+                    depthLogits = unconditioned + 4 * (depthLogits - unconditioned)
+                }
+                depthLogits = maskReservedTokens(depthLogits, allowsEOS: false)
+                let next = sample(depthLogits, sampler: sampler)
+                frame.append(Int32(next))
+                depthInputs.append(Int32(next))
+            }
+            frames.append(frame)
+
+            let codebooks = MLXArray(frame).reshaped([1, 1, config.numCodebooks])
+            conditionalHidden = backboneModel(inputIDs: codebooks, cache: conditionalCache)[0..., -1, 0...]
+            if let cache = unconditionalCache {
+                unconditionalHidden = backboneModel(inputIDs: codebooks, cache: cache)[0..., -1, 0...]
+            }
+            eval(conditionalHidden)
+            if let unconditionalHidden { eval(unconditionalHidden) }
+        }
+
+        let audio: MLXArray
+        if frames.isEmpty {
+            audio = MLXArray.zeros([0])
+        } else {
+            let flat = frames.flatMap { $0 }
+            let codes = MLXArray(flat).reshaped([1, frames.count, config.numCodebooks])
+            let decoded = audioTokenizer.decode(codes)
+            var waveform = decoded.0.squeezed()
+            let validSamples = decoded.1.asArray(Int32.self).first.map(Int.init) ?? waveform.dim(0)
+            if validSamples >= 0 && validSamples < waveform.dim(0) {
+                waveform = waveform[..<validSamples]
+            }
+            audio = waveform
+        }
+        eval(audio)
+
+        let totalTime = Date().timeIntervalSince(started)
+        let generationTime = max(totalTime - prefillTime, 0)
+        return GenerationResult(
+            audio: audio,
+            info: AudioGenerationInfo(
+                promptTokenCount: conditionalPrompt.dim(1),
+                generationTokenCount: frames.count,
+                prefillTime: prefillTime,
+                generateTime: generationTime,
+                tokensPerSecond: Double(frames.count) / max(generationTime, 0.001),
+                peakMemoryUsage: Double(Memory.peakMemory) / 1_000_000_000
+            )
+        )
+    }
+
+    private func promptEmbeddings(
+        text: String,
+        instruction: String?,
+        refAudio: MLXArray?,
+        refText: String?
+    ) throws -> MLXArray {
+        guard let tokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Breeze text tokenizer is not loaded")
+        }
+        var parts = [MLXArray]()
+        if let refAudio, let refText {
+            parts.append(textEmbeddings(for: "[S0]\(refText)", tokenizer: tokenizer))
+            parts.append(try referenceAudioEmbeddings(refAudio))
+            let eos = MLXArray(
+                [Int32](repeating: Int32(config.codebookEOSTokenID), count: config.numCodebooks)
+            ).reshaped([1, 1, config.numCodebooks])
+            parts.append(backboneModel.embedTokens(eos))
+        }
+        parts.append(textEmbeddings(for: Self.promptText(text: text, instruction: instruction), tokenizer: tokenizer))
+        return concatenated(parts, axis: 1)
+    }
+
+    private func textEmbeddings(for text: String, tokenizer: Tokenizers.Tokenizer) -> MLXArray {
+        let ids = MLXArray(tokenizer.encode(text: text).map { Int32($0) }).reshaped([1, -1])
+        return textEncoderProjection(textEncoder(ids))
+    }
+
+    private func referenceAudioEmbeddings(_ reference: MLXArray) throws -> MLXArray {
+        guard let audioTokenizer else {
+            throw AudioGenerationError.modelNotInitialized("Breeze audio tokenizer is not loaded")
+        }
+        let input: MLXArray
+        switch reference.ndim {
+        case 1: input = reference.reshaped([1, 1, reference.dim(0)])
+        case 2: input = reference.expandedDimensions(axis: 1)
+        case 3: input = reference
+        default:
+            throw AudioGenerationError.invalidInput("Reference audio must have one to three dimensions")
+        }
+        guard input.dim(0) == 1 else {
+            throw AudioGenerationError.invalidInput("Breeze accepts one reference clip per request")
+        }
+        return backboneModel.embedTokens(audioTokenizer.encode(input).transposed(0, 2, 1))
+    }
+
+    private func maskReservedTokens(_ logits: MLXArray, allowsEOS: Bool) -> MLXArray {
+        var result = logits
+        if config.codecVocabSize < config.audioVocabSize {
+            let count = config.audioVocabSize - config.codecVocabSize
+            let ids = MLXArray((config.codecVocabSize..<config.audioVocabSize).map(Int32.init)).reshaped([1, count])
+            result = putAlong(
+                result,
+                ids,
+                values: MLXArray.full([1, count], values: MLXArray(-Float.infinity), dtype: result.dtype),
+                axis: -1
+            )
+        }
+        let width = allowsEOS ? config.audioVocabSize + 1 : config.audioVocabSize
+        return result[0..., ..<width]
+    }
+
+    private func sample(_ logits: MLXArray, sampler: TopPSampler?) -> Int {
+        let token = sampler?.sample(logits: logits) ?? argMax(logits, axis: -1)
+        eval(token)
+        return token.item(Int.self)
+    }
+
+    private func applyRepetitionPenalty(
+        _ logits: MLXArray,
+        generatedTokens: [Int],
+        penalty: Float
+    ) -> MLXArray {
+        let unique = Array(Set(generatedTokens)).filter { $0 >= 0 && $0 < logits.dim(-1) }
+        guard penalty != 1, !unique.isEmpty else { return logits }
+        let ids = MLXArray(unique.map(Int32.init)).reshaped([1, -1])
+        let selected = takeAlong(logits, ids, axis: -1)
+        let penalized = MLX.where(selected .< 0, selected * penalty, selected / penalty)
+        return putAlong(logits, ids, values: penalized, axis: -1)
+    }
+
+    public static func fromPretrained(
+        _ modelRepo: String,
+        cache: HubCache = .default
+    ) async throws -> BreezeTTSModel {
+        guard let repoID = Repo.ID(rawValue: modelRepo) else {
+            throw TTSModelError.invalidRepositoryID(modelRepo)
+        }
+        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            cache: cache
+        )
+        return try await fromModelDirectory(modelDir)
+    }
+
+    public static func fromModelDirectory(_ modelDir: URL) async throws -> BreezeTTSModel {
+        let data = try Data(contentsOf: modelDir.appendingPathComponent("config.json"))
+        let config = try JSONDecoder().decode(BreezeTTSConfig.self, from: data)
+        let model = BreezeTTSModel(config: config)
+        let weights = try loadSafetensors(in: modelDir)
+        let sanitized = sanitize(weights: weights)
+
+        if config.quantization != nil || config.perLayerQuantization != nil {
+            quantize(model: model) { path, _ in
+                guard sanitized["\(path).scales"] != nil else { return nil }
+                if let layer = config.perLayerQuantization?.quantization(layer: path) {
+                    return layer.asTuple
+                }
+                return config.quantization?.asTuple
+            }
+        }
+        try model.update(
+            parameters: ModuleParameters.unflattened(sanitized.map { ($0.key, $0.value) }),
+            verify: .all
+        )
+        eval(model.parameters())
+        model.tokenizer = try await AutoTokenizer.from(modelFolder: modelDir)
+        model.audioTokenizer = try loadAudioTokenizer(
+            from: modelDir.appendingPathComponent("audio_tokenizer")
+        )
+        return model
+    }
+
+    private static func loadSafetensors(in directory: URL) throws -> [String: MLXArray] {
+        var result = [String: MLXArray]()
+        let files = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        for file in files where file.pathExtension == "safetensors" {
+            result.merge(try MLX.loadArrays(url: file)) { _, new in new }
+        }
+        return result
+    }
+
+    private static func loadAudioTokenizer(from directory: URL) throws -> Qwen3TTSSpeechTokenizer {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw AudioGenerationError.modelNotInitialized("Breeze checkpoint has no audio_tokenizer directory")
+        }
+        let data = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        let config = try JSONDecoder().decode(Qwen3TTSTokenizerConfig.self, from: data)
+        let tokenizer = Qwen3TTSSpeechTokenizer(config: config)
+        let weights = try loadSafetensors(in: directory)
+        let sanitized = Qwen3TTSSpeechTokenizer.sanitize(weights: weights)
+        try tokenizer.update(
+            parameters: ModuleParameters.unflattened(sanitized.map { ($0.key, $0.value) }),
+            verify: .all
+        )
+        eval(tokenizer.parameters())
+        return tokenizer
+    }
+}
+
+private func zipOptional<A, B>(_ lhs: A?, _ rhs: B?) -> (A, B)? {
+    guard let lhs, let rhs else { return nil }
+    return (lhs, rhs)
+}

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSModules.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSModules.swift
@@ -1,0 +1,239 @@
+@preconcurrency import MLX
+@preconcurrency import MLXLMCommon
+import MLXNN
+
+final class BreezeAudioEmbedding: Module {
+    let numCodebooks: Int
+    let vocabSize: Int
+
+    @ModuleInfo(key: "embed_audio_tokens") var embedAudioTokens: Embedding
+    @ModuleInfo(key: "audio_embeds_projector") var audioEmbedsProjector: Linear?
+
+    init(numCodebooks: Int, vocabSize: Int, audioEmbedSize: Int, hiddenSize: Int) {
+        self.numCodebooks = numCodebooks
+        self.vocabSize = vocabSize
+        _embedAudioTokens.wrappedValue = Embedding(
+            embeddingCount: numCodebooks * vocabSize,
+            dimensions: audioEmbedSize
+        )
+        _audioEmbedsProjector.wrappedValue = audioEmbedSize == hiddenSize
+            ? nil
+            : Linear(audioEmbedSize, hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ codebooks: MLXArray) -> MLXArray {
+        precondition(
+            codebooks.ndim == 3 && codebooks.dim(-1) == numCodebooks,
+            "Breeze audio codebooks must have shape [batch, time, numCodebooks]"
+        )
+        let offsets = MLX.arange(numCodebooks).reshaped([1, 1, numCodebooks]) * vocabSize
+        var hidden = embedAudioTokens(codebooks + offsets)
+        if let audioEmbedsProjector {
+            hidden = audioEmbedsProjector(hidden)
+        }
+        return hidden.sum(axis: -2)
+    }
+}
+
+final class BreezeBackbone: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: BreezeAudioEmbedding
+    @ModuleInfo var layers: [Qwen3TransformerBlock]
+    @ModuleInfo var norm: RMSNorm
+
+    init(config: BreezeTTSConfig) {
+        let backbone = config.backboneConfig
+        let qwen = Qwen3Configuration(
+            hiddenSize: backbone.hiddenSize,
+            hiddenLayers: backbone.numHiddenLayers,
+            intermediateSize: backbone.intermediateSize,
+            attentionHeads: backbone.numAttentionHeads,
+            kvHeads: backbone.numKeyValueHeads,
+            headDim: backbone.headDim,
+            vocabularySize: backbone.vocabSize,
+            rmsNormEps: backbone.rmsNormEps,
+            ropeTheta: backbone.ropeTheta,
+            ropeScaling: backbone.ropeScaling,
+            maxPositionEmbeddings: backbone.maxPositionEmbeddings
+        )
+        _embedTokens.wrappedValue = BreezeAudioEmbedding(
+            numCodebooks: config.numCodebooks,
+            vocabSize: config.audioVocabSize,
+            audioEmbedSize: config.audioEmbedSize,
+            hiddenSize: backbone.hiddenSize
+        )
+        _layers.wrappedValue = (0..<backbone.numHiddenLayers).map { _ in Qwen3TransformerBlock(qwen) }
+        _norm.wrappedValue = RMSNorm(dimensions: backbone.hiddenSize, eps: backbone.rmsNormEps)
+    }
+
+    func callAsFunction(
+        inputIDs: MLXArray? = nil,
+        inputEmbeddings: MLXArray? = nil,
+        cache: [KVCache]? = nil
+    ) -> MLXArray {
+        precondition((inputIDs == nil) != (inputEmbeddings == nil), "Pass input IDs or embeddings")
+        var hidden = inputEmbeddings ?? embedTokens(inputIDs!)
+        let mask = createAttentionMask(h: hidden, cache: cache?.first)
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(hidden, mask: mask, cache: cache?[index])
+        }
+        return norm(hidden)
+    }
+
+    func makeCache() -> [KVCache] {
+        layers.map { _ in KVCache() }
+    }
+}
+
+final class BreezeDepthAttention: Module {
+    let config: BreezeDepthDecoderConfig
+    let scale: Float
+    let rope: RoPE
+
+    @ModuleInfo(key: "q_proj") var query: Linear
+    @ModuleInfo(key: "k_proj") var key: Linear
+    @ModuleInfo(key: "v_proj") var value: Linear
+    @ModuleInfo(key: "o_proj") var output: Linear
+
+    init(config: BreezeDepthDecoderConfig) {
+        self.config = config
+        self.scale = pow(Float(config.headDim), -0.5)
+        self.rope = RoPE(dimensions: config.headDim, traditional: false, base: config.ropeTheta, scale: 1)
+        _query.wrappedValue = Linear(config.hiddenSize, config.numAttentionHeads * config.headDim, bias: false)
+        _key.wrappedValue = Linear(config.hiddenSize, config.numKeyValueHeads * config.headDim, bias: false)
+        _value.wrappedValue = Linear(config.hiddenSize, config.numKeyValueHeads * config.headDim, bias: false)
+        _output.wrappedValue = Linear(config.numAttentionHeads * config.headDim, config.hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        let queries = rope(
+            query(x).reshaped([batch, length, config.numAttentionHeads, config.headDim])
+                .transposed(0, 2, 1, 3)
+        )
+        let keys = rope(
+            key(x).reshaped([batch, length, config.numKeyValueHeads, config.headDim])
+                .transposed(0, 2, 1, 3)
+        )
+        let values = value(x)
+            .reshaped([batch, length, config.numKeyValueHeads, config.headDim])
+            .transposed(0, 2, 1, 3)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .causal
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped([batch, length, -1]))
+    }
+}
+
+final class BreezeDepthMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+
+    init(config: BreezeDepthDecoderConfig) {
+        _gate.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _down.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        _up.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(silu(gate(x)) * up(x))
+    }
+}
+
+final class BreezeDepthLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: BreezeDepthAttention
+    @ModuleInfo var mlp: BreezeDepthMLP
+    @ModuleInfo(key: "input_layernorm") var inputNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: RMSNorm
+
+    init(config: BreezeDepthDecoderConfig) {
+        _attention.wrappedValue = BreezeDepthAttention(config: config)
+        _mlp.wrappedValue = BreezeDepthMLP(config: config)
+        _inputNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postAttentionNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let attended = x + attention(inputNorm(x))
+        return attended + mlp(postAttentionNorm(attended))
+    }
+}
+
+final class BreezeDepthModel: Module {
+    let config: BreezeDepthDecoderConfig
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "backbone_hidden_state_projector") var backboneProjector: Linear?
+    @ModuleInfo(key: "inputs_embeds_projector") var inputProjector: Linear
+    @ModuleInfo var layers: [BreezeDepthLayer]
+    @ModuleInfo var norm: RMSNorm
+
+    init(config: BreezeDepthDecoderConfig) {
+        self.config = config
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.numCodebooks * config.vocabSize,
+            dimensions: config.audioEmbedSize
+        )
+        _backboneProjector.wrappedValue = config.backboneHiddenSize == config.audioEmbedSize
+            ? nil
+            : Linear(config.backboneHiddenSize, config.audioEmbedSize, bias: false)
+        _inputProjector.wrappedValue = Linear(config.audioEmbedSize, config.hiddenSize, bias: false)
+        _layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in BreezeDepthLayer(config: config) }
+        _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ tokenIDs: MLXArray, backboneHiddenState: MLXArray) -> MLXArray {
+        precondition(tokenIDs.ndim == 2, "Depth token IDs must have shape [batch, time]")
+        precondition(backboneHiddenState.ndim == 2, "Backbone hidden state must have shape [batch, hidden]")
+        precondition(tokenIDs.dim(0) == backboneHiddenState.dim(0), "Depth batch sizes must match")
+        let length = tokenIDs.dim(1)
+        let positions = MLX.maximum(MLX.arange(length) - 1, MLXArray(0))
+        var embeddings = embedTokens(tokenIDs + positions.reshaped([1, length]) * config.vocabSize)
+        var backbone = backboneHiddenState
+        if let backboneProjector {
+            backbone = backboneProjector(backbone)
+        }
+        embeddings = concatenated([
+            backbone.expandedDimensions(axis: 1),
+            embeddings[0..., 1..., 0...],
+        ], axis: 1)
+        var hidden = inputProjector(embeddings)
+        for layer in layers {
+            hidden = layer(hidden)
+        }
+        return norm(hidden)
+    }
+}
+
+final class BreezeCodebooksHead: Module {
+    @ParameterInfo var weight: MLXArray
+
+    init(headCount: Int, hiddenSize: Int, vocabSize: Int) {
+        _weight.wrappedValue = MLXArray.zeros([headCount, hiddenSize, vocabSize])
+    }
+}
+
+final class BreezeDepthDecoder: Module {
+    @ModuleInfo var model: BreezeDepthModel
+    @ModuleInfo(key: "codebooks_head") var codebooksHead: BreezeCodebooksHead
+
+    init(config: BreezeDepthDecoderConfig) {
+        _model.wrappedValue = BreezeDepthModel(config: config)
+        _codebooksHead.wrappedValue = BreezeCodebooksHead(
+            headCount: config.numCodebooks - 1,
+            hiddenSize: config.hiddenSize,
+            vocabSize: config.vocabSize
+        )
+    }
+
+    func nextLogits(tokenIDs: MLXArray, backboneHiddenState: MLXArray) -> MLXArray {
+        let headIndex = tokenIDs.dim(1) - 2
+        precondition(headIndex >= 0 && headIndex < codebooksHead.weight.dim(0), "Invalid depth head")
+        let hidden = model(tokenIDs, backboneHiddenState: backboneHiddenState)[0..., -1, 0...]
+        return matmul(hidden, codebooksHead.weight[headIndex])
+    }
+}

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSModules.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSModules.swift
@@ -1,6 +1,7 @@
 @preconcurrency import MLX
 @preconcurrency import MLXLMCommon
 import MLXNN
+import Foundation
 
 final class BreezeAudioEmbedding: Module {
     let numCodebooks: Int
@@ -80,7 +81,7 @@ final class BreezeBackbone: Module {
     }
 
     func makeCache() -> [KVCache] {
-        layers.map { _ in KVCache() }
+        layers.map { _ in KVCacheSimple() }
     }
 }
 
@@ -96,7 +97,7 @@ final class BreezeDepthAttention: Module {
 
     init(config: BreezeDepthDecoderConfig) {
         self.config = config
-        self.scale = pow(Float(config.headDim), -0.5)
+        self.scale = Foundation.pow(Float(config.headDim), -0.5)
         self.rope = RoPE(dimensions: config.headDim, traditional: false, base: config.ropeTheta, scale: 1)
         _query.wrappedValue = Linear(config.hiddenSize, config.numAttentionHeads * config.headDim, bias: false)
         _key.wrappedValue = Linear(config.hiddenSize, config.numKeyValueHeads * config.headDim, bias: false)

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSTextEncoder.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSTextEncoder.swift
@@ -1,5 +1,6 @@
 @preconcurrency import MLX
 import MLXNN
+import Foundation
 
 func breezeTextAttentionMask(
     length: Int,
@@ -55,7 +56,7 @@ final class BreezeTTSTextEmbedding: Module {
     }
 
     func callAsFunction(_ inputIDs: MLXArray) -> MLXArray {
-        let embeddings = weight[inputIDs] * sqrt(Float(dimensions))
+        let embeddings = weight[inputIDs] * Foundation.sqrt(Float(dimensions))
         return MLX.where(
             (inputIDs .== eoiTokenIndex).expandedDimensions(axis: -1),
             eoiEmbedding,
@@ -94,7 +95,7 @@ final class BreezeTTSTextAttention: Module {
     init(config: BreezeTextEncoderConfig, layerIndex: Int) {
         self.config = config
         self.layerType = config.layerTypes[layerIndex]
-        self.scale = pow(config.queryPreAttentionScalar, -0.5)
+        self.scale = Foundation.pow(config.queryPreAttentionScalar, -0.5)
         let ropeBase: Float = layerType == "sliding_attention" ? 10_000 : 1_000_000
         self.rope = RoPE(dimensions: config.headDim, traditional: false, base: ropeBase, scale: 1)
         _query.wrappedValue = Linear(config.hiddenSize, config.numAttentionHeads * config.headDim, bias: false)

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSTextEncoder.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSTextEncoder.swift
@@ -37,8 +37,7 @@ func breezeTextAttentionMask(
         }
     }
 
-    guard let allowed else { return nil }
-    return MLX.where(allowed, MLXArray(Float(0)), MLXArray(-Float.infinity))
+    return allowed
 }
 
 final class BreezeTTSTextEmbedding: Module {

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSTextEncoder.swift
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/BreezeTTSTextEncoder.swift
@@ -1,0 +1,206 @@
+@preconcurrency import MLX
+import MLXNN
+
+func breezeTextAttentionMask(
+    length: Int,
+    layerType: String,
+    slidingWindow: Int,
+    attentionMask: MLXArray? = nil
+) -> MLXArray? {
+    precondition(length >= 0, "Attention length must be non-negative")
+    precondition(
+        layerType == "full_attention" || layerType == "sliding_attention",
+        "Unsupported T5Gemma2 attention layer"
+    )
+
+    var allowed: MLXArray?
+    if layerType == "sliding_attention" {
+        precondition(slidingWindow > 0, "Sliding attention needs a positive window")
+        let positions = MLX.arange(length)
+        let distance = positions.expandedDimensions(axis: 1) - positions.expandedDimensions(axis: 0)
+        let left = (slidingWindow + 1) / 2
+        let right = slidingWindow / 2 + 1
+        let local = logicalOr(
+            logicalAnd(distance .>= 0, distance .< left),
+            logicalAnd(distance .< 0, -distance .< right)
+        )
+        allowed = local.reshaped([1, 1, length, length])
+    }
+
+    if let attentionMask {
+        let valid = attentionMask.asType(.bool).reshaped([attentionMask.dim(0), 1, 1, length])
+        if let current = allowed {
+            allowed = logicalAnd(current, valid)
+        } else {
+            allowed = valid
+        }
+    }
+
+    guard let allowed else { return nil }
+    return MLX.where(allowed, MLXArray(Float(0)), MLXArray(-Float.infinity))
+}
+
+final class BreezeTTSTextEmbedding: Module {
+    let dimensions: Int
+    let eoiTokenIndex: Int
+
+    @ParameterInfo var weight: MLXArray
+    @ParameterInfo(key: "eoi_embedding") var eoiEmbedding: MLXArray
+
+    init(vocabSize: Int, dimensions: Int, eoiTokenIndex: Int) {
+        self.dimensions = dimensions
+        self.eoiTokenIndex = eoiTokenIndex
+        _weight.wrappedValue = MLXArray.zeros([vocabSize, dimensions])
+        _eoiEmbedding.wrappedValue = MLXArray.zeros([dimensions])
+    }
+
+    func callAsFunction(_ inputIDs: MLXArray) -> MLXArray {
+        let embeddings = weight[inputIDs] * sqrt(Float(dimensions))
+        return MLX.where(
+            (inputIDs .== eoiTokenIndex).expandedDimensions(axis: -1),
+            eoiEmbedding,
+            embeddings
+        )
+    }
+}
+
+final class BreezeT5GemmaRMSNorm: Module {
+    let eps: Float
+    @ParameterInfo var weight: MLXArray
+
+    init(dimensions: Int, eps: Float) {
+        self.eps = eps
+        _weight.wrappedValue = MLXArray.zeros([dimensions])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: 1 + weight, eps: eps)
+    }
+}
+
+final class BreezeTTSTextAttention: Module {
+    let config: BreezeTextEncoderConfig
+    let layerType: String
+    let scale: Float
+    let rope: RoPE
+
+    @ModuleInfo(key: "q_proj") var query: Linear
+    @ModuleInfo(key: "k_proj") var key: Linear
+    @ModuleInfo(key: "v_proj") var value: Linear
+    @ModuleInfo(key: "o_proj") var output: Linear
+    @ModuleInfo(key: "q_norm") var queryNorm: BreezeT5GemmaRMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: BreezeT5GemmaRMSNorm
+
+    init(config: BreezeTextEncoderConfig, layerIndex: Int) {
+        self.config = config
+        self.layerType = config.layerTypes[layerIndex]
+        self.scale = pow(config.queryPreAttentionScalar, -0.5)
+        let ropeBase: Float = layerType == "sliding_attention" ? 10_000 : 1_000_000
+        self.rope = RoPE(dimensions: config.headDim, traditional: false, base: ropeBase, scale: 1)
+        _query.wrappedValue = Linear(config.hiddenSize, config.numAttentionHeads * config.headDim, bias: false)
+        _key.wrappedValue = Linear(config.hiddenSize, config.numKeyValueHeads * config.headDim, bias: false)
+        _value.wrappedValue = Linear(config.hiddenSize, config.numKeyValueHeads * config.headDim, bias: false)
+        _output.wrappedValue = Linear(config.numAttentionHeads * config.headDim, config.hiddenSize, bias: false)
+        _queryNorm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.headDim, eps: config.rmsNormEps)
+        _keyNorm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.headDim, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray, attentionMask: MLXArray?) -> MLXArray {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        let queries = rope(
+            queryNorm(query(x).reshaped([batch, length, config.numAttentionHeads, config.headDim]))
+                .transposed(0, 2, 1, 3)
+        )
+        let keys = rope(
+            keyNorm(key(x).reshaped([batch, length, config.numKeyValueHeads, config.headDim]))
+                .transposed(0, 2, 1, 3)
+        )
+        let values = value(x)
+            .reshaped([batch, length, config.numKeyValueHeads, config.headDim])
+            .transposed(0, 2, 1, 3)
+        let mask = breezeTextAttentionMask(
+            length: length,
+            layerType: layerType,
+            slidingWindow: config.slidingWindow,
+            attentionMask: attentionMask
+        )
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: mask.map(MLXFast.ScaledDotProductAttentionMaskMode.array) ?? .none
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped([batch, length, -1]))
+    }
+}
+
+final class BreezeTTSTextMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+
+    init(config: BreezeTextEncoderConfig) {
+        _gate.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _up.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _down.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(MLXNN.geluApproximate(gate(x)) * up(x))
+    }
+}
+
+final class BreezeTTSTextLayer: Module {
+    let layerType: String
+    @ModuleInfo(key: "self_attn") var attention: BreezeTTSTextAttention
+    @ModuleInfo(key: "pre_self_attn_layernorm") var preAttentionNorm: BreezeT5GemmaRMSNorm
+    @ModuleInfo(key: "post_self_attn_layernorm") var postAttentionNorm: BreezeT5GemmaRMSNorm
+    @ModuleInfo var mlp: BreezeTTSTextMLP
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedForwardNorm: BreezeT5GemmaRMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedForwardNorm: BreezeT5GemmaRMSNorm
+
+    init(config: BreezeTextEncoderConfig, layerIndex: Int) {
+        layerType = config.layerTypes[layerIndex]
+        _attention.wrappedValue = BreezeTTSTextAttention(config: config, layerIndex: layerIndex)
+        _preAttentionNorm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postAttentionNorm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _mlp.wrappedValue = BreezeTTSTextMLP(config: config)
+        _preFeedForwardNorm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postFeedForwardNorm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray, attentionMask: MLXArray?) -> MLXArray {
+        let attended = x + postAttentionNorm(attention(preAttentionNorm(x), attentionMask: attentionMask))
+        return attended + postFeedForwardNorm(mlp(preFeedForwardNorm(attended)))
+    }
+}
+
+final class BreezeTTSTextEncoder: Module {
+    let config: BreezeTextEncoderConfig
+    @ModuleInfo(key: "embed_tokens") var embedTokens: BreezeTTSTextEmbedding
+    @ModuleInfo var layers: [BreezeTTSTextLayer]
+    @ModuleInfo var norm: BreezeT5GemmaRMSNorm
+
+    init(config: BreezeTextEncoderConfig) {
+        self.config = config
+        _embedTokens.wrappedValue = BreezeTTSTextEmbedding(
+            vocabSize: config.vocabSize,
+            dimensions: config.hiddenSize,
+            eoiTokenIndex: config.eoiTokenIndex
+        )
+        _layers.wrappedValue = (0..<config.numHiddenLayers).map {
+            BreezeTTSTextLayer(config: config, layerIndex: $0)
+        }
+        _norm.wrappedValue = BreezeT5GemmaRMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ inputIDs: MLXArray, attentionMask: MLXArray? = nil) -> MLXArray {
+        var hidden = embedTokens(inputIDs)
+        for layer in layers {
+            hidden = layer(hidden, attentionMask: attentionMask)
+        }
+        return norm(hidden)
+    }
+}

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/README.md
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/README.md
@@ -1,6 +1,6 @@
 # Breeze TTS 2
 
-TL;DR: This module runs Breeze TTS 2 with MLX on Apple silicon. It supports English and Chinese voice design and voice cloning. The Swift package does not include model weights. Breeze weights and output are limited to research and non-commercial use under the model license.
+Breeze TTS 2 is a bilingual English and Chinese text-to-speech model with natural-language voice design and zero-shot voice cloning.
 
 ## Load a model
 

--- a/Sources/MLXAudioTTS/Models/BreezeTTS/README.md
+++ b/Sources/MLXAudioTTS/Models/BreezeTTS/README.md
@@ -1,0 +1,54 @@
+# Breeze TTS 2
+
+TL;DR: This module runs Breeze TTS 2 with MLX on Apple silicon. It supports English and Chinese voice design and voice cloning. The Swift package does not include model weights. Breeze weights and output are limited to research and non-commercial use under the model license.
+
+## Load a model
+
+The same Swift code works with the BF16, 8-bit, and 4-bit MLX checkpoints:
+
+- `mlx-community/Breeze-TTS-2-mlx`
+- `mlx-community/Breeze-TTS-2-mlx-8bit`
+- `mlx-community/Breeze-TTS-2-mlx-4bit`
+
+```swift
+import MLXAudioCore
+import MLXAudioTTS
+
+let model = try await TTS.loadModel(
+    modelRepo: "mlx-community/Breeze-TTS-2-mlx-4bit"
+)
+
+let audio = try await model.generate(
+    text: "Hello from Breeze TTS 2.",
+    voice: "A clear and calm English narrator",
+    refAudio: nil,
+    refText: nil,
+    language: "English"
+)
+```
+
+`voice` is the voice-design instruction. The generic `language` field does not change Breeze prompt assembly; include language, accent, pace, tone, and style in the instruction when needed.
+
+## Voice cloning
+
+Pass one reference waveform and its exact transcript:
+
+```swift
+let cloned = try await model.generate(
+    text: "This sentence uses the reference voice.",
+    voice: nil,
+    refAudio: referenceAudio,
+    refText: "The exact words spoken in the reference clip.",
+    language: "English"
+)
+```
+
+You can also set `voice` while cloning to direct the cloned voice. The model uses classifier-free guidance for voice design and directed cloning.
+
+## Output and streaming
+
+Breeze returns mono audio at 24 kHz. `generateStream` reports token and timing events while it generates, then yields the decoded waveform as one audio event. The public API can add codec chunk streaming later without changing model loading or prompt controls.
+
+## License
+
+The Swift source in this repository uses the repository license. Breeze model weights, derived checkpoints, and self-hosted output use the Breeze model license, which limits use to research and non-commercial work. Review the [Breeze TTS 2 model card](https://huggingface.co/BreezeBlue/Breeze-TTS-2) before downloading or using a checkpoint.

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -272,6 +272,9 @@ public enum TTS {
 
     private static func inferModelType(from modelRepo: String) -> String? {
         let lower = modelRepo.lowercased()
+        if lower.contains("breeze") && lower.contains("tts") {
+            return "breeze"
+        }
         // Repo names are hyphenated (e.g. "Irodori-TTS-600M-…"); match the bare name.
         if lower.contains("irodori") {
             return "irodori_tts"

--- a/Sources/MLXAudioTTS/TTSModel.swift
+++ b/Sources/MLXAudioTTS/TTSModel.swift
@@ -102,6 +102,13 @@ public enum TTS {
         }
 
         switch resolvedType {
+        case "breeze", "breeze_tts":
+            return try await load(
+                source,
+                modelType: resolvedType,
+                pretrained: { try await BreezeTTSModel.fromPretrained($0, cache: $1) },
+                local: { modelDir, _ in try await BreezeTTSModel.fromModelDirectory(modelDir) }
+            )
         case "moss_tts_nano":
             return try await load(
                 source,

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -1941,10 +1941,11 @@ struct BreezeTTSTests {
 
     @Test func slidingTextMaskRestrictsDistantKeys() {
         let mask = breezeTextAttentionMask(length: 5, layerType: "sliding_attention", slidingWindow: 3)!
-        let values = mask.asArray(Float.self)
+        let values = mask.asArray(Bool.self)
         #expect(mask.shape == [1, 1, 5, 5])
-        #expect(values[0] == 0)
-        #expect(values[4] == -Float.infinity)
+        #expect(mask.dtype == .bool)
+        #expect(values[0])
+        #expect(!values[4])
     }
 
     @Test func audioEmbeddingSumsAllCodebooks() {

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -1844,6 +1844,81 @@ struct KittenTTSTests {
     }
 }
 
+@Suite("BreezeTTS")
+struct BreezeTTSTests {
+    @Test func configKeepsWrapperAudioValuesSeparateFromBackboneValues() throws {
+        let json = """
+        {
+          "model_type": "breeze",
+          "audio_num_codebooks": 16,
+          "audio_vocab_size": 2051,
+          "audio_embed_size": 2048,
+          "text_vocab_size": 262158,
+          "audio_token_id": 262144,
+          "audio_eos_token_id": 262145,
+          "codec_config": {
+            "sampling_rate": 24000,
+            "codebook_size": 2048
+          },
+          "backbone_config": {
+            "model_type": "qwen3",
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "intermediate_size": 6144,
+            "num_hidden_layers": 28,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "rms_norm_eps": 0.00001,
+            "max_position_embeddings": 40960,
+            "rope_theta": 500000
+          },
+          "depth_decoder_config": {
+            "vocab_size": 2051,
+            "num_codebooks": 16,
+            "hidden_size": 1024,
+            "num_hidden_layers": 12,
+            "intermediate_size": 8192,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 2,
+            "head_dim": 128
+          },
+          "text_encoder_config": {
+            "vocab_size": 262158,
+            "hidden_size": 1152,
+            "intermediate_size": 6912,
+            "num_hidden_layers": 26,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "rms_norm_eps": 0.000001,
+            "eoi_token_index": 262145,
+            "sliding_window": 512,
+            "layer_types": ["full_attention"]
+          }
+        }
+        """
+
+        let config = try JSONDecoder().decode(BreezeTTSConfig.self, from: Data(json.utf8))
+
+        #expect(config.modelType == "breeze")
+        #expect(config.numCodebooks == 16)
+        #expect(config.audioVocabSize == 2051)
+        #expect(config.codecVocabSize == 2048)
+        #expect(config.sampleRate == 24_000)
+        #expect(config.backboneConfig.vocabSize == 151_936)
+        #expect(config.backboneConfig.hiddenSize == 2_048)
+        #expect(config.depthDecoderConfig.hiddenSize == 1_024)
+        #expect(config.textEncoderConfig.hiddenSize == 1_152)
+        #expect(config.textEncoderConfig.layerTypes == ["full_attention"])
+    }
+
+    @Test func factoryInfersBreezeModelType() {
+        #expect(TTS.resolveModelType(modelRepo: "mlx-community/Breeze-TTS-2-mlx-4bit") == "breeze")
+        #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "breeze_tts") == "breeze_tts")
+    }
+}
+
 
 // MARK: - Kokoro TTS Tests
 

--- a/Tests/MLXAudioTTSTests.swift
+++ b/Tests/MLXAudioTTSTests.swift
@@ -1917,6 +1917,101 @@ struct BreezeTTSTests {
         #expect(TTS.resolveModelType(modelRepo: "mlx-community/Breeze-TTS-2-mlx-4bit") == "breeze")
         #expect(TTS.resolveModelType(modelRepo: "anything", modelType: "breeze_tts") == "breeze_tts")
     }
+
+    @Test func textEncoderKeepsSequenceShape() throws {
+        let config = try JSONDecoder().decode(BreezeTextEncoderConfig.self, from: Data("""
+        {
+          "vocab_size": 32,
+          "hidden_size": 16,
+          "intermediate_size": 32,
+          "num_hidden_layers": 2,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 1,
+          "head_dim": 8,
+          "eoi_token_index": 31,
+          "sliding_window": 4,
+          "layer_types": ["sliding_attention", "full_attention"]
+        }
+        """.utf8))
+        let encoder = BreezeTTSTextEncoder(config: config)
+        let output = encoder(MLXArray([1, 2, 31, 3]).reshaped([1, 4]))
+        eval(output)
+        #expect(output.shape == [1, 4, 16])
+    }
+
+    @Test func slidingTextMaskRestrictsDistantKeys() {
+        let mask = breezeTextAttentionMask(length: 5, layerType: "sliding_attention", slidingWindow: 3)!
+        let values = mask.asArray(Float.self)
+        #expect(mask.shape == [1, 1, 5, 5])
+        #expect(values[0] == 0)
+        #expect(values[4] == -Float.infinity)
+    }
+
+    @Test func audioEmbeddingSumsAllCodebooks() {
+        let embedding = BreezeAudioEmbedding(
+            numCodebooks: 3,
+            vocabSize: 8,
+            audioEmbedSize: 4,
+            hiddenSize: 4
+        )
+        let output = embedding(MLXArray([1, 2, 3]).reshaped([1, 1, 3]))
+        eval(output)
+        #expect(output.shape == [1, 1, 4])
+    }
+
+    @Test func depthDecoderSelectsOneHeadPerCodebook() throws {
+        let config = try JSONDecoder().decode(BreezeDepthDecoderConfig.self, from: Data("""
+        {
+          "vocab_size": 8,
+          "num_codebooks": 3,
+          "audio_embed_size": 4,
+          "backbone_hidden_size": 4,
+          "hidden_size": 4,
+          "num_hidden_layers": 1,
+          "intermediate_size": 8,
+          "num_attention_heads": 1,
+          "num_key_value_heads": 1,
+          "head_dim": 4
+        }
+        """.utf8))
+        let decoder = BreezeDepthDecoder(config: config)
+        let first = decoder.nextLogits(
+            tokenIDs: MLXArray([0, 1]).reshaped([1, 2]),
+            backboneHiddenState: MLXArray.zeros([1, 4])
+        )
+        let second = decoder.nextLogits(
+            tokenIDs: MLXArray([0, 1, 2]).reshaped([1, 3]),
+            backboneHiddenState: MLXArray.zeros([1, 4])
+        )
+        eval(first, second)
+        #expect(first.shape == [1, 8])
+        #expect(second.shape == [1, 8])
+    }
+
+    @Test func promptUsesVoiceAsInstruction() {
+        #expect(BreezeTTSModel.promptText(text: "Hello", instruction: nil) == "[S0]Hello")
+        #expect(
+            BreezeTTSModel.promptText(text: "Hello", instruction: "Warm and calm")
+                == "[S0]<ins_bos>Warm and calm<ins_eos>Hello"
+        )
+    }
+
+    @Test func sanitizeSeparatesMainModelFromCodecWeights() {
+        let depth = MLXArray.ones([2, 2])
+        let stale = MLXArray.zeros([2, 2])
+        let sanitized = BreezeTTSModel.sanitize(weights: [
+            "depth_decoder.model.embed_tokens.weight": depth,
+            "backbone_model.embed_tokens.embed_audio_tokens.weight": stale,
+            "codec_model.decoder.weight": MLXArray.ones([1]),
+            "backbone_model.rotary_emb.inv_freq": MLXArray.ones([1]),
+        ])
+        #expect(sanitized["codec_model.decoder.weight"] == nil)
+        #expect(sanitized["backbone_model.rotary_emb.inv_freq"] == nil)
+        #expect(
+            sanitized["backbone_model.embed_tokens.embed_audio_tokens.weight"]?.shape
+                == depth.shape
+        )
+    }
 }
 
 


### PR DESCRIPTION
## TL;DR

This PR adds native Breeze TTS 2 support to `MLXAudioTTS`. It loads the public MLX BF16, 8-bit, and 4-bit checkpoints, supports voice design and reference-audio cloning through the shared speech API, and does not add model weights.

Closes #254.

## What changed

- add Breeze config types for the Qwen3 backbone, depth decoder, T5Gemma2 text encoder, and audio codec
- port prompt building, text encoding, autoregressive generation, guidance, and audio decoding from the Python MLX implementation
- load and check the nested Qwen3-TTS audio tokenizer
- register `breeze` and `breeze_tts` with the TTS factory
- add config, prompt, factory, and weight-cleanup tests
- document supported checkpoints, voice design, cloning, limits, and license terms

## Checks

- `MLXAudioTTS` builds with the Breeze source and factory registration
- a downstream ReadBack build using this exact commit succeeds
- the downstream ReadBack test runner passes 153 tests
- `git diff --check` passes
- no model weights are part of this branch

I could not run the full upstream test target on this Mac. The installed command-line Swift setup cannot load Apple's `Testing` module, and the same error occurs in existing test files. The production target compiles.

## Model license

The Swift source remains under this repository's license. Breeze model weights, derivative models, and self-hosted outputs use the BreezeBlue Research and Non-Commercial License. This PR does not add or download model weights.

## Disclosure

These changes are AI-generated and human-reviewed.
