### PR TITLE
Core: fix partial model cache when additional download patterns are required

### DIFF
--- a/Sources/MLXAudioCore/ModelUtils.swift
+++ b/Sources/MLXAudioCore/ModelUtils.swift
@@ -94,8 +94,20 @@ public enum ModelUtils {
                 if FileManager.default.fileExists(atPath: configPath.path) {
                     if let configData = try? Data(contentsOf: configPath),
                        let _ = try? JSONSerialization.jsonObject(with: configData) {
-                        print("Using cached model at: \(modelDir.path)")
-                        return modelDir
+                        // A cache hit is only complete if it was downloaded
+                        // with (a superset of) the requested patterns:
+                        // resolveModelType pre-downloads with no additional
+                        // patterns, so a later load that needs e.g. "*.mvn"
+                        // would otherwise silently get a partial snapshot.
+                        let requestedPatterns = Set(additionalMatchingPatterns)
+                        let recorded = recordedPatterns(modelDir: modelDir)
+                        if requestedPatterns.isEmpty
+                            || (recorded.map { requestedPatterns.isSubset(of: $0) } ?? false) {
+                            print("Using cached model at: \(modelDir.path)")
+                            return modelDir
+                        }
+                        // Fall through and re-download with the union of
+                        // patterns; the hub cache deduplicates large blobs.
                     } else {
                         print("Cached config.json is invalid, clearing cache...")
                         Self.clearCaches(modelDir: modelDir, repoID: repoID, hubCache: cache)
@@ -110,6 +122,9 @@ public enum ModelUtils {
         // Create directory if needed
         try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
 
+        let effectivePatterns = Set(additionalMatchingPatterns)
+            .union(recordedPatterns(modelDir: modelDir) ?? [])
+
         var allowedExtensions: Set<String> = [
             "*.\(normalizedRequiredExtension)",
             "*.safetensors",
@@ -117,7 +132,7 @@ public enum ModelUtils {
             "*.txt",
             "*.wav",
         ]
-        allowedExtensions.formUnion(additionalMatchingPatterns)
+        allowedExtensions.formUnion(effectivePatterns)
 
         print("Downloading model \(repoID)...")
         _ = try await client.downloadSnapshot(
@@ -147,7 +162,29 @@ public enum ModelUtils {
         }
 
         print("Model downloaded to: \(modelDir.path)")
+        recordPatterns(modelDir: modelDir, patterns: effectivePatterns)
         return modelDir
+    }
+
+    /// Name of the manifest recording which `additionalMatchingPatterns` a
+    /// cached snapshot was downloaded with (one pattern per line).
+    private static let patternsManifestName = ".mlx-audio-patterns"
+
+    /// Patterns a cached snapshot was downloaded with, or nil when the
+    /// manifest is missing/unreadable (cache predates this mechanism).
+    private static func recordedPatterns(modelDir: URL) -> Set<String>? {
+        let manifestURL = modelDir.appendingPathComponent(patternsManifestName)
+        guard let data = try? Data(contentsOf: manifestURL),
+              let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        return Set(text.split(separator: "\n").map(String.init))
+    }
+
+    private static func recordPatterns(modelDir: URL, patterns: Set<String>) {
+        let manifestURL = modelDir.appendingPathComponent(patternsManifestName)
+        try? patterns.sorted().joined(separator: "\n").write(
+            to: manifestURL, atomically: true, encoding: .utf8
+        )
     }
 
     private static func clearCaches(modelDir: URL, repoID: Repo.ID, hubCache: HubCache) {

--- a/Tests/MLXAudioCoreModelUtilsTests.swift
+++ b/Tests/MLXAudioCoreModelUtilsTests.swift
@@ -1,0 +1,102 @@
+//  Tests for ModelUtils cache-completeness tracking (.mlx-audio-patterns).
+//
+//  Run this suite:
+//    xcodebuild test \
+//      -scheme MLXAudio-Package \
+//      -destination 'platform=macOS' \
+//      -parallel-testing-enabled NO \
+//      -only-testing:'MLXAudioTests/ModelUtilsCacheTests' \
+//      CODE_SIGNING_ALLOWED=NO
+
+import Testing
+import Foundation
+import HuggingFace
+@testable import MLXAudioCore
+
+private func makeTemporaryCacheDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("modelutils-cache-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
+/// Pre-populates the on-disk cache layout that `resolveOrDownloadModel`
+/// inspects: `<cache>/mlx-audio/<repo with _>/` containing a valid
+/// config.json and a non-empty weights file.
+private func populateCachedModel(
+    cache: HubCache,
+    repoID: Repo.ID,
+    patternsManifest: String?
+) throws -> URL {
+    let modelSubdir = repoID.description.replacingOccurrences(of: "/", with: "_")
+    let modelDir = cache.cacheDirectory
+        .appendingPathComponent("mlx-audio")
+        .appendingPathComponent(modelSubdir)
+    try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: modelDir.appendingPathComponent("config.json"))
+    try Data([0x01]).write(to: modelDir.appendingPathComponent("model.safetensors"))
+    if let patternsManifest {
+        try Data(patternsManifest.utf8).write(
+            to: modelDir.appendingPathComponent(".mlx-audio-patterns"))
+    }
+    return modelDir
+}
+
+@Suite("ModelUtils cache completeness")
+struct ModelUtilsCacheTests {
+
+    @Test func cachedModelWithoutManifestServesPlainLoad() async throws {
+        let cacheDir = try makeTemporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: cacheDir) }
+        let cache = HubCache(cacheDirectory: cacheDir)
+        let repoID = try #require(Repo.ID(rawValue: "mlx-audio-tests/cache-fixture"))
+        let modelDir = try populateCachedModel(cache: cache, repoID: repoID, patternsManifest: nil)
+
+        let resolved = try await ModelUtils.resolveOrDownloadModel(
+            client: HubClient(cache: cache),
+            cache: cache,
+            repoID: repoID,
+            requiredExtension: "safetensors"
+        )
+        #expect(resolved.standardizedFileURL == modelDir.standardizedFileURL)
+    }
+
+    @Test func cachedModelWithCoveringManifestServesPatternLoad() async throws {
+        let cacheDir = try makeTemporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: cacheDir) }
+        let cache = HubCache(cacheDirectory: cacheDir)
+        let repoID = try #require(Repo.ID(rawValue: "mlx-audio-tests/cache-fixture"))
+        let modelDir = try populateCachedModel(
+            cache: cache, repoID: repoID, patternsManifest: "*.mvn\n*.model")
+
+        let resolved = try await ModelUtils.resolveOrDownloadModel(
+            client: HubClient(cache: cache),
+            cache: cache,
+            repoID: repoID,
+            requiredExtension: "safetensors",
+            additionalMatchingPatterns: ["*.mvn"]
+        )
+        #expect(resolved.standardizedFileURL == modelDir.standardizedFileURL)
+    }
+
+    @Test func cachedModelMissingPatternsIsNotAccepted() async throws {
+        let cacheDir = try makeTemporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: cacheDir) }
+        let cache = HubCache(cacheDirectory: cacheDir)
+        // A repo that does not exist: if the incomplete cache is (wrongly)
+        // accepted this returns instantly; the fixed behavior falls through
+        // to a download which must fail for this repo.
+        let repoID = try #require(Repo.ID(rawValue: "mlx-audio-tests/nonexistent-cache-fixture"))
+        try populateCachedModel(cache: cache, repoID: repoID, patternsManifest: nil)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await ModelUtils.resolveOrDownloadModel(
+                client: HubClient(cache: cache),
+                cache: cache,
+                repoID: repoID,
+                requiredExtension: "safetensors",
+                additionalMatchingPatterns: ["*.mvn"]
+            )
+        }
+    }
+}


### PR DESCRIPTION
resolveModelType pre-downloads a snapshot with no additional matching patterns; a later load that requires extra files (e.g. SenseVoice's *.mvn / tokenizer) then silently accepted the incomplete cache, so the model loaded without CMVN/tokenizer and emitted raw token IDs.

Record the patterns used per snapshot in .mlx-audio-patterns and treat a cache hit as complete only when the requested patterns are a subset; otherwise re-download with the union of patterns (hub cache deduplicates the large blobs).