### PR TITLE
STT: scale fbank input to int16 unconditionally in FireRedASR2/SenseVoice

### DIFF
--- a/Sources/MLXAudioSTT/Models/FireRedASR2/FireRedASR2Audio.swift
+++ b/Sources/MLXAudioSTT/Models/FireRedASR2/FireRedASR2Audio.swift
@@ -18,10 +18,15 @@ enum FireRedASR2Audio {
             return MLXArray.zeros([0, numMels], type: Float.self)
         }
 
-        let amplitude = abs(waveform).max().item(Float.self)
-        if amplitude <= 1.0 {
-            waveform = waveform * MLXArray(Float(32768.0))
-        }
+        // Input is normalized float audio in [-1, 1] (as produced by
+        // `loadAudioArray`); scale it unconditionally to the int16 range
+        // the Kaldi fbank recipe (and the CMVN stats) expects — same as
+        // sherpa-onnx, which hard-codes `normalize_samples = false` for
+        // FireRedASR. An earlier version auto-detected the scale with
+        // `amplitude <= 1.0`, but lossy decoders (AAC via AVFoundation)
+        // can overshoot past 1.0 on clipped content, which flipped the
+        // decision and silently collapsed decoding (empty segments on iOS).
+        waveform = waveform * MLXArray(Float(32768.0))
 
         return computeKaldiFbank(
             waveform,

--- a/Sources/MLXAudioSTT/Models/SenseVoice/SenseVoiceAudio.swift
+++ b/Sources/MLXAudioSTT/Models/SenseVoice/SenseVoiceAudio.swift
@@ -24,9 +24,13 @@ enum SenseVoiceAudio {
             return MLXArray.zeros([0, nMels], type: Float.self)
         }
 
-        if abs(audio).max().item(Float.self) <= 1.0 {
-            audio = audio * MLXArray(Float(1 << 15))
-        }
+        // Input is normalized float audio in [-1, 1]; scale it
+        // unconditionally to the int16 range the Kaldi fbank recipe (and
+        // the CMVN stats) expects — same as sherpa-onnx's hard-coded
+        // `normalize_samples = false`. A data-dependent amplitude check
+        // would misfire on clipped content, where lossy decoders (AAC via
+        // AVFoundation) can overshoot past 1.0 (see FireRedASR2Audio).
+        audio = audio * MLXArray(Float(1 << 15))
 
         return computeKaldiFbank(
             audio,

--- a/Tests/MLXAudioSTTTests.swift
+++ b/Tests/MLXAudioSTTTests.swift
@@ -3910,6 +3910,27 @@ struct FireRedASR2Tests {
         #expect(fbank.shape[1] == 80)
     }
 
+    @Test func fbankScalesClippedFloatInput() {
+        // Regression: extractFbank scales normalized float input by 32768
+        // unconditionally. An earlier version auto-detected the scale with
+        // `amplitude <= 1.0`, so float input that lossy decoders (AAC via
+        // AVFoundation) overshoot past 1.0 on clipped content skipped the
+        // scaling, and decoding silently collapsed (empty segments on iOS).
+        let base = MLXRandom.normal([16000]) * MLXArray(Float(0.1))
+        let clipped = base * MLXArray(Float(1.1)) // max amplitude > 1.0
+        eval(base, clipped)
+
+        let fbankBase = FireRedASR2Audio.extractFbank(base)
+        let fbankClipped = FireRedASR2Audio.extractFbank(clipped)
+
+        // Both must take the float path, so the clipped fbank differs only
+        // by the +2*log(1.1) energy offset, not by the x32768 scale jump.
+        let delta = (fbankClipped - fbankBase).mean()
+        eval(delta)
+        let expected = 2 * log(Float(1.1))
+        #expect(abs(delta.item(Float.self) - expected) < 0.05)
+    }
+
     @Test func tokenizerCleanup() {
         let tokenizer = FireRedASR2Tokenizer(vocabulary: ["<blank>", "\u{2581}Hello", "<sil>", "World"])
         let text = tokenizer.decode(tokenIds: [0, 1, 2, 3])


### PR DESCRIPTION
Both models' Kaldi fbank recipe expects int16-scale audio, and the input was auto-detected with `amplitude <= 1.0`. Lossy decoders (AAC via AVFoundation) can overshoot past 1.0 on clipped content, which flipped the decision: the x32768 scaling was skipped, features landed far off the training distribution, and decoding silently collapsed — on iOS, over half of the VAD segments of a long podcast decoded empty while the same audio (peak 0.999969 via ffmpeg) was fine on Mac.

Scale unconditionally instead, matching sherpa-onnx (which hard-codes normalize_samples = false for FireRedASR) and the existing MossFormer2SE and FSMNVAD code. Input contract is normalized float in [-1, 1], as produced by loadAudioArray.

Adds a regression test with clipped input (max amplitude > 1).